### PR TITLE
Bump kube-aws to 1.1.1

### DIFF
--- a/Documentation/configure-kubectl.md
+++ b/Documentation/configure-kubectl.md
@@ -8,7 +8,7 @@ First, download the binary using a command-line tool such as `wget` or `curl`:
 
 ```sh
 # Replace ${ARCH} with "linux" or "darwin" based on your workstation operating system
-$ ARCH=linux; wget https://storage.googleapis.com/kubernetes-release/release/v1.0.7/bin/${ARCH}/amd64/kubectl
+$ ARCH=linux; wget https://storage.googleapis.com/kubernetes-release/release/v1.1.1/bin/${ARCH}/amd64/kubectl
 ```
 
 After downloading the binary, ensure it is executable and move it into your `PATH`:

--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -128,7 +128,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-apiserver
-    image: gcr.io/google_containers/hyperkube:v1.0.7
+    image: gcr.io/google_containers/hyperkube:v1.1.1
     command:
     - /hyperkube
     - apiserver
@@ -186,7 +186,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-proxy
-    image: gcr.io/google_containers/hyperkube:v1.0.7
+    image: gcr.io/google_containers/hyperkube:v1.1.1
     command:
     - /hyperkube
     - proxy
@@ -287,7 +287,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-controller-manager
-    image: gcr.io/google_containers/hyperkube:v1.0.7
+    image: gcr.io/google_containers/hyperkube:v1.1.1
     command:
     - /hyperkube
     - controller-manager
@@ -335,7 +335,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-scheduler
-    image: gcr.io/google_containers/hyperkube:v1.0.7
+    image: gcr.io/google_containers/hyperkube:v1.1.1
     command:
     - /hyperkube
     - scheduler

--- a/Documentation/deploy-workers.md
+++ b/Documentation/deploy-workers.md
@@ -112,7 +112,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-proxy
-    image: gcr.io/google_containers/hyperkube:v1.0.7
+    image: gcr.io/google_containers/hyperkube:v1.1.1
     command:
     - /hyperkube
     - proxy

--- a/Documentation/kubernetes-on-vagrant-single.md
+++ b/Documentation/kubernetes-on-vagrant-single.md
@@ -17,11 +17,11 @@ Navigate to the [Vagrant downloads page][vagrant-downloads] and grab the appropr
 The primary CLI tool used to interact with the Kubernetes API is called `kubectl`.
 This tool is not yet available through the typical means of software distribution, so it is suggested that you download the binary directly from the Kubernetes release artifact site:
 
-First, download the binary using a command-line tool such as `wget` or `curl` from `https://storage.googleapis.com/kubernetes-release/release/v1.0.7/bin/${ARCH}/amd64/kubectl`.
+First, download the binary using a command-line tool such as `wget` or `curl` from `https://storage.googleapis.com/kubernetes-release/release/v1.1.1/bin/${ARCH}/amd64/kubectl`.
 Set the ARCH environment variable to "linux" or "darwin" based on your workstation operating system:
 
 ```sh
-ARCH=linux; wget https://storage.googleapis.com/kubernetes-release/release/v1.0.7/bin/$ARCH/amd64/kubectl
+ARCH=linux; wget https://storage.googleapis.com/kubernetes-release/release/v1.1.1/bin/$ARCH/amd64/kubectl
 ```
 
 After downloading the binary, ensure it is executable and move it into your PATH:

--- a/Documentation/kubernetes-on-vagrant.md
+++ b/Documentation/kubernetes-on-vagrant.md
@@ -16,11 +16,11 @@ Navigate to the [Vagrant downloads page][vagrant-downloads] and grab the appropr
 The primary CLI tool used to interact with the Kubernetes API is called `kubectl`.
 This tool is not yet available through the typical means of software distribution, so it is suggested that you download the binary directly from the Kubernetes release artifact site:
 
-First, download the binary using a command-line tool such as `wget` or `curl` from `https://storage.googleapis.com/kubernetes-release/release/v1.0.7/bin/${ARCH}/amd64/kubectl`.
+First, download the binary using a command-line tool such as `wget` or `curl` from `https://storage.googleapis.com/kubernetes-release/release/v1.1.1/bin/${ARCH}/amd64/kubectl`.
 Set the ARCH environment variable to "linux" or "darwin" based on your workstation operating system:
 
 ```sh
-ARCH=linux; wget https://storage.googleapis.com/kubernetes-release/release/v1.0.7/bin/$ARCH/amd64/kubectl
+ARCH=linux; wget https://storage.googleapis.com/kubernetes-release/release/v1.1.1/bin/$ARCH/amd64/kubectl
 ```
 
 After downloading the binary, ensure it is executable and move it into your PATH:

