### PR TITLE
multi-node/aws/artifacts: Add node labels for AWS metadata.

### DIFF
--- a/multi-node/aws/artifacts/manifests/worker/aws-node-labels.yaml
+++ b/multi-node/aws/artifacts/manifests/worker/aws-node-labels.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: aws-node-labels
+spec:
+  hostNework: true
+  restartPolicy: OnFailure
+  containers:
+    - name: apply-labels
+      image: elevy/aws-node-labels:latest
+      securityContext:
+        privileged: true
+      env:
+        - name: CONTROLLER_ENDPOINT
+          value: "${CONTROLLER_ENDPOINT}"
+      volumeMounts:
+        - mountPath: /etc/kubernetes/ssl
+          name: kubernetes-ssl
+          readOnly: true
+  volumes:
+    - name: kubernetes-ssl
+      hostPath:
+        path: /etc/kubernetes/ssl

--- a/multi-node/aws/artifacts/scripts/install-worker.sh
+++ b/multi-node/aws/artifacts/scripts/install-worker.sh
@@ -99,6 +99,7 @@ EOF
 	mkdir -p /etc/kubernetes/manifests
 	template manifests/worker/kubeconfig /etc/kubernetes/worker-kubeconfig.yaml
 	template manifests/worker/kube-proxy.yaml /etc/kubernetes/manifests/kube-proxy.yaml
+	template manifests/worker/aws-node-labels.yaml /etc/kubernetes/manifests/aws-node-labels.yaml
 
 	local TEMPLATE=/run/flannel/options.env
 	[ -f $TEMPLATE ] || {


### PR DESCRIPTION
This demonstrates a proposal on how to tag nodes with labels derived from AWS metadata.  It makes use of a small single-shot container dropped into the /etc/kubernetes/metadata directory to fetch the metadata and apply the label.

The container I use can be found in Docker Hub as elevy/aws-node-labels.  CoreOS would copy and host the container for it to be officially integrated.

Note that this is just a stopgap until the https://github.com/kubernetes/kubernetes/pull/13524 proposal is implemented.

Fixes #120.