### PR TITLE
Use the correct AWS role when creating workers.

### DIFF
--- a/multi-node/aws/pkg/cluster/stack_template.go
+++ b/multi-node/aws/pkg/cluster/stack_template.go
@@ -366,7 +366,7 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 		"Properties": map[string]interface{}{
 			"Path": "/",
 			"Roles": []map[string]interface{}{
-				newRef(resNameIAMRoleController),
+				newRef(resNameIAMRoleWorker),
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #95.