### PR TITLE
flannel: use vxlan backend

### DIFF
--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -361,7 +361,7 @@ Earlier it was mentioned that flannel stores cluster-level configuration in etcd
 * Replace `$ETCD_SERVER` with one host from `$ETCD_ENDPOINTS`
 
 ```sh
-$ curl -X PUT -d "value={\"Network\":\"$POD_NETWORK\"}" "$ETCD_SERVER/v2/keys/coreos.com/network/config"
+$ curl -X PUT -d "value={\"Network\":\"$POD_NETWORK\",\"Backend\":{\"Type\":\"vxlan\"}}" "$ETCD_SERVER/v2/keys/coreos.com/network/config"
 ```
 
 #### Start kubelet

--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -68,7 +68,7 @@ function init_flannel {
             break
         fi
     done
-    RES=$(curl --silent -X PUT -d "value={\"Network\":\"$POD_NETWORK\"}" "$ACTIVE_ETCD/v2/keys/coreos.com/network/config?prevExist=false")
+    RES=$(curl --silent -X PUT -d "value={\"Network\":\"$POD_NETWORK\",\"Backend\":{\"Type\":\"vxlan\"}}" "$ACTIVE_ETCD/v2/keys/coreos.com/network/config?prevExist=false")
     if [ -z "$(echo $RES | grep '"action":"create"')" ] && [ -z "$(echo $RES | grep 'Key already exists')" ]; then
         echo "Unexpected error configuring flannel pod network: $RES"
     fi

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -61,7 +61,7 @@ function init_flannel {
             break
         fi
     done
-    RES=$(curl --silent -X PUT -d "value={\"Network\":\"$POD_NETWORK\"}" "$ACTIVE_ETCD/v2/keys/coreos.com/network/config?prevExist=false")
+    RES=$(curl --silent -X PUT -d "value={\"Network\":\"$POD_NETWORK\",\"Backend\":{\"Type\":\"vxlan\"}}" "$ACTIVE_ETCD/v2/keys/coreos.com/network/config?prevExist=false")
     if [ -z "$(echo $RES | grep '"action":"create"')" ] && [ -z "$(echo $RES | grep 'Key already exists')" ]; then
         echo "Unexpected error configuring flannel pod network: $RES"
     fi


### PR DESCRIPTION
Fixes: https://github.com/coreos/coreos-kubernetes/issues/112

Ran k8s conformance tests. All worked well.
Leaving the aws installation as-is for now (using udp) because we are switching to use the cloud-provider/vpc integration soon anyway.

/cc @philips @eyakubovich 