### PR TITLE
Configure kubectl keys with apiserver

### DIFF
--- a/Documentation/kubernetes-on-vagrant-single.md
+++ b/Documentation/kubernetes-on-vagrant-single.md
@@ -51,7 +51,7 @@ Once in the `coreos-kubernetes/single-node/` directory, configure your local Kub
 
 ```sh
 $ kubectl config set-cluster vagrant --server=https://172.17.4.99:443 --certificate-authority=${PWD}/ssl/ca.pem
-$ kubectl config set-credentials vagrant-admin --certificate-authority=${PWD}/ssl/ca.pem --client-key=${PWD}/ssl/admin-key.pem --client-certificate=${PWD}/ssl/admin.pem
+$ kubectl config set-credentials vagrant-admin --certificate-authority=${PWD}/ssl/ca.pem --client-key=${PWD}/ssl/apiserver-key.pem --client-certificate=${PWD}/ssl/apiserver.pem
 $ kubectl config set-context vagrant --cluster=vagrant --user=vagrant-admin
 $ kubectl config use-context vagrant
 ```


### PR DESCRIPTION
admin.pem and admin-key.pem no longer exists. The name seems to have changed to apiserver.pem and apiserver-key.pem