### PR TITLE
Instantiate a VPN access server with the Kubernetes cluster

### DIFF
--- a/multi-node/aws/pkg/cluster/cluster.go
+++ b/multi-node/aws/pkg/cluster/cluster.go
@@ -12,8 +12,8 @@ import (
 )
 
 type ClusterInfo struct {
-	Name         string
-	ControllerIP string
+	Name  string
+	VpnIP string
 }
 
 func (c *ClusterInfo) String() string {
@@ -22,7 +22,8 @@ func (c *ClusterInfo) String() string {
 	w.Init(buf, 0, 8, 0, '\t', 0)
 
 	fmt.Fprintf(w, "Cluster Name:\t%s\n", c.Name)
-	fmt.Fprintf(w, "Controller IP:\t%s\n", c.ControllerIP)
+	fmt.Fprintf(w, "Controller IP:\t10.0.0.50\n")
+	fmt.Fprintf(w, "VPN IP:\t%s\n", c.VpnIP)
 
 	w.Flush()
 	return buf.String()

--- a/multi-node/aws/pkg/cluster/stack.go
+++ b/multi-node/aws/pkg/cluster/stack.go
@@ -78,14 +78,9 @@ func mapStackResourcesToClusterInfo(svc *ec2.EC2, resources []cloudformation.Sta
 	var info ClusterInfo
 	for _, r := range resources {
 		switch aws.StringValue(r.LogicalResourceId) {
-		case resNameEIPController:
-			if r.PhysicalResourceId != nil {
-				info.ControllerIP = *r.PhysicalResourceId
-			} else {
-				return nil, fmt.Errorf("unable to get public IP of controller instance")
-			}
 		}
 	}
+	return nil, fmt.Errorf("unable to get public IP of controller instance")
 
 	return &info, nil
 }

--- a/multi-node/aws/pkg/cluster/stack.go
+++ b/multi-node/aws/pkg/cluster/stack.go
@@ -78,9 +78,14 @@ func mapStackResourcesToClusterInfo(svc *ec2.EC2, resources []cloudformation.Sta
 	var info ClusterInfo
 	for _, r := range resources {
 		switch aws.StringValue(r.LogicalResourceId) {
+		case resNameEipVpn:
+			if r.PhysicalResourceId != nil {
+				info.ControllerIP = *r.PhysicalResourceId
+			} else {
+				return nil, fmt.Errorf("unable to get public IP of VPN instance")
+			}
 		}
 	}
-	return nil, fmt.Errorf("unable to get public IP of controller instance")
 
 	return &info, nil
 }

--- a/multi-node/aws/pkg/cluster/stack_template.go
+++ b/multi-node/aws/pkg/cluster/stack_template.go
@@ -385,7 +385,7 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 			"NetworkInterfaces": []map[string]interface{}{
 				map[string]interface{}{
 					"PrivateIpAddress":         "10.0.0.50",
-					"AssociatePublicIpAddress": false,
+					"AssociatePublicIpAddress": true,
 					"DeleteOnTermination":      true,
 					"DeviceIndex":              "0",
 					"SubnetId":                 newRef(resNameSubnet),

--- a/multi-node/aws/pkg/cluster/stack_template.go
+++ b/multi-node/aws/pkg/cluster/stack_template.go
@@ -48,6 +48,8 @@ var (
 	supportedChannels    = []string{"alpha"}
 	tagKubernetesCluster = "KubernetesCluster"
 
+	vpcCidr = "10.0.0.0/16"
+
 	sgProtoTCP = "tcp"
 	sgProtoUDP = "udp"
 
@@ -141,7 +143,7 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 	res[resNameVPC] = map[string]interface{}{
 		"Type": "AWS::EC2::VPC",
 		"Properties": map[string]interface{}{
-			"CidrBlock":          "10.0.0.0/16",
+			"CidrBlock":          vpcCidr,
 			"EnableDnsSupport":   true,
 			"EnableDnsHostnames": true,
 			"InstanceTenancy":    "default",
@@ -222,8 +224,8 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 				map[string]interface{}{"IpProtocol": sgProtoUDP, "FromPort": 0, "ToPort": sgPortMax, "CidrIp": sgAllIPs},
 			},
 			"SecurityGroupIngress": []map[string]interface{}{
-				map[string]interface{}{"IpProtocol": sgProtoTCP, "FromPort": 22, "ToPort": 22, "CidrIp": sgAllIPs},
-				map[string]interface{}{"IpProtocol": sgProtoTCP, "FromPort": 443, "ToPort": 443, "CidrIp": sgAllIPs},
+				map[string]interface{}{"IpProtocol": sgProtoTCP, "FromPort": 22, "ToPort": 22, "CidrIp": vpcCidr},
+				map[string]interface{}{"IpProtocol": sgProtoTCP, "FromPort": 443, "ToPort": 443, "CidrIp": vpcCidr},
 			},
 			"Tags": []map[string]interface{}{
 				newTag(tagKubernetesCluster, newRef(parClusterName)),
@@ -251,7 +253,7 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 				map[string]interface{}{"IpProtocol": sgProtoUDP, "FromPort": 0, "ToPort": sgPortMax, "CidrIp": sgAllIPs},
 			},
 			"SecurityGroupIngress": []map[string]interface{}{
-				map[string]interface{}{"IpProtocol": sgProtoTCP, "FromPort": 22, "ToPort": 22, "CidrIp": sgAllIPs},
+				map[string]interface{}{"IpProtocol": sgProtoTCP, "FromPort": 22, "ToPort": 22, "CidrIp": vpcCidr},
 			},
 			"Tags": []map[string]interface{}{
 				newTag(tagKubernetesCluster, newRef(parClusterName)),

--- a/multi-node/aws/pkg/cluster/stack_template.go
+++ b/multi-node/aws/pkg/cluster/stack_template.go
@@ -15,6 +15,11 @@ const (
 	resNameRouteToInternet              = "RouteToInternet"
 	resNameSubnet                       = "Subnet"
 	resNameSubnetRouteTableAssociation  = "SubnetRouteTableAssociation"
+	resNameSecurityGroupVpn             = "SecurityGroupVpn"
+	resNameEipVpn                       = "EipVpn"
+	resNameInstanceVpn                  = "InstanceVpn"
+	resNameEipAssociationVpn            = "EipAssociationVpn"
+	resNameAlarmControllerRecoverVpn    = "AlarmControllerRecoverVpn"
 	resNameSecurityGroupController      = "SecurityGroupController"
 	resNameSecurityGroupWorker          = "SecurityGroupWorker"
 	resNameInstanceController           = "InstanceController"
@@ -121,6 +126,14 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 		},
 	}
 
+	vpnImageID := map[string]interface{}{
+		"Fn::FindInMap": []interface{}{
+			"VpnRegionMap",
+			newRef("AWS::Region"),
+			"AMI",
+		},
+	}
+
 	defaultAvailabilityZone := map[string]interface{}{
 		"Fn::Select": []interface{}{
 			"0",
@@ -211,6 +224,105 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 		"Properties": map[string]interface{}{
 			"RouteTableId": newRef(resNameRouteTable),
 			"SubnetId":     newRef(resNameSubnet),
+		},
+	}
+
+	res[resNameSecurityGroupVpn] = map[string]interface{}{
+		"Type": "AWS::EC2::SecurityGroup",
+		"Properties": map[string]interface{}{
+			"GroupDescription": "VPN server security group",
+			"VpcId":            newRef(resNameVPC),
+			"SecurityGroupIngress": []map[string]interface{}{
+				map[string]interface{}{"IpProtocol": sgProtoTCP, "FromPort":   22, "ToPort":   22, "CidrIp": "0.0.0.0/0"},
+				map[string]interface{}{"IpProtocol": sgProtoTCP, "FromPort":  443, "ToPort":  443, "CidrIp": "0.0.0.0/0"},
+				map[string]interface{}{"IpProtocol": sgProtoTCP, "FromPort":  943, "ToPort":  943, "CidrIp": "0.0.0.0/0"},
+				map[string]interface{}{"IpProtocol": sgProtoUDP, "FromPort": 1194, "ToPort": 1194, "CidrIp": "0.0.0.0/0"},
+			},
+			"Tags": []map[string]interface{}{
+				newTag(tagKubernetesCluster, newRef(parClusterName)),
+			},
+		},
+	}
+
+	res[resNameEipVpn] = map[string]interface{}{
+		"Type": "AWS::EC2::EIP",
+		"Properties": map[string]interface{}{
+			"Domain": "vpc",
+		},
+	}
+
+	res[resNameInstanceVpn] = map[string]interface{}{
+		"Type": "AWS::EC2::Instance",
+		"DependsOn": resNameEipVpn,
+		"Properties": map[string]interface{}{
+			"ImageId": vpnImageID,
+			"InstanceType": "t2.small",
+			"KeyName": newRef(parNameKeyName),
+			"SubnetId":	newRef(resNameSubnet),
+			"SecurityGroupIds": []interface{}{
+				newRef(resNameSecurityGroupVpn),
+			},
+			"Tags": []map[string]interface{}{
+				newTag(tagKubernetesCluster, newRef(parClusterName)),
+				newTag("Name", "OpenVPN server"),
+			},
+			"UserData": map[string]interface{}{
+				"Fn::Base64": map[string]interface{}{
+					"Fn::Join": []interface{}{
+						"",
+						[]interface{}{
+							"public_hostname=",
+							newRef(resNameEipVpn),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	res[resNameEipAssociationVpn] = map[string]interface{}{
+		"Type": "AWS::EC2::EIPAssociation",
+		"DependsOn": resNameInstanceVpn,
+		"Properties": map[string]interface{}{
+			"AllocationId": map[string]interface{}{
+				"Fn::GetAtt": []string{
+					resNameEipVpn,
+					"AllocationId",
+				},
+			},
+			"InstanceId": newRef(resNameInstanceVpn),
+		},
+	}
+
+	res[resNameAlarmControllerRecoverVpn] = map[string]interface{}{
+		"Type": "AWS::CloudWatch::Alarm",
+		"Properties": map[string]interface{}{
+			"AlarmDescription":   "Trigger a recovery when system check fails for 5 consecutive minutes.",
+			"Namespace":          "AWS/EC2",
+			"MetricName":         "StatusCheckFailed_System",
+			"Statistic":          "Minimum",
+			"Period":             "60",
+			"EvaluationPeriods":  "5",
+			"ComparisonOperator": "GreaterThanThreshold",
+			"Threshold":          "0",
+			"AlarmActions": []interface{}{
+				map[string]interface{}{
+					"Fn::Join": []interface{}{
+						"",
+						[]interface{}{
+							"arn:aws:automate:",
+							newRef("AWS::Region"),
+							":ec2:recover",
+						},
+					},
+				},
+			},
+			"Dimensions": []interface{}{
+				map[string]interface{}{
+					"Name":  "InstanceId",
+					"Value": newRef(resNameInstanceVpn),
+				},
+			},
 		},
 	}
 
@@ -579,7 +691,18 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 	}
 
 	mappings := map[string]interface{}{
-		"RegionMap": regionMap,
+    "RegionMap": regionMap,
+    "VpnRegionMap":     map[string]interface{}{
+      "us-east-1":      map[string]string { "AMI" : "ami-5fe36434", },
+      "us-west-1":      map[string]string { "AMI" : "ami-8bf40fcf", },
+      "us-west-2":      map[string]string { "AMI" : "ami-9fe2f2af", },
+      "eu-west-1":      map[string]string { "AMI" : "ami-03644074", },
+      "eu-central-1":   map[string]string { "AMI" : "ami-507f7e4d", },
+      "sa-east-1":      map[string]string { "AMI" : "ami-4fd55f52", },
+      "ap-southeast-1": map[string]string { "AMI" : "ami-365c5764", },
+      "ap-southeast-2": map[string]string { "AMI" : "ami-831d51b9", },
+      "ap-northeast-1": map[string]string { "AMI" : "ami-5ea72b5e", },
+ 		},
 	}
 
 	conditions := map[string]interface{}{

--- a/multi-node/aws/pkg/cluster/stack_template.go
+++ b/multi-node/aws/pkg/cluster/stack_template.go
@@ -18,7 +18,6 @@ const (
 	resNameSecurityGroupController      = "SecurityGroupController"
 	resNameSecurityGroupWorker          = "SecurityGroupWorker"
 	resNameInstanceController           = "InstanceController"
-	resNameEIPController                = "EIPController"
 	resNameAlarmControllerRecover       = "AlarmControllerRecover"
 	resNameAutoScaleWorker              = "AutoScaleWorker"
 	resNameLaunchConfigurationWorker    = "LaunchConfigurationWorker"
@@ -370,14 +369,6 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 			"Roles": []map[string]interface{}{
 				newRef(resNameIAMRoleWorker),
 			},
-		},
-	}
-
-	res[resNameEIPController] = map[string]interface{}{
-		"Type": "AWS::EC2::EIP",
-		"Properties": map[string]interface{}{
-			"InstanceId": newRef(resNameInstanceController),
-			"Domain":     "vpc",
 		},
 	}
 


### PR DESCRIPTION
It also disables the controller elastic IP and SSH and HTTPS access to cluster nodes.

To configure the VPN access server after its brought up by the CloudFormation template:
- ssh openvpnas@[elastic_ip]
- passwd openvpn
- if desired, login to https://[elastic_ip]:943/admin with the openvpn user to config the VPN
- login to https://[elastic_ip], select login, not connect, from the drop down and download VPN connection profile
- import the profile into Tunnelblick or other VPN client by opening the file
- connect using your username (openvpn) and password

Closes #137.