### PR TITLE
Require confirmation for destroying a cluster

### DIFF
--- a/multi-node/aws/cmd/kube-aws/command_destroy.go
+++ b/multi-node/aws/cmd/kube-aws/command_destroy.go
@@ -17,10 +17,13 @@ var (
 		Long:  ``,
 		Run:   runCmdDestroy,
 	}
+
+	force bool
 )
 
 func init() {
 	cmdRoot.AddCommand(cmdDestroy)
+	cmdDestroy.Flags().BoolVar(&force, "force", false, "Destroy the cluster without interactive confirmation")
 }
 
 func runCmdDestroy(cmd *cobra.Command, args []string) {
@@ -32,6 +35,20 @@ func runCmdDestroy(cmd *cobra.Command, args []string) {
 	}
 
 	c := cluster.New(cfg, newAWSConfig(cfg))
+
+	if !force {
+		var confirmation string
+
+		fmt.Print("Are you sure you want to destroy the cluster? This action cannot be undone. Type \"yes\" to proceed: ")
+		if _, err = fmt.Scanln(&confirmation); err != nil {
+			stderr("Failed to read user input: %v", err)
+			os.Exit(1)
+		}
+
+		if confirmation != "yes" {
+			os.Exit(1)
+		}
+	}
 
 	if err := c.Destroy(); err != nil {
 		stderr("Failed destroying cluster: %v", err)


### PR DESCRIPTION
Help prevent accidental cluster destruction by requiring either interactive confirmation or --force=true.