### PR TITLE
multi-node/aws: increase default volume size

### DIFF
--- a/multi-node/aws/cluster.yaml.example
+++ b/multi-node/aws/cluster.yaml.example
@@ -18,8 +18,14 @@ region:
 # is responsible for making this name routable
 externalDNSName:
 
+# Disk size (GB) for controller node
+#controllerRootVolumeSize: 30
+
 # Number of worker nodes to create
 #workerCount: 1
+
+# Disk size (GB) for worker nodes
+#workerRootVolumeSize: 30
 
 # Location of kube-aws artifacts used to deploy a new
 # Kubernetes cluster. The necessary artifacts are already

--- a/multi-node/aws/pkg/cluster/cluster.go
+++ b/multi-node/aws/pkg/cluster/cluster.go
@@ -102,6 +102,11 @@ func (c *Cluster) Create(tlsConfig *TLSConfig) error {
 			UsePreviousValue: aws.Bool(true),
 		},
 		{
+			ParameterKey:     aws.String(parNameControllerRootVolumeSize),
+			ParameterValue:   aws.String(fmt.Sprintf("%d", c.cfg.ControllerRootVolumeSize)),
+			UsePreviousValue: aws.Bool(true),
+		},
+		{
 			ParameterKey:     aws.String(parWorkerCert),
 			ParameterValue:   aws.String(base64.StdEncoding.EncodeToString(tlsConfig.WorkerCert)),
 			UsePreviousValue: aws.Bool(true),
@@ -114,6 +119,11 @@ func (c *Cluster) Create(tlsConfig *TLSConfig) error {
 		{
 			ParameterKey:     aws.String(parWorkerCount),
 			ParameterValue:   aws.String(fmt.Sprintf("%d", c.cfg.WorkerCount)),
+			UsePreviousValue: aws.Bool(true),
+		},
+		{
+			ParameterKey:     aws.String(parNameWorkerRootVolumeSize),
+			ParameterValue:   aws.String(fmt.Sprintf("%d", c.cfg.WorkerRootVolumeSize)),
 			UsePreviousValue: aws.Bool(true),
 		},
 	}

--- a/multi-node/aws/pkg/cluster/config.go
+++ b/multi-node/aws/pkg/cluster/config.go
@@ -14,13 +14,15 @@ var (
 )
 
 type Config struct {
-	ClusterName      string `yaml:"clusterName"`
-	ExternalDNSName  string `yaml:"externalDNSName"`
-	KeyName          string `yaml:"keyName"`
-	Region           string `yaml:"region"`
-	AvailabilityZone string `yaml:"availabilityZone"`
-	ArtifactURL      string `yaml:"artifactURL"`
-	WorkerCount      int    `yaml:"workerCount"`
+	ClusterName              string `yaml:"clusterName"`
+	ExternalDNSName          string `yaml:"externalDNSName"`
+	KeyName                  string `yaml:"keyName"`
+	Region                   string `yaml:"region"`
+	AvailabilityZone         string `yaml:"availabilityZone"`
+	ArtifactURL              string `yaml:"artifactURL"`
+	ControllerRootVolumeSize int    `yaml:"controllerRootVolumeSize"`
+	WorkerCount              int    `yaml:"workerCount"`
+	WorkerRootVolumeSize     int    `yaml:"workerRootVolumeSize"`
 }
 
 func (cfg *Config) Valid() error {

--- a/multi-node/aws/pkg/cluster/stack_template.go
+++ b/multi-node/aws/pkg/cluster/stack_template.go
@@ -28,19 +28,21 @@ const (
 	resNameIAMInstanceProfileWorker     = "IAMInstanceProfileWorker"
 
 	// parameter names
-	parClusterName                = "ClusterName"
-	parNameReleaseChannel         = "ReleaseChannel"
-	parNameControllerInstanceType = "ControllerInstanceType"
-	parNameWorkerInstanceType     = "WorkerInstanceType"
-	parNameKeyName                = "KeyName"
-	parArtifactURL                = "ArtifactURL"
-	parCACert                     = "CACert"
-	parAPIServerCert              = "APIServerCert"
-	parAPIServerKey               = "APIServerKey"
-	parWorkerCert                 = "WorkerCert"
-	parWorkerKey                  = "WorkerKey"
-	parWorkerCount                = "WorkerCount"
-	parAvailabilityZone           = "AvailabilityZone"
+	parClusterName                  = "ClusterName"
+	parNameReleaseChannel           = "ReleaseChannel"
+	parNameControllerInstanceType   = "ControllerInstanceType"
+	parNameControllerRootVolumeSize = "ControllerRootVolumeSize"
+	parNameWorkerInstanceType       = "WorkerInstanceType"
+	parNameKeyName                  = "KeyName"
+	parArtifactURL                  = "ArtifactURL"
+	parCACert                       = "CACert"
+	parAPIServerCert                = "APIServerCert"
+	parAPIServerKey                 = "APIServerKey"
+	parWorkerCert                   = "WorkerCert"
+	parWorkerKey                    = "WorkerKey"
+	parWorkerCount                  = "WorkerCount"
+	parNameWorkerRootVolumeSize     = "WorkerRootVolumeSize"
+	parAvailabilityZone             = "AvailabilityZone"
 )
 
 var (
@@ -401,6 +403,14 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 					},
 				},
 			},
+			"BlockDeviceMappings": []map[string]interface{}{
+				map[string]interface{}{
+					"DeviceName": "/dev/xvda",
+					"Ebs": map[string]interface{}{
+						"VolumeSize": newRef(parNameControllerRootVolumeSize),
+					},
+				},
+			},
 			"AvailabilityZone": availabilityZone,
 			"Tags": []map[string]interface{}{
 				newTag(tagKubernetesCluster, newRef(parClusterName)),
@@ -452,6 +462,14 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 			},
 			"SecurityGroups":     []interface{}{newRef(resNameSecurityGroupWorker)},
 			"IamInstanceProfile": newRef(resNameIAMInstanceProfileWorker),
+			"BlockDeviceMappings": []map[string]interface{}{
+				map[string]interface{}{
+					"DeviceName": "/dev/xvda",
+					"Ebs": map[string]interface{}{
+						"VolumeSize": newRef(parNameWorkerRootVolumeSize),
+					},
+				},
+			},
 		},
 	}
 
@@ -493,6 +511,12 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 		"Type":        "String",
 		"Default":     "m3.medium",
 		"Description": "EC2 instance type used for each controller instance",
+	}
+
+	par[parNameControllerRootVolumeSize] = map[string]interface{}{
+		"Type":        "String",
+		"Default":     "30",
+		"Description": "Controller root volume size (GiB)",
 	}
 
 	par[parNameWorkerInstanceType] = map[string]interface{}{
@@ -541,6 +565,12 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 		"Type":        "String",
 		"Default":     "1",
 		"Description": "Number of worker instances to create, may be modified later",
+	}
+
+	par[parNameWorkerRootVolumeSize] = map[string]interface{}{
+		"Type":        "String",
+		"Default":     "30",
+		"Description": "Worker root volume size (GiB)",
 	}
 
 	par[parAvailabilityZone] = map[string]interface{}{


### PR DESCRIPTION
The current template defaults to 8 GiB root volumes with ~5 GiB of usable space with system overhead.