### PR TITLE
multi-node setup example using libvirt

### DIFF
--- a/multi-node/libvirt/README.md
+++ b/multi-node/libvirt/README.md
@@ -1,0 +1,60 @@
+## Download the CoreOS image
+
+In this guide, the example virtual machines we are creating are called
+`kube-master` and `kube-worker`. They will be backed by a CoreOS image and
+stored under `/var/lib/libvirt/images/coreos`. This is not a requirement - feel
+free to substitute that path if you use another one.
+
+```
+mkdir -p /var/lib/libvirt/images/coreos
+cd /var/lib/libvirt/images/coreos
+wget http://alpha.release.core-os.net/amd64-usr/current/coreos_production_qemu_image.img.bz2 -O - | bzcat > coreos_production_qemu_image.img
+```
+
+## Virtual machine configuration
+
+New create a qcow2 image snapshot for both machines using the command below:
+```
+cd /var/lib/libvirt/images/coreos
+qemu-img create -f qcow2 -b coreos_production_qemu_image.img kube-master.qcow2
+qemu-img create -f qcow2 -b coreos_production_qemu_image.img kube-worker.qcow2
+```
+These images will store the differences between the VM and the base image
+separately for each machine.
+
+## Generate ssh keys
+
+It is good practice to use dedicated credentials for accessing guest systems.
+Generate a new SSH keypair like this:
+```
+cd /var/lib/libvirt/images/coreos
+ssh-keygen -t rsa -b 2048 -f vm_key
+```
+
+## Set up config drive
+
+Now create a config drive file system to configure CoreOS itself. We will use
+these to configure the machines and provision TLS artifacts for Kubernetes.
+
+The config drives should contain provisioning scripts and the resources they
+need to operate. Assuming you have cloned `coreos-kubernetes` to $CLONEDIR:
+
+For kube-master:
+```
+cp -R $CLONEDIR/multi-node/libvirt/kube-master /var/lib/libvirt/images/coreos/
+cp vm_key.pub /var/lib/libvirt/images/coreos/kube-master/openstack/latest/
+
+```
+
+For kube-worker:
+```
+cp -R $CLONEDIR/multi-node/libvirt/kube-worker /var/lib/libvirt/images/coreos/
+cp vm_key.pub /var/lib/libvirt/images/coreos/kube-worker/openstack/latest/
+```
+
+The `user_data` scripts will install the necessary Kubernetes manifests and
+assume a certain preconfigured network structure.
+
+## Network configuration
+
+TODO

--- a/multi-node/libvirt/README.md
+++ b/multi-node/libvirt/README.md
@@ -64,6 +64,17 @@ cp vm_key.pub /var/lib/libvirt/images/coreos/kube-worker/openstack/latest/
 The `user_data` scripts will install the necessary Kubernetes manifests and
 assume a certain preconfigured network structure.
 
+## SELinux configuration
+
+If you are using SELinux in enforcing mode, you will need to properly label
+these config drive directories.
+
+```
+cd /var/lib/libvirt/images/coreos
+chcon -R -t svirt_image_t kube-master
+chcon -R -t svirt_image_t kube-worker
+```
+
 ## Network configuration
 
 ```

--- a/multi-node/libvirt/README.md
+++ b/multi-node/libvirt/README.md
@@ -31,6 +31,10 @@ cd /var/lib/libvirt/images/coreos
 ssh-keygen -t rsa -b 2048 -f vm_key
 ```
 
+## Generate TLS keys
+
+TODO
+
 ## Set up config drive
 
 Now create a config drive file system to configure CoreOS itself. We will use
@@ -56,5 +60,25 @@ The `user_data` scripts will install the necessary Kubernetes manifests and
 assume a certain preconfigured network structure.
 
 ## Network configuration
+
+```
+# virsh net-define $CLONEDIR/multi-node/libvirt/network-kubernetes.xml
+# virsh net-autostart kubernetes
+# virsh net-start kubernetes
+```
+
+## Virtual machine startup
+
+kube-master
+```
+virt-install --connect qemu:///system --import --name kube-master --ram 1024 --vcpus 1 --os-type=linux --os-variant=virtio26 --disk path=/var/lib/libvirt/images/coreos/kube-master.qcow2,format=qcow2,bus=virtio --filesystem /var/lib/libvirt/images/coreos/kube-master/,config-2,type=mount,mode=squash --network bridge=virbrk8s,mac=54:52:00:fe:b3:b0 --vnc --noautoconsole
+```
+
+kube-worker
+```
+virt-install --connect qemu:///system --import --name kube-worker --ram 1024 --vcpus 1 --os-type=linux --os-variant=virtio26 --disk path=/var/lib/libvirt/images/coreos/kube-worker.qcow2,format=qcow2,bus=virtio --filesystem /var/lib/libvirt/images/coreos/kube-worker/,config-2,type=mount,mode=squash --network bridge=virbrk8s,mac=54:52:00:fe:b3:b1 --vnc --noautoconsole
+```
+
+## Configure kubectl
 
 TODO

