### PR TITLE
Added Addon Kube-UI to multi-node aws artifacts

### DIFF
--- a/multi-node/aws/artifacts/manifests/cluster/kube-ui-rc.json
+++ b/multi-node/aws/artifacts/manifests/cluster/kube-ui-rc.json
@@ -1,0 +1,59 @@
+{
+  "apiVersion": "v1",
+  "kind": "ReplicationController",
+  "metadata": {
+    "labels": {
+      "k8s-app": "kube-ui",
+      "kubernetes.io/cluster-service": "true",
+      "version": "v3"
+    },
+    "name": "kube-ui-v3",
+    "namespace": "kube-system"
+  },
+  "spec": {
+    "replicas": 1,
+    "selector": {
+      "k8s-app": "kube-ui",
+      "version": "v3"
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "k8s-app": "kube-ui",
+          "kubernetes.io/cluster-service": "true",
+          "version": "v3"
+        }
+      },
+      "spec": {
+            "containers":[
+               {
+                  "name":"kube-ui",
+                  "image":"gcr.io/google_containers/kube-ui:v3",
+                  "resources": {
+                    "limits": {
+                      "cpu": "100m",
+                      "memory": "50Mi"
+                     }
+                   },
+                  "livenessProbe": {
+                    "httpGet": {
+                      "path": "/",
+                      "port": 8080,
+                      "scheme": "HTTP"
+                    },
+                   "initialDelaySeconds": 30,
+                   "timeoutSeconds": 5
+                  },
+                  "ports":[
+                     {
+                        "name":"http-server",
+                        "containerPort":8080
+                     }
+                  ]
+               }
+            ]
+         }
+      }
+   }
+}
+

--- a/multi-node/aws/artifacts/manifests/cluster/kube-ui-svc.json
+++ b/multi-node/aws/artifacts/manifests/cluster/kube-ui-svc.json
@@ -1,0 +1,25 @@
+{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "name": "kube-ui",
+    "namespace": "kube-system",
+    "labels": {
+      "k8s-app": "kube-ui",
+      "kubernetes.io/name": "KubeUI",
+      "kubernetes.io/cluster-service": "true"
+    }
+  },
+  "spec": {
+    "ports": [
+      {
+        "protocol": "TCP",
+        "targerPort": 8080,
+        "port": 8080
+      }
+    ],
+    "selector": {
+      "k8s-app": "kube-ui"
+    }
+  }
+}

--- a/multi-node/aws/artifacts/scripts/install-controller.sh
+++ b/multi-node/aws/artifacts/scripts/install-controller.sh
@@ -102,7 +102,7 @@ ExecStart=/usr/bin/kubelet \
   --config=/etc/kubernetes/manifests \
   --cluster_dns=${DNS_SERVICE_IP} \
   --cluster_domain=cluster.local \
-  --cadvisor-port=0
+  --cadvisor-port=4194
 Restart=always
 RestartSec=10
 
@@ -123,6 +123,8 @@ EOF
 	template manifests/cluster/kube-system.json /srv/kubernetes/manifests/kube-system.json
 	template manifests/cluster/kube-dns-rc.json /srv/kubernetes/manifests/kube-dns-rc.json
 	template manifests/cluster/kube-dns-svc.json /srv/kubernetes/manifests/kube-dns-svc.json
+	template manifests/cluster/kube-ui-rc.json /srv/kubernetes/manifests/kube-ui-rc.json
+	template manifests/cluster/kube-ui-svc.json /srv/kubernetes/manifests/kube-ui-svc.json
 
 	local TEMPLATE=/etc/flannel/options.env
 	[ -f $TEMPLATE ] || {
@@ -168,6 +170,8 @@ function start_addons {
 	echo "K8S: DNS addon"
 	curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
 	curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
+	curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/kube-ui-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
+	curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/kube-ui-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
 }
 
 init_config

--- a/multi-node/aws/artifacts/scripts/install-worker.sh
+++ b/multi-node/aws/artifacts/scripts/install-worker.sh
@@ -88,7 +88,7 @@ ExecStart=/usr/bin/kubelet \
   --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
   --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
   --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
-  --cadvisor-port=0
+  --cadvisor-port=4194
 Restart=always
 RestartSec=10
 [Install]

--- a/multi-node/aws/pkg/cluster/stack_template.go
+++ b/multi-node/aws/pkg/cluster/stack_template.go
@@ -279,6 +279,16 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 			"IpProtocol":            sgProtoUDP,
 		},
 	}
+        res[resNameSecurityGroupWorker+"IngressFromControllerTocAdvisor"] = map[string]interface{}{
+                "Type": "AWS::EC2::SecurityGroupIngress",
+                "Properties": map[string]interface{}{
+                        "GroupId":               newRef(resNameSecurityGroupWorker),
+                        "SourceSecurityGroupId": newRef(resNameSecurityGroupController),
+                        "FromPort":              4194,
+                        "ToPort":                4194,
+                        "IpProtocol":            sgProtoTCP,
+                },
+        }
 	res[resNameSecurityGroupWorker+"IngressFromControllerToKubelet"] = map[string]interface{}{
 		"Type": "AWS::EC2::SecurityGroupIngress",
 		"Properties": map[string]interface{}{


### PR DESCRIPTION
1. Added Replication Controller for Kube-UI
2. Added Service for Kube-UI
3. Added Addon - Kube-UI to be launched on Controller node with 'kube-aws up' script also changed the cadvisor port from 0 to 4194
4. Changed the cadvisor port from 0 to 4194 to be used with Kube-UI to get the stats from worker nodes
5. Added Port TCP port 4194 for cAdvisor when using KubeUI in render function for kube-aw