### PR TITLE
multi-node/aws: expose more config options

### DIFF
--- a/multi-node/aws/cluster.yaml.example
+++ b/multi-node/aws/cluster.yaml.example
@@ -18,13 +18,19 @@ region:
 # is responsible for making this name routable
 externalDNSName:
 
-# Disk size (GB) for controller node
+# Instance type for controller node
+#controllerInstanceType: m3.medium
+
+# Disk size (GiB) for controller node
 #controllerRootVolumeSize: 30
 
 # Number of worker nodes to create
 #workerCount: 1
 
-# Disk size (GB) for worker nodes
+# Instance type for worker nodes
+#workerInstanceType: m3.medium
+
+# Disk size (GiB) for worker nodes
 #workerRootVolumeSize: 30
 
 # Location of kube-aws artifacts used to deploy a new

--- a/multi-node/aws/pkg/cluster/cluster.go
+++ b/multi-node/aws/pkg/cluster/cluster.go
@@ -72,11 +72,6 @@ func (c *Cluster) Create(tlsConfig *TLSConfig) error {
 			UsePreviousValue: aws.Bool(true),
 		},
 		{
-			ParameterKey:     aws.String(parNameReleaseChannel),
-			ParameterValue:   aws.String("alpha"),
-			UsePreviousValue: aws.Bool(true),
-		},
-		{
 			ParameterKey:     aws.String(parNameKeyName),
 			ParameterValue:   aws.String(c.cfg.KeyName),
 			UsePreviousValue: aws.Bool(true),
@@ -102,11 +97,6 @@ func (c *Cluster) Create(tlsConfig *TLSConfig) error {
 			UsePreviousValue: aws.Bool(true),
 		},
 		{
-			ParameterKey:     aws.String(parNameControllerRootVolumeSize),
-			ParameterValue:   aws.String(fmt.Sprintf("%d", c.cfg.ControllerRootVolumeSize)),
-			UsePreviousValue: aws.Bool(true),
-		},
-		{
 			ParameterKey:     aws.String(parWorkerCert),
 			ParameterValue:   aws.String(base64.StdEncoding.EncodeToString(tlsConfig.WorkerCert)),
 			UsePreviousValue: aws.Bool(true),
@@ -116,16 +106,54 @@ func (c *Cluster) Create(tlsConfig *TLSConfig) error {
 			ParameterValue:   aws.String(base64.StdEncoding.EncodeToString(tlsConfig.WorkerKey)),
 			UsePreviousValue: aws.Bool(true),
 		},
-		{
+	}
+
+	if c.cfg.ReleaseChannel != "" {
+		parameters = append(parameters, &cloudformation.Parameter{
+			ParameterKey:     aws.String(parNameReleaseChannel),
+			ParameterValue:   aws.String(c.cfg.ReleaseChannel),
+			UsePreviousValue: aws.Bool(true),
+		})
+	}
+
+	if c.cfg.ControllerInstanceType != "" {
+		parameters = append(parameters, &cloudformation.Parameter{
+			ParameterKey:     aws.String(parNameControllerInstanceType),
+			ParameterValue:   aws.String(c.cfg.ControllerInstanceType),
+			UsePreviousValue: aws.Bool(true),
+		})
+	}
+
+	if c.cfg.ControllerRootVolumeSize > 0 {
+		parameters = append(parameters, &cloudformation.Parameter{
+			ParameterKey:     aws.String(parNameControllerRootVolumeSize),
+			ParameterValue:   aws.String(fmt.Sprintf("%d", c.cfg.ControllerRootVolumeSize)),
+			UsePreviousValue: aws.Bool(true),
+		})
+	}
+
+	if c.cfg.WorkerCount > 0 {
+		parameters = append(parameters, &cloudformation.Parameter{
 			ParameterKey:     aws.String(parWorkerCount),
 			ParameterValue:   aws.String(fmt.Sprintf("%d", c.cfg.WorkerCount)),
 			UsePreviousValue: aws.Bool(true),
-		},
-		{
+		})
+	}
+
+	if c.cfg.WorkerInstanceType != "" {
+		parameters = append(parameters, &cloudformation.Parameter{
+			ParameterKey:     aws.String(parNameWorkerInstanceType),
+			ParameterValue:   aws.String(c.cfg.WorkerInstanceType),
+			UsePreviousValue: aws.Bool(true),
+		})
+	}
+
+	if c.cfg.WorkerRootVolumeSize > 0 {
+		parameters = append(parameters, &cloudformation.Parameter{
 			ParameterKey:     aws.String(parNameWorkerRootVolumeSize),
 			ParameterValue:   aws.String(fmt.Sprintf("%d", c.cfg.WorkerRootVolumeSize)),
 			UsePreviousValue: aws.Bool(true),
-		},
+		})
 	}
 
 	if c.cfg.AvailabilityZone != "" {

--- a/multi-node/aws/pkg/cluster/config.go
+++ b/multi-node/aws/pkg/cluster/config.go
@@ -20,8 +20,11 @@ type Config struct {
 	Region                   string `yaml:"region"`
 	AvailabilityZone         string `yaml:"availabilityZone"`
 	ArtifactURL              string `yaml:"artifactURL"`
+	ReleaseChannel           string `yaml:"releaseChannel"`
+	ControllerInstanceType   string `yaml:"controllerInstanceType"`
 	ControllerRootVolumeSize int    `yaml:"controllerRootVolumeSize"`
 	WorkerCount              int    `yaml:"workerCount"`
+	WorkerInstanceType       string `yaml:"workerInstanceType"`
 	WorkerRootVolumeSize     int    `yaml:"workerRootVolumeSize"`
 }
 
@@ -65,7 +68,6 @@ func NewDefaultConfig(ver string) *Config {
 	return &Config{
 		ClusterName: "kubernetes",
 		ArtifactURL: DefaultArtifactURL(ver),
-		WorkerCount: 1,
 	}
 }
 

--- a/multi-node/aws/pkg/cluster/stack_template.go
+++ b/multi-node/aws/pkg/cluster/stack_template.go
@@ -46,7 +46,7 @@ const (
 )
 
 var (
-	supportedChannels    = []string{"alpha"}
+	supportedChannels    = []string{"alpha", "beta"}
 	tagKubernetesCluster = "KubernetesCluster"
 
 	sgProtoTCP = "tcp"


### PR DESCRIPTION
This allows users to configure the controller and worker instance types.

It also changes the config to use the aws defaults unless defined in the config and updates the supported channels to include beta.

Fixes #150 and possibly #154