### PR TITLE
[ssl] include IP SANS information for worker containers in the worker…

### DIFF
--- a/multi-node/vagrant/.gitignore
+++ b/multi-node/vagrant/.gitignore
@@ -1,3 +1,5 @@
 .vagrant
 config.rb
 ssl/
+.dockercfg
+

--- a/multi-node/vagrant/Vagrantfile
+++ b/multi-node/vagrant/Vagrantfile
@@ -49,8 +49,9 @@ etcd_endpoints = etcdIPs.map.with_index{ |ip, i| "http://#{ip}:2379" }.join(",")
 
 # Configure SSL certificates
 if !File.exist?(SSL_CONTROLLER_PATH) || !File.exists?(SSL_WORKER_PATH) then
-    sans = "IP.1=10.3.0.1," + controllerIPs.map.with_index { |ip, i| "IP.#{i+2}=#{ip}"}.join(",")
-    system("mkdir -p ssl && ./init-ssl ssl #{sans}") or abort ("failed generating SSL artifacts")
+  controller_sans = "IP.1=10.3.0.1," + controllerIPs.map.with_index { |ip, i| "IP.#{i+2}=#{ip}"}.join(",")
+  worker_sans = "IP.1=10.3.0.1," + workerIPs.map.with_index { |ip, i| "IP.#{i+2}=#{ip}"}.join(",")
+  system("mkdir -p ssl && ./init-ssl ssl #{controller_sans} #{worker_sans}") or abort ("failed generating SSL artifacts")
 end
 
 Vagrant.configure("2") do |config|

--- a/multi-node/vagrant/Vagrantfile
+++ b/multi-node/vagrant/Vagrantfile
@@ -92,6 +92,12 @@ Vagrant.configure("2") do |config|
     vb.gui = false
   end
 
+  if File.file?("./.dockercfg") then
+    config.vm.provision :file, :source => "./.dockercfg", :destination => "/home/core/.dockercfg"
+    config.vm.provision :shell, :inline => "cp /home/core/.dockercfg /root/.dockercfg", :privileged => true
+    config.vm.provision :shell, :inline => "cp /home/core/.dockercfg /.dockercfg", :privileged => true
+  end
+
   (1..$etcd_count).each do |i|
     config.vm.define vm_name = "e%d" % i do |etcd|
 

--- a/multi-node/vagrant/init-ssl
+++ b/multi-node/vagrant/init-ssl
@@ -5,8 +5,8 @@
 OPENSSL=/usr/bin/openssl
 
 function usage {
-    echo "USAGE: $0 <output-dir> [SAN,SAN,SAN]"
-    echo "  example: $0 ./ssl IP.1=127.0.0.1,IP.2=10.0.0.1"
+    echo "USAGE: $0 <output-dir> [CONTROLLER_SAN,CONTROLLER_SAN] [WORKER_SAN,WORKER_SAN]"
+    echo "  example: $0 ./ssl IP.1=127.0.0.1,IP.2=10.0.0.1 IP.1=172.16.8.4,IP.2=172.16.8.6"
 }
 
 if [ -z "$1" ]; then
@@ -20,7 +20,8 @@ if [ ! -d $1 ]; then
 fi
 
 OUTDIR=$1
-SANS=$2
+API_SANS=$2
+WORKER_SANS=$3
 
 OUTFILE_CONTROLLER="$OUTDIR/controller.tar"
 OUTFILE_WORKER="$OUTDIR/worker.tar"
@@ -44,7 +45,8 @@ DNS.2 = kubernetes.default
 echo "Generating SSL artifacts in $OUTDIR"
 
 # Add SANs to openssl config
-echo "$CNF_TEMPLATE$(echo $SANS | tr ',' '\n')" > $OUTDIR/apiserver-req.cnf
+echo "$CNF_TEMPLATE$(echo $API_SANS | tr ',' '\n')" > $OUTDIR/apiserver-req.cnf
+echo "$CNF_TEMPLATE$(echo $WORKER_SANS | tr ',' '\n')" > $OUTDIR/worker-req.cnf
 
 # establish cluster CA and self-sign a cert
 $OPENSSL genrsa -out $OUTDIR/ca-key.pem 2048
@@ -57,8 +59,8 @@ $OPENSSL x509 -req -in $OUTDIR/apiserver.csr -CA $OUTDIR/ca.pem -CAkey $OUTDIR/c
 
 # create worker key and signed cert
 $OPENSSL genrsa -out $OUTDIR/worker-key.pem 2048
-$OPENSSL req -new -key $OUTDIR/worker-key.pem -out $OUTDIR/worker.csr -subj "/CN=kube-worker"
-$OPENSSL x509 -req -in $OUTDIR/worker.csr -CA $OUTDIR/ca.pem -CAkey $OUTDIR/ca-key.pem -CAcreateserial -out $OUTDIR/worker.pem -days 365
+$OPENSSL req -new -key $OUTDIR/worker-key.pem -out $OUTDIR/worker.csr -subj "/CN=kube-worker" -config $OUTDIR/worker-req.cnf
+$OPENSSL x509 -req -in $OUTDIR/worker.csr -CA $OUTDIR/ca.pem -CAkey $OUTDIR/ca-key.pem -CAcreateserial -out $OUTDIR/worker.pem -days 365 -extensions v3_req -extfile $OUTDIR/worker-req.cnf
 
 # create admin key and signed cert
 $OPENSSL genrsa -out $OUTDIR/admin-key.pem 2048


### PR DESCRIPTION
… ssl key. allows for exec'ing into worker containers

Fixes the X509 cert validation problem when calling "kubectl exec" into a pod, where the worker is accessed by a different network address than the controller (default case).

$> kubectl exec <worker_pod_name>  -ti -- sh 

error: Unable to upgrade connection: {
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "x509: cannot validate certificate for 172.17.4.201 because it doesn't contain any IP SANs",
  "code": 500
}