### PR TITLE
multi-node/aws: Upgrade to K8s 1.1.1 and configure kube-proxy to use iptables

### DIFF
--- a/multi-node/aws/artifacts/manifests/controller/kube-proxy.yaml
+++ b/multi-node/aws/artifacts/manifests/controller/kube-proxy.yaml
@@ -12,6 +12,7 @@ spec:
     - /hyperkube
     - proxy
     - --master=http://127.0.0.1:8080
+    - --proxy-mode=iptables
     securityContext:
       privileged: true
     volumeMounts:

--- a/multi-node/aws/artifacts/manifests/worker/kube-proxy.yaml
+++ b/multi-node/aws/artifacts/manifests/worker/kube-proxy.yaml
@@ -13,6 +13,7 @@ spec:
     - proxy
     - --master=${CONTROLLER_ENDPOINT}
     - --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml
+    - --proxy-mode=iptables
     securityContext:
       privileged: true
     volumeMounts:

--- a/multi-node/aws/artifacts/scripts/install-controller.sh
+++ b/multi-node/aws/artifacts/scripts/install-controller.sh
@@ -5,7 +5,7 @@ set -e
 export ETCD_ENDPOINTS=
 
 # Specify the version (vX.Y.Z) of Kubernetes assets to deploy
-export K8S_VER=v1.0.7
+export K8S_VER=v1.1.1
 
 # The CIDR network to use for pod IPs.
 # Each pod launched in the cluster will be assigned an IP out of this range.

--- a/multi-node/aws/artifacts/scripts/install-controller.sh
+++ b/multi-node/aws/artifacts/scripts/install-controller.sh
@@ -67,7 +67,7 @@ function init_config {
 function install_kubelet {
 	mkdir /opt
 	cd /opt
-	curl -sLO https://storage.googleapis.com/kubernetes-release/release/v1.1.1/bin/linux/amd64/kubelet
+	curl -sLO https://storage.googleapis.com/kubernetes-release/release/${K8S_VER}/bin/linux/amd64/kubelet
 	chmod a+rx /opt/kubelet
 }
 

--- a/multi-node/aws/artifacts/scripts/install-controller.sh
+++ b/multi-node/aws/artifacts/scripts/install-controller.sh
@@ -64,6 +64,13 @@ function init_config {
 	done
 }
 
+function install_kubelet {
+	mkdir /opt
+	cd /opt
+	curl -sLO https://storage.googleapis.com/kubernetes-release/release/v1.1.1/bin/linux/amd64/kubelet
+	chmod a+rx /opt/kubelet
+}
+
 function init_flannel {
 	echo "Waiting for etcd..."
 	while true
@@ -95,7 +102,7 @@ function init_templates {
 		cat << EOF > $TEMPLATE
 [Service]
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
-ExecStart=/usr/bin/kubelet \
+ExecStart=/opt/kubelet \
   --api_servers=http://127.0.0.1:8080 \
   --register-node=false \
   --allow-privileged=true \
@@ -171,8 +178,8 @@ function start_addons {
 }
 
 init_config
+install_kubelet
 init_templates
-
 init_flannel
 
 systemctl daemon-reload

--- a/multi-node/aws/artifacts/scripts/install-worker.sh
+++ b/multi-node/aws/artifacts/scripts/install-worker.sh
@@ -10,7 +10,7 @@ export ETCD_ENDPOINTS=
 export CONTROLLER_ENDPOINT=
 
 # Specify the version (vX.Y.Z) of Kubernetes assets to deploy
-export K8S_VER=v1.0.7
+export K8S_VER=v1.1.1
 
 # The IP address of the cluster DNS service.
 # This must be the same DNS_SERVICE_IP used when configuring the controller nodes.

--- a/multi-node/aws/artifacts/scripts/install-worker.sh
+++ b/multi-node/aws/artifacts/scripts/install-worker.sh
@@ -37,7 +37,7 @@ EOF
 function install_kubelet {
 	mkdir /opt
 	cd /opt
-	curl -sLO https://storage.googleapis.com/kubernetes-release/release/v1.1.1/bin/linux/amd64/kubelet
+	curl -sLO https://storage.googleapis.com/kubernetes-release/release/${K8S_VER}/bin/linux/amd64/kubelet
 	chmod a+rx /opt/kubelet
 }
 

--- a/multi-node/aws/artifacts/scripts/install-worker.sh
+++ b/multi-node/aws/artifacts/scripts/install-worker.sh
@@ -34,6 +34,13 @@ EOF
 " > $2
 }
 
+function install_kubelet {
+	mkdir /opt
+	cd /opt
+	curl -sLO https://storage.googleapis.com/kubernetes-release/release/v1.1.1/bin/linux/amd64/kubelet
+	chmod a+rx /opt/kubelet
+}
+
 function init_config {
 	local REQUIRED=( 'ADVERTISE_IP' 'ETCD_ENDPOINTS' 'CONTROLLER_ENDPOINT' 'DNS_SERVICE_IP' 'K8S_VER' 'ARTIFACT_URL' )
 
@@ -78,7 +85,7 @@ function init_templates {
 		cat << EOF > $TEMPLATE
 [Service]
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
-ExecStart=/usr/bin/kubelet \
+ExecStart=/opt/kubelet \
   --api_servers=${CONTROLLER_ENDPOINT} \
   --register-node=true \
   --allow-privileged=true \
@@ -113,6 +120,7 @@ EOF
 }
 
 init_config
+install_kubelet
 init_templates
 init_docker
 


### PR DESCRIPTION
The kubelet 1.1.1 binary is downloaded and used instead of the CoreOS kubelet to maintain version parity with other components.  To be reversed once CoreOS ships a v1.1.1 kubelet.