### PR TITLE
pkg/cluster: mark AZ choice as optional

### DIFF
--- a/multi-node/aws/pkg/cluster/stack_template.go
+++ b/multi-node/aws/pkg/cluster/stack_template.go
@@ -546,7 +546,7 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 	par[parAvailabilityZone] = map[string]interface{}{
 		"Type":        "String",
 		"Default":     "",
-		"Description": "Specific availability zone",
+		"Description": "Specific availability zone (optional)",
 	}
 
 	regionMap, err := getRegionMap()


### PR DESCRIPTION
When using the AWS CloudFormation interface, the Availability Zone field is not marked optional.

> If not set, a zone will be chosen for you in the region being used to deploy the CloudFormation stack.