--- a/multi-node/libvirt/gentls.sh
+++ b/multi-node/libvirt/gentls.sh
@@ -8,6 +8,8 @@ fi
 echo "Generating TLS assets..."
 mkdir -p certs
 ../../lib/init-ssl-ca ./certs
-../../lib/init-ssl ./certs apiserver kube-apiserver IP.1=127.0.0.1,IP.2=192.168.120.10
+
+# the apiserver can be addressed locally, over the NAT bridge, or by internal cluster IP
+../../lib/init-ssl ./certs apiserver kube-apiserver IP.1=127.0.0.1,IP.2=192.168.120.10,IP.3=10.3.0.1
 ../../lib/init-ssl ./certs worker kube-worker IP.1=127.0.0.1,IP.2=192.168.120.11
 ../../lib/init-ssl ./certs admin kube-admin

--- a/multi-node/libvirt/gentls.sh
+++ b/multi-node/libvirt/gentls.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [ -d certs ]; then
+  echo "There is already a certs directory."
+  exit 0
+fi
+
+echo "Generating TLS assets..."
+mkdir -p certs
+../../lib/init-ssl-ca ./certs
+../../lib/init-ssl ./certs apiserver kube-apiserver IP.1=127.0.0.1,IP.2=192.168.120.10
+../../lib/init-ssl ./certs worker kube-worker IP.1=127.0.0.1,IP.2=192.168.120.11
+../../lib/init-ssl ./certs admin kube-admin

--- a/multi-node/libvirt/kube-master/openstack/latest/user_data
+++ b/multi-node/libvirt/kube-master/openstack/latest/user_data
@@ -41,7 +41,7 @@ function init_config {
 
     if [ -z $ADVERTISE_IP ]; then
         # There is no metadata service to reference, so rely on the network configuration.
-        export $(ifconfig eth0 | awk '/inet /{print $2}')
+        export ADVERTISE_IP=$(ifconfig eth0 | awk '/inet /{print $2}')
     fi
 
     for REQ in "${REQUIRED[@]}"; do

--- a/multi-node/libvirt/kube-master/openstack/latest/user_data
+++ b/multi-node/libvirt/kube-master/openstack/latest/user_data
@@ -582,7 +582,7 @@ add_authorized_key
 init_config
 init_templates
 
-systemctl set-environment ETCD_LISTEN_CLIENT_URLS="http://${ADVERTISE_IP}:2379"
+systemctl set-environment ETCD_LISTEN_CLIENT_URLS="http://${ADVERTISE_IP}:2379,http://127.0.0.1:2379"
 systemctl set-environment ETCD_ADVERTISE_CLIENT_URLS="http://${ADVERTISE_IP}:2379"
 systemctl enable etcd2; systemctl start etcd2;
 

--- a/multi-node/libvirt/kube-master/openstack/latest/user_data
+++ b/multi-node/libvirt/kube-master/openstack/latest/user_data
@@ -551,6 +551,17 @@ After=flanneld.service
 EOF
     }
 
+    local TEMPLATE=/etc/systemd/system/etcd2.service.d/urls.conf
+     [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+[Service]
+Environment="ETCD_LISTEN_CLIENT_URLS=http://${ADVERTISE_IP}:2379,http://127.0.0.1:2379"
+Environment="ETCD_ADVERTISE_CLIENT_URLS=http://${ADVERTISE_IP}:2379"
+EOF
+    }
+
 }
 
 function start_addons {
@@ -594,16 +605,11 @@ deploy_tls_assets
 
 init_config
 init_templates
-
-systemctl set-environment ETCD_LISTEN_CLIENT_URLS="http://${ADVERTISE_IP}:2379,http://127.0.0.1:2379"
-systemctl set-environment ETCD_ADVERTISE_CLIENT_URLS="http://${ADVERTISE_IP}:2379"
-systemctl enable etcd2; systemctl start etcd2;
-
 init_flannel
 
 systemctl stop update-engine; systemctl mask update-engine
-
 systemctl daemon-reload
+systemctl enable etcd2; systemctl start etcd2;
 systemctl enable kubelet; systemctl start kubelet
 start_addons
 echo "DONE"

--- a/multi-node/libvirt/kube-master/openstack/latest/user_data
+++ b/multi-node/libvirt/kube-master/openstack/latest/user_data
@@ -551,7 +551,7 @@ After=flanneld.service
 EOF
     }
 
