### PR TITLE
Add heads-up in replacement of variable when using curl

### DIFF
--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -366,7 +366,7 @@ $ sudo systemctl daemon-reload
 Earlier it was mentioned that flannel stores cluster-level configuration in etcd. We need to configure our Pod network IP range now. Since etcd was started earlier, we can set this now. If you don't have etcd running, start it now.
 
 * Replace `$POD_NETWORK`
-* Replace `$ETCD_SERVER` with one host from `$ETCD_ENDPOINTS`
+* Replace `$ETCD_SERVER` with one url (`http://ip:port`) from `$ETCD_ENDPOINTS`
 
 ```sh
 $ curl -X PUT -d "value={\"Network\":\"$POD_NETWORK\",\"Backend\":{\"Type\":\"vxlan\"}}" "$ETCD_SERVER/v2/keys/coreos.com/network/config"


### PR DESCRIPTION
Assuming there will be another poor soul that will be confused... In retrospective, this seems obvious. But you never know.

*EDIT*: Oops! :droplet: In `getting-started` is stated _clearly_ that the syntaxis for `ETCD_ENDPOINTS` is `http://ip:port`. So, I'm not sure. Do we cancel the PR. or add this redundant note anyways?

*EDIT 2*: Modified on observation by @phemmer.