--- a/contrib/publish-release.sh
+++ b/contrib/publish-release.sh
@@ -10,7 +10,7 @@ if [ $# -ne 1 ]; then
 fi
 
 VERSION=$1
-S3_BUCKET="coreos-kubernetes"
+S3_BUCKET=${S3_BUCKET:-coreos-kubernetes}
 
 echo "Preparing release artifacts for $VERSION"
 

--- a/multi-node/aws/artifacts/scripts/install-controller.sh
+++ b/multi-node/aws/artifacts/scripts/install-controller.sh
@@ -5,7 +5,7 @@ set -e
 export ETCD_ENDPOINTS=
 
 # Specify the version (vX.Y.Z) of Kubernetes assets to deploy
-export K8S_VER=v1.0.7
+export K8S_VER=v1.1.1
 
 # The CIDR network to use for pod IPs.
 # Each pod launched in the cluster will be assigned an IP out of this range.

--- a/multi-node/aws/artifacts/scripts/install-worker.sh
+++ b/multi-node/aws/artifacts/scripts/install-worker.sh
@@ -10,7 +10,7 @@ export ETCD_ENDPOINTS=
 export CONTROLLER_ENDPOINT=
 
 # Specify the version (vX.Y.Z) of Kubernetes assets to deploy
-export K8S_VER=v1.0.7
+export K8S_VER=v1.1.1
 
 # The IP address of the cluster DNS service.
 # This must be the same DNS_SERVICE_IP used when configuring the controller nodes.

--- a/multi-node/aws/build
+++ b/multi-node/aws/build
@@ -17,5 +17,5 @@ fi
 
 
 echo "Building kube-aws ${VERSION}..."
-GOPATH=${GOPATH}:${PWD}/Godeps/_workspace CGO_ENABLED=0 go build -ldflags "-X main.VERSION ${VERSION}" -a -tags netgo -installsuffix netgo -o bin/kube-aws github.com/coreos/coreos-kubernetes/multi-node/aws/cmd/kube-aws
+GOPATH=${PWD}/Godeps/_workspace:${GOPATH} CGO_ENABLED=0 go build -ldflags "-X main.VERSION ${VERSION}" -a -tags netgo -installsuffix netgo -o bin/kube-aws github.com/coreos/coreos-kubernetes/multi-node/aws/cmd/kube-aws
 echo "done"

--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -5,7 +5,7 @@ set -e
 export ETCD_ENDPOINTS=
 
 # Specify the version (vX.Y.Z) of Kubernetes assets to deploy
-export K8S_VER=v1.0.7
+export K8S_VER=v1.1.1
 
 # The CIDR network to use for pod IPs.
 # Each pod launched in the cluster will be assigned an IP out of this range.

--- a/multi-node/generic/worker-install.sh
+++ b/multi-node/generic/worker-install.sh
@@ -10,7 +10,7 @@ export ETCD_ENDPOINTS=
 export CONTROLLER_ENDPOINT=
 
 # Specify the version (vX.Y.Z) of Kubernetes assets to deploy
-export K8S_VER=v1.0.7
+export K8S_VER=v1.1.1
 
 # The IP address of the cluster DNS service.
 # This must be the same DNS_SERVICE_IP used when configuring the controller nodes.
@@ -176,4 +176,3 @@ systemctl stop update-engine; systemctl mask update-engine
 
 systemctl daemon-reload
 systemctl enable kubelet; systemctl start kubelet
-

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -5,7 +5,7 @@ set -e
 export ETCD_ENDPOINTS="http://127.0.0.1:2379"
 
 # Specify the version (vX.Y.Z) of Kubernetes assets to deploy
-export K8S_VER=v1.0.7
+export K8S_VER=v1.1.1
 
 # The CIDR network to use for pod IPs.
 # Each pod launched in the cluster will be assigned an IP out of this range.


### PR DESCRIPTION
This PR bumps Kube AWS to 1.1.1 and in prep for a 0.1.1 or 0.2.0.  Tested and seems to be working end-to-end.