-    local TEMPLATE=/etc/systemd/system/etcd2.service.d/urls.conf
+    local TEMPLATE=/etc/systemd/system/etcd2.service.d/50-listen-urls.conf
      [ -f $TEMPLATE ] || {
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
@@ -605,11 +605,12 @@ deploy_tls_assets
 
 init_config
 init_templates
-init_flannel
 
 systemctl stop update-engine; systemctl mask update-engine
 systemctl daemon-reload
-systemctl enable etcd2; systemctl start etcd2;
+systemctl enable etcd2; systemctl start etcd2
 systemctl enable kubelet; systemctl start kubelet
+
+init_flannel
 start_addons
 echo "DONE"

--- a/multi-node/libvirt/kube-master/openstack/latest/user_data
+++ b/multi-node/libvirt/kube-master/openstack/latest/user_data
@@ -1,0 +1,596 @@
+#!/bin/bash
+set -e
+
+# List of etcd servers (http://ip:port), comma separated
+export ETCD_ENDPOINTS="http://127.0.0.1:2379"
+
+# Specify the version (vX.Y.Z) of Kubernetes assets to deploy
+export K8S_VER=v1.0.7
+
+# The CIDR network to use for pod IPs.
+# Each pod launched in the cluster will be assigned an IP out of this range.
+# Each node will be configured such that these IPs will be routable using the flannel overlay network.
+export POD_NETWORK=10.2.0.0/16
+
+# The CIDR network to use for service cluster IPs.
+# Each service will be assigned a cluster IP out of this range.
+# This must not overlap with any IP ranges assigned to the POD_NETWORK, or other existing network infrastructure.
+# Routing to these IPs is handled by a proxy service local to each node, and are not required to be routable between nodes.
+export SERVICE_IP_RANGE=10.3.0.0/24
+
+# The IP address of the Kubernetes API Service
+# If the SERVICE_IP_RANGE is changed above, this must be set to the first IP in that range.
+export K8S_SERVICE_IP=10.3.0.1
+
+# The IP address of the cluster DNS service.
+# This IP must be in the range of the SERVICE_IP_RANGE and cannot be the first IP in the range.
+# This same IP must be configured on all worker nodes to enable DNS service discovery.
+export DNS_SERVICE_IP=10.3.0.10
+
+# The above settings can optionally be overridden using an environment file:
+ENV_FILE=/run/coreos-kubernetes/options.env
+
+# -------------
+
+function init_config {
+    local REQUIRED=('ADVERTISE_IP' 'POD_NETWORK' 'ETCD_ENDPOINTS' 'SERVICE_IP_RANGE' 'K8S_SERVICE_IP' 'DNS_SERVICE_IP' 'K8S_VER' )
+
+    if [ -f $ENV_FILE ]; then
+        export $(cat $ENV_FILE | xargs)
+    fi
+
+    if [ -z $ADVERTISE_IP ]; then
+        # There is no metadata service to reference, so rely on the network configuration.
+        export $(ifconfig eth0 | awk '/inet /{print $2}')
+    fi
+
+    for REQ in "${REQUIRED[@]}"; do
+        if [ -z "$(eval echo \$$REQ)" ]; then
+            echo "Missing required config value: ${REQ}"
+            exit 1
+        fi
+    done
+}
+
+function init_flannel {
+    echo "Waiting for etcd..."
+    while true
+    do
+        IFS=',' read -ra ES <<< "$ETCD_ENDPOINTS"
+        for ETCD in "${ES[@]}"; do
+            echo "Trying: $ETCD"
+            if [ -n "$(curl --silent "$ETCD/v2/machines")" ]; then
+                local ACTIVE_ETCD=$ETCD
+                break
+            fi
+            sleep 1
+        done
+        if [ -n "$ACTIVE_ETCD" ]; then
+            break
+        fi
+    done
+    RES=$(curl --silent -X PUT -d "value={\"Network\":\"$POD_NETWORK\",\"Backend\":{\"Type\":\"vxlan\"}}" "$ACTIVE_ETCD/v2/keys/coreos.com/network/config?prevExist=false")
+    if [ -z "$(echo $RES | grep '"action":"create"')" ] && [ -z "$(echo $RES | grep 'Key already exists')" ]; then
+        echo "Unexpected error configuring flannel pod network: $RES"
+    fi
+}
+
+function init_templates {
+    local TEMPLATE=/etc/systemd/system/kubelet.service
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+[Service]
+ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
+ExecStart=/usr/bin/kubelet \
+  --api_servers=http://127.0.0.1:8080 \
+  --register-node=false \
+  --allow-privileged=true \
+  --config=/etc/kubernetes/manifests \
+  --hostname-override=${ADVERTISE_IP} \
+  --cluster_dns=${DNS_SERVICE_IP} \
+  --cluster_domain=cluster.local \
+  --cadvisor-port=0
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    }
+
+    local TEMPLATE=/etc/kubernetes/manifests/kube-proxy.yaml
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-proxy
+  namespace: kube-system
+spec:
+  hostNetwork: true
+  containers:
+  - name: kube-proxy
+    image: gcr.io/google_containers/hyperkube:$K8S_VER
+    command:
+    - /hyperkube
+    - proxy
+    - --master=http://127.0.0.1:8080
+    securityContext:
+      privileged: true
+    volumeMounts:
+    - mountPath: /etc/ssl/certs
+      name: ssl-certs-host
+      readOnly: true
+  volumes:
+  - hostPath:
+      path: /usr/share/ca-certificates
+    name: ssl-certs-host
+EOF
+    }
+
+    local TEMPLATE=/etc/kubernetes/manifests/kube-apiserver.yaml
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-apiserver
+  namespace: kube-system
+spec:
+  hostNetwork: true
+  containers:
+  - name: kube-apiserver
+    image: gcr.io/google_containers/hyperkube:$K8S_VER
+    command:
+    - /hyperkube
+    - apiserver
+    - --bind-address=0.0.0.0
+    - --etcd_servers=${ETCD_ENDPOINTS}
+    - --allow-privileged=true
+    - --service-cluster-ip-range=${SERVICE_IP_RANGE}
+    - --secure_port=443
+    - --advertise-address=${ADVERTISE_IP}
+    - --admission-control=NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
+    - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
+    - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
+    - --client-ca-file=/etc/kubernetes/ssl/ca.pem
+    - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
+    ports:
+    - containerPort: 443
+      hostPort: 443
+      name: https
+    - containerPort: 8080
+      hostPort: 8080
+      name: local
+    volumeMounts:
+    - mountPath: /etc/kubernetes/ssl
+      name: ssl-certs-kubernetes
+      readOnly: true
+    - mountPath: /etc/ssl/certs
+      name: ssl-certs-host
+      readOnly: true
+  volumes:
+  - hostPath:
+      path: /etc/kubernetes/ssl
+    name: ssl-certs-kubernetes
+  - hostPath:
+      path: /usr/share/ca-certificates
+    name: ssl-certs-host
+EOF
+    }
+
+    local TEMPLATE=/etc/kubernetes/manifests/kube-podmaster.yaml
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-podmaster
+  namespace: kube-system
+spec:
+  hostNetwork: true
+  containers:
+  - name: scheduler-elector
+    image: gcr.io/google_containers/podmaster:1.1
+    command:
+    - /podmaster
+    - --etcd-servers=${ETCD_ENDPOINTS}
+    - --key=scheduler
+    - --whoami=${ADVERTISE_IP}
+    - --source-file=/src/manifests/kube-scheduler.yaml
+    - --dest-file=/dst/manifests/kube-scheduler.yaml
+    volumeMounts:
+    - mountPath: /src/manifests
+      name: manifest-src
+      readOnly: true
+    - mountPath: /dst/manifests
+      name: manifest-dst
+  - name: controller-manager-elector
+    image: gcr.io/google_containers/podmaster:1.1
+    command:
+    - /podmaster
+    - --etcd-servers=${ETCD_ENDPOINTS}
+    - --key=controller
+    - --whoami=${ADVERTISE_IP}
+    - --source-file=/src/manifests/kube-controller-manager.yaml
+    - --dest-file=/dst/manifests/kube-controller-manager.yaml
+    terminationMessagePath: /dev/termination-log
+    volumeMounts:
+    - mountPath: /src/manifests
+      name: manifest-src
+      readOnly: true
+    - mountPath: /dst/manifests
+      name: manifest-dst
+  volumes:
+  - hostPath:
+      path: /srv/kubernetes/manifests
+    name: manifest-src
+  - hostPath:
+      path: /etc/kubernetes/manifests
+    name: manifest-dst
+EOF
+    }
+
+    local TEMPLATE=/srv/kubernetes/manifests/kube-controller-manager.yaml
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-controller-manager
+  namespace: kube-system
+spec:
+  containers:
+  - name: kube-controller-manager
+    image: gcr.io/google_containers/hyperkube:$K8S_VER
+    command:
+    - /hyperkube
+    - controller-manager
+    - --master=http://127.0.0.1:8080
+    - --service-account-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
+    - --root-ca-file=/etc/kubernetes/ssl/ca.pem
+    livenessProbe:
+      httpGet:
+        host: 127.0.0.1
+        path: /healthz
+        port: 10252
+      initialDelaySeconds: 15
+      timeoutSeconds: 1
+    volumeMounts:
+    - mountPath: /etc/kubernetes/ssl
+      name: ssl-certs-kubernetes
+      readOnly: true
+    - mountPath: /etc/ssl/certs
+      name: ssl-certs-host
+      readOnly: true
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /etc/kubernetes/ssl
+    name: ssl-certs-kubernetes
+  - hostPath:
+      path: /usr/share/ca-certificates
+    name: ssl-certs-host
+EOF
+    }
+
+    local TEMPLATE=/srv/kubernetes/manifests/kube-scheduler.yaml
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-scheduler
+  namespace: kube-system
+spec:
+  hostNetwork: true
+  containers:
+  - name: kube-scheduler
+    image: gcr.io/google_containers/hyperkube:$K8S_VER
+    command:
+    - /hyperkube
+    - scheduler
+    - --master=http://127.0.0.1:8080
+    livenessProbe:
+      httpGet:
+        host: 127.0.0.1
+        path: /healthz
+        port: 10251
+      initialDelaySeconds: 15
+      timeoutSeconds: 1
+EOF
+    }
+
+    local TEMPLATE=/srv/kubernetes/manifests/kube-system.json
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+{
+  "apiVersion": "v1",
+  "kind": "Namespace",
+  "metadata": {
+    "name": "kube-system"
+  }
+}
+EOF
+    }
+
+    local TEMPLATE=/srv/kubernetes/manifests/kube-dns-rc.json
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+{
+    "apiVersion": "v1",
+    "kind": "ReplicationController",
+    "metadata": {
+        "labels": {
+            "k8s-app": "kube-dns",
+            "kubernetes.io/cluster-service": "true",
+            "version": "v9"
+        },
+        "name": "kube-dns-v9",
+        "namespace": "kube-system"
+    },
+    "spec": {
+        "replicas": 1,
+        "selector": {
+            "k8s-app": "kube-dns",
+            "version": "v9"
+        },
+        "template": {
+            "metadata": {
+                "labels": {
+                    "k8s-app": "kube-dns",
+                    "kubernetes.io/cluster-service": "true",
+                    "version": "v9"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "command": [
+                            "/usr/local/bin/etcd",
+                            "-data-dir",
+                            "/var/etcd/data",
+                            "-listen-client-urls",
+                            "http://127.0.0.1:2379,http://127.0.0.1:4001",
+                            "-advertise-client-urls",
+                            "http://127.0.0.1:2379,http://127.0.0.1:4001",
+                            "-initial-cluster-token",
+                            "skydns-etcd"
+                        ],
+                        "image": "gcr.io/google_containers/etcd:2.0.9",
+                        "name": "etcd",
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m",
+                                "memory": "50Mi"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/var/etcd/data",
+                                "name": "etcd-storage"
+                            }
+                        ]
+                    },
+                    {
+                        "args": [
+                            "-domain=cluster.local"
+                        ],
+                        "image": "gcr.io/google_containers/kube2sky:1.11",
+                        "name": "kube2sky",
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m",
+                                "memory": "50Mi"
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            "-machines=http://localhost:4001",
+                            "-addr=0.0.0.0:53",
+                            "-domain=cluster.local."
+                        ],
+                        "image": "gcr.io/google_containers/skydns:2015-03-11-001",
+                        "livenessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 8080,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 30,
+                            "timeoutSeconds": 5
+                        },
+                        "name": "skydns",
+                        "ports": [
+                            {
+                                "containerPort": 53,
+                                "name": "dns",
+                                "protocol": "UDP"
+                            },
+                            {
+                                "containerPort": 53,
+                                "name": "dns-tcp",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 8080,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 1,
+                            "timeoutSeconds": 5
+                        },
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m",
+                                "memory": "50Mi"
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            "-cmd=nslookup kubernetes.default.svc.cluster.local localhost >/dev/null",
+                            "-port=8080"
+                        ],
+                        "image": "gcr.io/google_containers/exechealthz:1.0",
+                        "name": "healthz",
+                        "ports": [
+                            {
+                                "containerPort": 8080,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "10m",
+                                "memory": "20Mi"
+                            }
+                        }
+                    }
+                ],
+                "dnsPolicy": "Default",
+                "volumes": [
+                    {
+                        "emptyDir": {},
+                        "name": "etcd-storage"
+                    }
+                ]
+            }
+        }
+    }
+}
+EOF
+    }
+
+    local TEMPLATE=/srv/kubernetes/manifests/kube-dns-svc.json
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "name": "kube-dns",
+    "namespace": "kube-system",
+    "labels": {
+      "k8s-app": "kube-dns",
+      "kubernetes.io/name": "KubeDNS",
+      "kubernetes.io/cluster-service": "true"
+    }
+  },
+  "spec": {
+    "clusterIP": "$DNS_SERVICE_IP",
+    "ports": [
+      {
+        "protocol": "UDP",
+        "name": "dns",
+        "port": 53
+      },
+      {
+        "protocol": "TCP",
+        "name": "dns-tcp",
+        "port": 53
+      }
+    ],
+    "selector": {
+      "k8s-app": "kube-dns"
+    }
+  }
+}
+EOF
+    }
+
+    local TEMPLATE=/etc/flannel/options.env
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+FLANNELD_IFACE=$ADVERTISE_IP
+FLANNELD_ETCD_ENDPOINTS=$ETCD_ENDPOINTS
+EOF
+    }
+
+    local TEMPLATE=/etc/systemd/system/flanneld.service.d/40-ExecStartPre-symlink.conf.conf
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+[Service]
+ExecStartPre=/usr/bin/ln -sf /etc/flannel/options.env /run/flannel/options.env
+EOF
+    }
+
+    local TEMPLATE=/etc/systemd/system/docker.service.d/40-flannel.conf
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+[Unit]
+Requires=flanneld.service
+After=flanneld.service
+EOF
+    }
+
+}
+
+function start_addons {
+    echo "Waiting for Kubernetes API..."
+    until curl --silent "http://127.0.0.1:8080/version"
+    do
+        sleep 5
+    done
+    echo
+    echo "K8S: kube-system namespace"
+    curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/kube-system.json)" "http://127.0.0.1:8080/api/v1/namespaces" > /dev/null
+    echo "K8S: DNS addon"
+    curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
+    curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
+}
+
+function add_authorized_key() {
+    echo "Adding user's authorized key..."
+
+    local PUBKEY="/media/configvirtfs/openstack/latest/vm_key.pub"
+    local AUTHORIZED_KEYS="/home/core/.ssh/authorized_keys"
+
+    if [ -e "${PUBKEY}" ]; then
+        cat "${PUBKEY}" >> "${AUTHORIZED_KEYS}"
+    fi
+}
+
+add_authorized_key
+init_config
+init_templates
+
+systemctl set-environment ETCD_LISTEN_CLIENT_URLS="http://${ADVERTISE_IP}:2379"
+systemctl set-environment ETCD_ADVERTISE_CLIENT_URLS="http://${ADVERTISE_IP}:2379"
+systemctl enable etcd2; systemctl start etcd2;
+
+init_flannel
+
+systemctl stop update-engine; systemctl mask update-engine
+
+systemctl daemon-reload
+systemctl enable kubelet; systemctl start kubelet
+start_addons
+echo "DONE"

