### PR TITLE
docs: create unique TLS certs per worker

### DIFF
--- a/Documentation/deploy-workers.md
+++ b/Documentation/deploy-workers.md
@@ -1,27 +1,36 @@
-## Deploy Worker Node(s)
+# Deploy Worker Node(s)
 
 Boot one or more CoreOS nodes which will be used as Kubernetes Workers. You must use a CoreOS version 773.1.0+ for the `kubelet` to be present in the image.
 
 See the [CoreOS Documentation](https://coreos.com/os/docs/latest/) for guides on launching nodes on supported platforms.
 
-### Configure Service Components
+## Configure Service Components
 
-#### TLS Assets
+### TLS Assets
 
-Place the TLS keypairs generated previously in the following locations:
+Place the TLS keypairs generated previously in the following locations. Note that each keypair is unique and should be installed on the worker node it was generated for:
 
 * File: `/etc/kubernetes/ssl/ca.pem`
-* File: `/etc/kubernetes/ssl/worker.pem`
-* File: `/etc/kubernetes/ssl/worker-key.pem`
+* File: `/etc/kubernetes/ssl/${WORKER_FQDN}-worker.pem`
+* File: `/etc/kubernetes/ssl/${WORKER_FQDN}-worker-key.pem`
 
 And make sure you've set proper permission for private key:
 
-```
+```sh
 $ sudo chmod 600 /etc/kubernetes/ssl/*-key.pem
 $ sudo chown root:root /etc/kubernetes/ssl/*-key.pem
 ```
 
-#### flannel Configuration
+Create symlinks to the worker-specific certificate and key so that the remaining configurations on the workers do not have to be unique per worker.
+
+```sh
+$ cd /etc/kubernetes/ssl/
+$ sudo ln -s ${WORKER_FQDN}-worker.pem worker.pem
+$ sudo ln -s ${WORKER_FQDN}-worker-key.pem worker-key.pem
+```
+
+
+### flannel Configuration
 
 *Note:* If the pod-network is being managed independently of flannel, this step can be skipped. See [kubernetes networking](kubernetes-networking.md) for more detail.
 
@@ -48,7 +57,7 @@ ExecStartPre=/usr/bin/ln -sf /etc/flannel/options.env /run/flannel/options.env
 
 [dropins]: https://coreos.com/os/docs/latest/using-systemd-drop-in-units.html
 
-#### Docker Configuration
+### Docker Configuration
 
 *Note:* If the pod-network is being managed independently of flannel, this step can be skipped. See [kubernetes networking](kubernetes-networking.md) for more detail.
 
@@ -64,7 +73,7 @@ Requires=flanneld.service
 After=flanneld.service
 ```
 
-#### Create the kubelet Unit
+### Create the kubelet Unit
 
 Create `/etc/systemd/system/kubelet.service` and substitute the following variables:
 
@@ -94,7 +103,7 @@ RestartSec=10
 WantedBy=multi-user.target
 ```
 
-#### Set Up the kube-proxy Pod
+### Set Up the kube-proxy Pod
 
 Create `/etc/kubernetes/manifests/kube-proxy.yaml`:
 
@@ -142,7 +151,7 @@ spec:
         path: "/etc/kubernetes/ssl"
 ```
 
-#### Set Up kubeconfig
+### Set Up kubeconfig
 
 In order to facilitate secure communication between Kubernetes components, kubeconfig can be used to define authentication settings. In this case, the kubelet and proxy are reading this configuration to communicate with the API.
 
@@ -170,11 +179,11 @@ contexts:
 current-context: kubelet-context
 ```
 
-### Start Services
+## Start Services
 
 Now we can start the Worker services.
 
-#### Load Changed Units
+### Load Changed Units
 
 Tell systemd to rescan the units on disk:
 
@@ -182,7 +191,7 @@ Tell systemd to rescan the units on disk:
 $ sudo systemctl daemon-reload
 ```
 
-#### Start kubelet
+### Start kubelet
 
 Start the kubelet, which will start the proxy as well.
 

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -122,9 +122,11 @@ apiserver-key.pem
 
 **Worker Node Public & Private Keys**
 
-worker.pem
+_You should have one certificate/key set for every worker node in the planned cluster._
 
-worker-key.pem
+${WORKER_FQDN}-worker.pem
+
+${WORKER_FQDN}-worker-key.pem
 
 <hr/>
 

--- a/Documentation/openssl.md
+++ b/Documentation/openssl.md
@@ -14,11 +14,19 @@ The address of the master node. In most cases this will be the publicly routable
 
 If you will be running a highly-available control-plane consisting of multiple master nodes, then `MASTER_HOST` will ideally be a network load balancer that sits in front of the master nodes. Alternatively, a DNS name can be configured which will resolve to the master node IPs. In either case, the certificates which are generated below need to have the correct CommonName and/or SubjectAlternateNames.
 
-<hr/>
+---
 
 **K8S_SERVICE_IP**=10.3.0.1
 
 The IP address of the Kubernetes API Service. The `K8S_SERVICE_IP` will be the first IP in the `SERVICE_IP_RANGE` discussed in the [deployment guide][deployment-guide]. The first IP in the default range of 10.3.0.0/24 will be 10.3.0.1. If the SERVICE_IP_RANGE was changed from the default, this value must be updated as well.
+
+---
+
+**WORKER_IP**=_no default_
+
+**WORKER_FQDN**=_no default_
+
+The IP addresses and fully qualifed hostnames of all worker nodes will be needed. The certificates generated for the worker nodes will need to reflect how requests will be routed to those nodes. In most cases this will be a routable IP and/or a routable hostname. These will be unique per worker; when you see them used below, consider it a loop and do that step for _each_ worker.
 
 ## Create a Cluster Root CA
 
@@ -68,7 +76,7 @@ IP.3 = ${MASTER_IP}
 IP.4 = ${MASTER_LOADBALANCER_IP}
 ```
 
-## Generate the API Server Keypair
+### Generate the API Server Keypair
 
 Using the above `openssl.cnf`, create the api-server keypair:
 
@@ -78,12 +86,37 @@ $ openssl req -new -key apiserver-key.pem -out apiserver.csr -subj "/CN=kube-api
 $ openssl x509 -req -in apiserver.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out apiserver.pem -days 365 -extensions v3_req -extfile openssl.cnf
 ```
 
-## Generate the Kubernetes Worker Keypair
+## Kubernetes Worker Keypairs
+
+This procedure generates a unique TLS certificate for every Kubernetes worker node in your cluster. While unique certificates are less convenient to generate and deploy, they do provide stronger security assurances and the most portable installation experience across multiple cloud-based and on-premises Kubernetes deployments.
+
+### OpenSSL Config
+
+We will use a common openssl configuration file for all workers. The certificate output will be customized per worker based on environment variables used in conjunction with the configuration file. Create the file `worker-openssl.cnf` on your local machine with the following contents.
+
+**worker-openssl.cnf**
+
+```
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectAltName = @alt_names
+[alt_names]
+IP.1 = $ENV::WORKER_IP
+```
+
+### Generate the Kubernetes Worker Keypairs
+
+Run the following set of commands once for every worker node in the planned cluster. Replace `WORKER_FQDN` and `WORKER_IP` in the following commands with the correct values for each node. If the node does not have a routeable hostname, set `WORKER_FQDN` to a unique, per-node placeholder name like `kube-worker-1`, `kube-worker-2` and so on.
 
 ```sh
-$ openssl genrsa -out worker-key.pem 2048
-$ openssl req -new -key worker-key.pem -out worker.csr -subj "/CN=kube-worker"
-$ openssl x509 -req -in worker.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out worker.pem -days 365
+$ openssl genrsa -out ${WORKER_FQDN}-worker-key.pem 2048
+$ WORKER_IP=${WORKER_IP} openssl req -new -key ${WORKER_FQDN}-worker-key.pem -out ${WORKER_FQDN}-worker.csr -subj "/CN=${WORKER_FQDN}" -config worker-openssl.cnf
+$ WORKER_IP=${WORKER_IP} openssl x509 -req -in ${WORKER_FQDN}-worker.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out ${WORKER_FQDN}-worker.pem -days 365 -extensions v3_req -extfile worker-openssl.cnf
 ```
 
 ## Generate the Cluster Administrator Keypair


### PR DESCRIPTION
Using per-worker TLS certificates/keys allows the SubjectAltNames to be
accurate for each worker node and increases security over
shared-certificate solutions like setting `\CN=*` and is more portable
to different cloud providers and on-prem installations than solutions
like using `*.ec2.internal` in the SAN. Sadly, doing this also adds
installation complexity. Having correct SAN settings on the workers allows
`kubectl exec` to work instead of giving TLS errors.

Fixes documentation part of
[#73](https://github.com/coreos/coreos-kubernetes/issues/73)