### PR TITLE
*: remove unnecessary container port

### DIFF
--- a/Documentation/deploy-master-single.md
+++ b/Documentation/deploy-master-single.md
@@ -121,9 +121,6 @@ spec:
     - containerPort: 443
       hostPort: 443
       name: https
-    - containerPort: 7080
-      hostPort: 7080
-      name: http
     - containerPort: 8080
       hostPort: 8080
       name: local

--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -181,9 +181,6 @@ spec:
     - containerPort: 443
       hostPort: 443
       name: https
-    - containerPort: 7080
-      hostPort: 7080
-      name: http
     - containerPort: 8080
       hostPort: 8080
       name: local

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -174,9 +174,6 @@ spec:
     - containerPort: 443
       hostPort: 443
       name: https
-    - containerPort: 7080
-      hostPort: 7080
-      name: http
     - containerPort: 8080
       hostPort: 8080
       name: local


### PR DESCRIPTION
This was likely added by accident, and we don't see it
being necessary for the cluster to operate correctly.