--- a/multi-node/libvirt/kube-master/openstack/latest/user_data
+++ b/multi-node/libvirt/kube-master/openstack/latest/user_data
@@ -568,17 +568,30 @@ function start_addons {
 }
 
 function add_authorized_key() {
-    echo "Adding user's authorized key..."
-
     local PUBKEY="/media/configvirtfs/openstack/latest/vm_key.pub"
     local AUTHORIZED_KEYS="/home/core/.ssh/authorized_keys"
 
-    if [ -e "${PUBKEY}" ]; then
+    if [ ! -e "${AUTHORIZED_KEYS}" ] && [ -e "${PUBKEY}" ]; then
+        echo "Adding user's authorized key..."
         cat "${PUBKEY}" >> "${AUTHORIZED_KEYS}"
     fi
 }
 
+function deploy_tls_assets() {
+    local CERTS="/media/configvirtfs/openstack/latest/kube-apiserver.tar"
+    local CERT_DIR="/etc/kubernetes/ssl"
+
+    if [ ! -e "${CERT_DIR}/ca.pem" ] && [ -e "${CERTS}" ]; then
+        mkdir -p "${CERT_DIR}"
+        tar -C "${CERT_DIR}" -xf "${CERTS}"
+        chmod 600 "${CERT_DIR}/apiserver-key.pem"
+        chown root:root "${CERT_DIR}/apiserver-key.pem"
+    fi
+}
+
 add_authorized_key
