### PR TITLE
[multi-node/aws docs] update s3 artifact URL docs to recognize new s3…

### DIFF
--- a/multi-node/aws/README.md
+++ b/multi-node/aws/README.md
@@ -22,7 +22,7 @@ $ kube-aws render --output=artifacts/template.json
 $ aws s3 cp --recursive --acl=public-read artifacts/ s3://<bucket>/
 ```
 
-Then, simply create a cluster using `artifactURL: https://s3.amazonaws.com/<bucket>`.
+Then, simply create a cluster using `artifactURL: https://<bucket>.s3.amazonaws.com`.
 
 ### Useful Resources
 


### PR DESCRIPTION
… endpoint format

Requesting https://s3.amazonaws.com/bucket/path you get an xml blob telling you
to use the url https://bucket.s3.amazonaws.com/path instead