### PR TITLE
Documentation: add missing semicolons in bash commands

### DIFF
--- a/Documentation/configure-kubectl.md
+++ b/Documentation/configure-kubectl.md
@@ -8,7 +8,7 @@ First, download the binary using a command-line tool such as `wget` or `curl`:
 
 ```sh
 # Replace ${ARCH} with "linux" or "darwin" based on your workstation operating system
-$ wget https://storage.googleapis.com/kubernetes-release/release/v1.0.3/bin/${ARCH}/amd64/kubectl
+$ ARCH=linux; wget https://storage.googleapis.com/kubernetes-release/release/v1.0.3/bin/${ARCH}/amd64/kubectl
 ```
 
 After downloading the binary, ensure it is executable and move it into your `PATH`:

--- a/Documentation/kubernetes-on-vagrant-single.md
+++ b/Documentation/kubernetes-on-vagrant-single.md
@@ -21,7 +21,7 @@ First, download the binary using a command-line tool such as `wget` or `curl` fr
 Set the ARCH environment variable to "linux" or "darwin" based no your workstation operating system:
 
 ```sh
-ARCH=linux wget https://storage.googleapis.com/kubernetes-release/release/v1.0.3/bin/$ARCH/amd64/kubectl
+ARCH=linux; wget https://storage.googleapis.com/kubernetes-release/release/v1.0.3/bin/$ARCH/amd64/kubectl
 ```
 
 After downloading the binary, ensure it is executable and move it into your PATH:

--- a/Documentation/kubernetes-on-vagrant.md
+++ b/Documentation/kubernetes-on-vagrant.md
@@ -20,7 +20,7 @@ First, download the binary using a command-line tool such as `wget` or `curl` fr
 Set the ARCH environment variable to "linux" or "darwin" based no your workstation operating system:
 
 ```sh
-ARCH=linux wget https://storage.googleapis.com/kubernetes-release/release/v1.0.3/bin/$ARCH/amd64/kubectl
+ARCH=linux; wget https://storage.googleapis.com/kubernetes-release/release/v1.0.3/bin/$ARCH/amd64/kubectl
 ```
 
 After downloading the binary, ensure it is executable and move it into your PATH:


### PR DESCRIPTION
Copying and pasting those commands neither worked on my mac or my CoreOS machine. The env var was not expanding.