+deploy_tls_assets
+
 init_config
 init_templates
 

--- a/multi-node/libvirt/kube-worker/openstack/latest/user_data
+++ b/multi-node/libvirt/kube-worker/openstack/latest/user_data
@@ -1,0 +1,192 @@
+#!/bin/bash
+set -e
+
+# List of etcd servers (http://ip:port), comma separated
+export ETCD_ENDPOINTS="http://192.168.122.10:2379"
+
+# The endpoint the worker node should use to contact controller nodes (https://ip:port)
+# In HA configurations this should be an external DNS record or loadbalancer in front of the control nodes.
+# However, it is also possible to point directly to a single control node.
+export CONTROLLER_ENDPOINT="https://192.168.122.10:443"
+
+# Specify the version (vX.Y.Z) of Kubernetes assets to deploy
+export K8S_VER=v1.0.7
+
+# The IP address of the cluster DNS service.
+# This must be the same DNS_SERVICE_IP used when configuring the controller nodes.
+export DNS_SERVICE_IP=10.3.0.10
+
+# The above settings can optionally be overridden using an environment file:
+ENV_FILE=/run/coreos-kubernetes/options.env
+
+# -------------
+
+function init_config {
+    local REQUIRED=( 'ADVERTISE_IP' 'ETCD_ENDPOINTS' 'CONTROLLER_ENDPOINT' 'DNS_SERVICE_IP' 'K8S_VER' )
+
+    if [ -f $ENV_FILE ]; then
+        export $(cat $ENV_FILE | xargs)
+    fi
+
+    if [ -z $ADVERTISE_IP ]; then
+        # There is no metadata service to reference, so rely on the network configuration.
+        export $(ifconfig eth0 | awk '/inet /{print $2}')
+    fi
+
+    for REQ in "${REQUIRED[@]}"; do
+        if [ -z "$(eval echo \$$REQ)" ]; then
+            echo "Missing required config value: ${REQ}"
+            exit 1
+        fi
+    done
+}
+
+function init_templates {
+    local TEMPLATE=/etc/systemd/system/kubelet.service
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+[Service]
+ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
+ExecStart=/usr/bin/kubelet \
+  --api_servers=${CONTROLLER_ENDPOINT} \
+  --register-node=true \
+  --allow-privileged=true \
+  --config=/etc/kubernetes/manifests \
+  --hostname-override=${ADVERTISE_IP} \
+  --cluster_dns=${DNS_SERVICE_IP} \
+  --cluster_domain=cluster.local \
+  --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
+  --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
+  --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
+  --cadvisor-port=0
+Restart=always
+RestartSec=10
+[Install]
+WantedBy=multi-user.target
+EOF
+    }
+
+    local TEMPLATE=/etc/kubernetes/worker-kubeconfig.yaml
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+apiVersion: v1
+kind: Config
+clusters:
+- name: local
+  cluster:
+    certificate-authority: /etc/kubernetes/ssl/ca.pem
+users:
+- name: kubelet
+  user:
+    client-certificate: /etc/kubernetes/ssl/worker.pem
+    client-key: /etc/kubernetes/ssl/worker-key.pem
+contexts:
+- context:
+    cluster: local
+    user: kubelet
+  name: kubelet-context
+current-context: kubelet-context
+EOF
+    }
+
+    local TEMPLATE=/etc/kubernetes/manifests/kube-proxy.yaml
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-proxy
+  namespace: kube-system
+spec:
+  hostNetwork: true
+  containers:
+  - name: kube-proxy
+    image: gcr.io/google_containers/hyperkube:$K8S_VER
+    command:
+    - /hyperkube
+    - proxy
+    - --master=${CONTROLLER_ENDPOINT}
+    - --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml
+    securityContext:
+      privileged: true
+    volumeMounts:
+      - mountPath: /etc/ssl/certs
+        name: "ssl-certs"
+      - mountPath: /etc/kubernetes/worker-kubeconfig.yaml
+        name: "kubeconfig"
+        readOnly: true
+      - mountPath: /etc/kubernetes/ssl
+        name: "etc-kube-ssl"
+        readOnly: true
+  volumes:
+    - name: "ssl-certs"
+      hostPath:
+        path: "/usr/share/ca-certificates"
+    - name: "kubeconfig"
+      hostPath:
+        path: "/etc/kubernetes/worker-kubeconfig.yaml"
+    - name: "etc-kube-ssl"
+      hostPath:
+        path: "/etc/kubernetes/ssl"
+EOF
+    }
+
+    local TEMPLATE=/etc/flannel/options.env
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+FLANNELD_IFACE=$ADVERTISE_IP
+FLANNELD_ETCD_ENDPOINTS=$ETCD_ENDPOINTS
+EOF
+    }
+
+    local TEMPLATE=/etc/systemd/system/flanneld.service.d/40-ExecStartPre-symlink.conf.conf
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+[Service]
+ExecStartPre=/usr/bin/ln -sf /etc/flannel/options.env /run/flannel/options.env
+EOF
+    }
+
+    local TEMPLATE=/etc/systemd/system/docker.service.d/40-flannel.conf
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+[Unit]
+Requires=flanneld.service
+After=flanneld.service
+EOF
+    }
+
+}
+
+function add_authorized_key() {
+    echo "Adding user's authorized key..."
+
+    local PUBKEY="/media/configvirtfs/openstack/latest/vm_key.pub"
+    local AUTHORIZED_KEYS="/home/core/.ssh/authorized_keys"
+
+    if [ -e "${PUBKEY}" ]; then
+        cat "${PUBKEY}" >> "${AUTHORIZED_KEYS}"
+    fi
+}
+
+add_authorized_key
+init_config
+init_templates
+
+systemctl stop update-engine; systemctl mask update-engine
+
+systemctl daemon-reload
+systemctl enable kubelet; systemctl start kubelet
+echo "DONE"

--- a/multi-node/libvirt/kube-worker/openstack/latest/user_data
+++ b/multi-node/libvirt/kube-worker/openstack/latest/user_data
@@ -2,12 +2,12 @@
 set -e
 
 # List of etcd servers (http://ip:port), comma separated
-export ETCD_ENDPOINTS="http://192.168.122.10:2379"
+export ETCD_ENDPOINTS="http://192.168.120.10:2379"
 
 # The endpoint the worker node should use to contact controller nodes (https://ip:port)
 # In HA configurations this should be an external DNS record or loadbalancer in front of the control nodes.
 # However, it is also possible to point directly to a single control node.
-export CONTROLLER_ENDPOINT="https://192.168.122.10:443"
+export CONTROLLER_ENDPOINT="https://192.168.120.10:443"
 
 # Specify the version (vX.Y.Z) of Kubernetes assets to deploy
 export K8S_VER=v1.0.7
@@ -171,17 +171,30 @@ EOF
 }
 
 function add_authorized_key() {
-    echo "Adding user's authorized key..."
-
     local PUBKEY="/media/configvirtfs/openstack/latest/vm_key.pub"
     local AUTHORIZED_KEYS="/home/core/.ssh/authorized_keys"
 
-    if [ -e "${PUBKEY}" ]; then
+    if [ ! -e "${AUTHORIZED_KEYS}" ] && [ -e "${PUBKEY}" ]; then
+        echo "Adding user's authorized key..."
         cat "${PUBKEY}" >> "${AUTHORIZED_KEYS}"
     fi
 }
 
+function deploy_tls_assets() {
+    local CERTS="/media/configvirtfs/openstack/latest/kube-worker.tar"
+    local CERT_DIR="/etc/kubernetes/ssl"
+
+    if [ ! -e "${CERT_DIR}/ca.pem" ] && [ -e "${CERTS}" ]; then
+        mkdir -p "${CERT_DIR}"
+        tar -C "${CERT_DIR}" -xf "${CERTS}"
+        chmod 600 "${CERT_DIR}/worker-key.pem"
+        chown root:root "${CERT_DIR}/worker-key.pem"
+    fi
+}
+
 add_authorized_key
+deploy_tls_assets
+
 init_config
 init_templates
 

--- a/multi-node/libvirt/kube-worker/openstack/latest/user_data
+++ b/multi-node/libvirt/kube-worker/openstack/latest/user_data
@@ -30,7 +30,7 @@ function init_config {
 
     if [ -z $ADVERTISE_IP ]; then
         # There is no metadata service to reference, so rely on the network configuration.
-        export $(ifconfig eth0 | awk '/inet /{print $2}')
+        export ADVERTISE_IP=$(ifconfig eth0 | awk '/inet /{print $2}')
     fi
 
     for REQ in "${REQUIRED[@]}"; do

--- a/multi-node/libvirt/network-kubernetes.xml
+++ b/multi-node/libvirt/network-kubernetes.xml
@@ -1,0 +1,14 @@
+<network>
+  <name>kubernetes</name>
+  <uuid>dcbef342-16a3-4f3e-8307-84bff91076e1</uuid>
+  <forward mode='nat'/>
+  <bridge name='virbr0' stp='on' delay='0'/>
+  <mac address='52:54:00:ba:7a:cb'/>
+  <ip address='192.168.122.1' netmask='255.255.255.0'>
+    <dhcp>
+      <range start='192.168.122.2' end='192.168.122.254'/>
+      <host mac='fe:54:00:fe:b3:c0' name='kube-master' ip='192.168.122.10'/>
+      <host mac='fe:54:00:fe:b3:c1' name='kube-worker' ip='192.168.122.11'/>
+    </dhcp>
+  </ip>
+</network>

--- a/multi-node/libvirt/network-kubernetes.xml
+++ b/multi-node/libvirt/network-kubernetes.xml
@@ -2,13 +2,13 @@
   <name>kubernetes</name>
   <uuid>dcbef342-16a3-4f3e-8307-84bff91076e1</uuid>
   <forward mode='nat'/>
-  <bridge name='virbr0' stp='on' delay='0'/>
-  <mac address='52:54:00:ba:7a:cb'/>
-  <ip address='192.168.122.1' netmask='255.255.255.0'>
+  <bridge name='virbrk8s' stp='on' delay='0'/>
+  <mac address='82:84:01:56:df:f3'/>
+  <ip address='192.168.120.1' netmask='255.255.255.0'>
     <dhcp>
-      <range start='192.168.122.2' end='192.168.122.254'/>
-      <host mac='fe:54:00:fe:b3:c0' name='kube-master' ip='192.168.122.10'/>
-      <host mac='fe:54:00:fe:b3:c1' name='kube-worker' ip='192.168.122.11'/>
+      <range start='192.168.120.2' end='192.168.120.254'/>
+      <host mac='54:52:00:fe:b3:b0' name='kube-master' ip='192.168.120.10'/>
+      <host mac='54:52:00:fe:b3:b1' name='kube-worker' ip='192.168.120.11'/>
     </dhcp>
   </ip>
 </network>


### PR DESCRIPTION
Demonstrates a basic multi-node Kubernetes setup on CoreOS using libvirt. Cluster consists of a master and a single worker node.