### PR TITLE
kube-aws: expose network configuration

### DIFF
--- a/multi-node/aws/artifacts/scripts/install-controller.sh
+++ b/multi-node/aws/artifacts/scripts/install-controller.sh
@@ -10,22 +10,22 @@ export K8S_VER=v1.1.2
 # The CIDR network to use for pod IPs.
 # Each pod launched in the cluster will be assigned an IP out of this range.
 # Each node will be configured such that these IPs will be routable using the flannel overlay network.
-export POD_NETWORK=10.2.0.0/16
+export POD_NETWORK=
 
 # The CIDR network to use for service cluster IPs.
 # Each service will be assigned a cluster IP out of this range.
 # This must not overlap with any IP ranges assigned to the POD_NETWORK, or other existing network infrastructure.
 # Routing to these IPs is handled by a proxy service local to each node, and are not required to be routable between nodes.
-export SERVICE_IP_RANGE=10.3.0.0/24
+export SERVICE_IP_RANGE=
 
 # The IP address of the Kubernetes API Service
 # If the SERVICE_IP_RANGE is changed above, this must be set to the first IP in that range.
-export K8S_SERVICE_IP=10.3.0.1
+export K8S_SERVICE_IP=
 
 # The IP address of the cluster DNS service.
 # This IP must be in the range of the SERVICE_IP_RANGE and cannot be the first IP in the range.
 # This same IP must be configured on all worker nodes to enable DNS service discovery.
-export DNS_SERVICE_IP=10.3.0.10
+export DNS_SERVICE_IP=
 
 # The HTTP(S) host serving the necessary Kubernetes artifacts
 export ARTIFACT_URL=

--- a/multi-node/aws/artifacts/scripts/install-worker.sh
+++ b/multi-node/aws/artifacts/scripts/install-worker.sh
@@ -14,7 +14,7 @@ export K8S_VER=v1.1.2
 
 # The IP address of the cluster DNS service.
 # This must be the same DNS_SERVICE_IP used when configuring the controller nodes.
-export DNS_SERVICE_IP=10.3.0.10
+export DNS_SERVICE_IP=
 
 # The HTTP(S) host serving the necessary Kubernetes artifacts
 export ARTIFACT_URL=

--- a/multi-node/aws/cluster.yaml.example
+++ b/multi-node/aws/cluster.yaml.example
@@ -39,3 +39,24 @@ externalDNSName:
 # of the kube-aws tool. This parameter is typically
 # overwritten only for development purposes.
 #artifactURL: https://coreos-kubernetes.s3.amazonaws.com/<VERSION>
+
+# CIDR for Kubernetes VPC
+# vpcCIDR: "10.0.0.0/16"
+
+# CIDR for Kubernetes subnet
+# instanceCIDR: "10.0.0.0/24"
+
+# IP Address for controller in Kubernetes subnet
+# controllerIP: 10.0.0.50
+
+# CIDR for all service IP addresses
+# serviceCIDR: "10.3.0.0/24"
+
+# CIDR for all pod IP addresses
+# podCIDR: "10.2.0.0/16"
+
+# IP address of Kubernetes controller service (must be contained by serviceCIDR)
+# kubernetesServiceIP: 10.3.0.1
+
+# IP address of Kubernetes dns service (must be contained by serviceCIDR)
+# dnsServiceIP: 10.3.0.10

--- a/multi-node/aws/cmd/kube-aws/command_up.go
+++ b/multi-node/aws/cmd/kube-aws/command_up.go
@@ -194,8 +194,8 @@ func initTLS(cfg *cluster.Config, dir string) (*cluster.TLSConfig, error) {
 			cfg.ExternalDNSName,
 		},
 		IPAddresses: []string{
-			"10.0.0.50",
-			"10.3.0.1",
+			cfg.ControllerIP,
+			cfg.KubernetesServiceIP,
 		},
 	}
 	if err := initTLSServer(apiserverConfig, caCert, caKey, apiserverKeyPath, apiserverCertPath); err != nil {

--- a/multi-node/aws/pkg/cluster/cloud_config_controller.go
+++ b/multi-node/aws/pkg/cluster/cloud_config_controller.go
@@ -32,6 +32,10 @@ write_files:
   content: |
     ETCD_ENDPOINTS=http://127.0.0.1:2379
     ARTIFACT_URL={{ ArtifactURL }}
+    SERVICE_IP_RANGE={{ ServiceCIDR }}
+    POD_NETWORK={{ PodCIDR }}
+    K8S_SERVICE_IP={{ KubernetesServiceIP }}
+    DNS_SERVICE_IP={{ DNSServiceIP }}
 
 - path: /tmp/install-controller.sh
   content: |

--- a/multi-node/aws/pkg/cluster/cloud_config_worker.go
+++ b/multi-node/aws/pkg/cluster/cloud_config_worker.go
@@ -7,7 +7,7 @@ coreos:
 
   flannel:
     interface: $private_ipv4
-    etcd_endpoints: http://10.0.0.50:2379
+    etcd_endpoints: http://{{ ControllerIP }}:2379
 
   units:
   - name: install-worker.service
@@ -20,10 +20,10 @@ coreos:
 write_files:
 - path: /run/coreos-kubernetes/options.env
   content: |
-    ETCD_ENDPOINTS=http://10.0.0.50:2379
-    CONTROLLER_ENDPOINT=https://10.0.0.50
+    ETCD_ENDPOINTS=http://{{ ControllerIP }}:2379
+    CONTROLLER_ENDPOINT=https://{{ ControllerIP }}
     ARTIFACT_URL={{ ArtifactURL }}
-
+    DNS_SERVICE_IP={{ DNSServiceIP }}
 - path: /tmp/install-worker.sh
   content: |
     #!/bin/bash

--- a/multi-node/aws/pkg/cluster/cluster.go
+++ b/multi-node/aws/pkg/cluster/cluster.go
@@ -164,6 +164,62 @@ func (c *Cluster) Create(tlsConfig *TLSConfig) error {
 		})
 	}
 
+	if c.cfg.VPCCIDR != "" {
+		parameters = append(parameters, &cloudformation.Parameter{
+			ParameterKey:     aws.String(parVPCCIDR),
+			ParameterValue:   aws.String(c.cfg.VPCCIDR),
+			UsePreviousValue: aws.Bool(true),
+		})
+	}
+
+	if c.cfg.InstanceCIDR != "" {
+		parameters = append(parameters, &cloudformation.Parameter{
+			ParameterKey:     aws.String(parInstanceCIDR),
+			ParameterValue:   aws.String(c.cfg.InstanceCIDR),
+			UsePreviousValue: aws.Bool(true),
+		})
+	}
+
+	if c.cfg.ControllerIP != "" {
+		parameters = append(parameters, &cloudformation.Parameter{
+			ParameterKey:     aws.String(parControllerIP),
+			ParameterValue:   aws.String(c.cfg.ControllerIP),
+			UsePreviousValue: aws.Bool(true),
+		})
+	}
+
+	if c.cfg.PodCIDR != "" {
+		parameters = append(parameters, &cloudformation.Parameter{
+			ParameterKey:     aws.String(parPodCIDR),
+			ParameterValue:   aws.String(c.cfg.PodCIDR),
+			UsePreviousValue: aws.Bool(true),
+		})
+	}
+
+	if c.cfg.ServiceCIDR != "" {
+		parameters = append(parameters, &cloudformation.Parameter{
+			ParameterKey:     aws.String(parServiceCIDR),
+			ParameterValue:   aws.String(c.cfg.ServiceCIDR),
+			UsePreviousValue: aws.Bool(true),
+		})
+	}
+
+	if c.cfg.KubernetesServiceIP != "" {
+		parameters = append(parameters, &cloudformation.Parameter{
+			ParameterKey:     aws.String(parKubernetesServiceIP),
+			ParameterValue:   aws.String(c.cfg.KubernetesServiceIP),
+			UsePreviousValue: aws.Bool(true),
+		})
+	}
+
+	if c.cfg.DNSServiceIP != "" {
+		parameters = append(parameters, &cloudformation.Parameter{
+			ParameterKey:     aws.String(parDNSServiceIP),
+			ParameterValue:   aws.String(c.cfg.DNSServiceIP),
+			UsePreviousValue: aws.Bool(true),
+		})
+	}
+
 	tmplURL := fmt.Sprintf("%s/template.json", c.cfg.ArtifactURL)
 	return createStackAndWait(cloudformation.New(c.aws), c.stackName(), tmplURL, parameters)
 }

--- a/multi-node/aws/pkg/cluster/config.go
+++ b/multi-node/aws/pkg/cluster/config.go
@@ -4,9 +4,20 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/url"
 
 	"gopkg.in/yaml.v2"
+)
+
+const (
+	DefaultVPCCIDR             = "10.0.0.0/16"
+	DefaultInstanceCIDR        = "10.0.0.0/24"
+	DefaultControllerIP        = "10.0.0.50"
+	DefaultPodCIDR             = "10.2.0.0/16"
+	DefaultServiceCIDR         = "10.3.0.0/24"
+	DefaultKubernetesServiceIP = "10.3.0.1"
+	DefaultDNSServiceIP        = "10.3.0.10"
 )
 
 var (
@@ -26,6 +37,13 @@ type Config struct {
 	WorkerCount              int    `yaml:"workerCount"`
 	WorkerInstanceType       string `yaml:"workerInstanceType"`
 	WorkerRootVolumeSize     int    `yaml:"workerRootVolumeSize"`
+	VPCCIDR                  string `yaml:"vpcCIDR"`
+	InstanceCIDR             string `yaml:"instanceCIDR"`
+	ControllerIP             string `yaml:"controllerIP"`
+	PodCIDR                  string `yaml:"podCIDR"`
+	ServiceCIDR              string `yaml:"serviceCIDR"`
+	KubernetesServiceIP      string `yaml:"kubernetesServiceIP"`
+	DNSServiceIP             string `yaml:"dnsServiceIP"`
 }
 
 func (cfg *Config) Valid() error {
@@ -44,6 +62,97 @@ func (cfg *Config) Valid() error {
 	if _, err := url.Parse(cfg.ArtifactURL); err != nil {
 		return fmt.Errorf("invalid artifactURL: %v", err)
 	}
+
+	vpcCIDR := cfg.VPCCIDR
+	if vpcCIDR == "" {
+		vpcCIDR = DefaultVPCCIDR
+	}
+	_, vpcNet, err := net.ParseCIDR(vpcCIDR)
+	if err != nil {
+		return fmt.Errorf("invalid vpcCIDR: %v", err)
+	}
+
+	instanceCIDR := cfg.InstanceCIDR
+	if instanceCIDR == "" {
+		instanceCIDR = DefaultInstanceCIDR
+	}
+	instancesNetIP, instancesNet, err := net.ParseCIDR(instanceCIDR)
+	if err != nil {
+		return fmt.Errorf("invalid instanceCIDR: %v", err)
+	}
+	if !vpcNet.Contains(instancesNetIP) {
+		return fmt.Errorf("vpcCIDR (%s) does not contain instanceCIDR (%s)",
+			vpcCIDR,
+			instanceCIDR,
+		)
+	}
+
+	controllerIP := cfg.ControllerIP
+	if controllerIP == "" {
+		controllerIP = DefaultControllerIP
+	}
+	controllerIPAddr := net.ParseIP(controllerIP)
+	if controllerIPAddr == nil {
+		return fmt.Errorf("invalid controllerIP: %s", controllerIP)
+	}
+	if !instancesNet.Contains(controllerIPAddr) {
+		return fmt.Errorf("instanceCIDR (%s) does not contain controllerIP (%s)",
+			instanceCIDR,
+			controllerIP,
+		)
+	}
+
+	podCIDR := cfg.PodCIDR
+	if podCIDR == "" {
+		podCIDR = DefaultPodCIDR
+	}
+	podNetIP, podNet, err := net.ParseCIDR(podCIDR)
+	if err != nil {
+		return fmt.Errorf("invalid podCIDR: %v", err)
+	}
+	if vpcNet.Contains(podNetIP) {
+		return fmt.Errorf("vpcCIDR (%s) overlaps with podCIDR (%s)", vpcCIDR, podCIDR)
+	}
+
+	serviceCIDR := cfg.ServiceCIDR
+	if serviceCIDR == "" {
+		serviceCIDR = DefaultServiceCIDR
+	}
+	serviceNetIP, serviceNet, err := net.ParseCIDR(serviceCIDR)
+	if err != nil {
+		return fmt.Errorf("invalid serviceCIDR: %v", err)
+	}
+	if vpcNet.Contains(serviceNetIP) {
+		return fmt.Errorf("vpcCIDR (%s) overlaps with serviceCIDR (%s)", vpcCIDR, serviceCIDR)
+	}
+	if podNet.Contains(serviceNetIP) || serviceNet.Contains(podNetIP) {
+		return fmt.Errorf("serviceCIDR (%s) overlaps with podCIDR (%s)", serviceCIDR, podCIDR)
+	}
+
+	kubernetesServiceIP := cfg.KubernetesServiceIP
+	if kubernetesServiceIP == "" {
+		kubernetesServiceIP = DefaultKubernetesServiceIP
+	}
+	kubernetesServiceIPAddr := net.ParseIP(kubernetesServiceIP)
+	if kubernetesServiceIPAddr == nil {
+		return fmt.Errorf("Invalid kubernetesServiceIP: %s", kubernetesServiceIP)
+	}
+	if !serviceNet.Contains(kubernetesServiceIPAddr) {
+		return fmt.Errorf("serviceCIDR (%s) does not contain kubernetesServiceIP (%s)", serviceCIDR, kubernetesServiceIP)
+	}
+
+	dnsServiceIP := cfg.DNSServiceIP
+	if dnsServiceIP == "" {
+		dnsServiceIP = DefaultDNSServiceIP
+	}
+	dnsServiceIPAddr := net.ParseIP(dnsServiceIP)
+	if dnsServiceIPAddr == nil {
+		return fmt.Errorf("Invalid dnsServiceIP: %s", dnsServiceIP)
+	}
+	if !serviceNet.Contains(dnsServiceIPAddr) {
+		return fmt.Errorf("serviceCIDR (%s) does not contain dnsServiceIP (%s)", serviceCIDR, dnsServiceIP)
+	}
+
 	return nil
 }
 

--- a/multi-node/aws/pkg/cluster/stack_template.go
+++ b/multi-node/aws/pkg/cluster/stack_template.go
@@ -43,6 +43,13 @@ const (
 	parWorkerCount                  = "WorkerCount"
 	parNameWorkerRootVolumeSize     = "WorkerRootVolumeSize"
 	parAvailabilityZone             = "AvailabilityZone"
+	parVPCCIDR                      = "VPCCIDR"
+	parInstanceCIDR                 = "InstanceCIDR"
+	parControllerIP                 = "ControllerIP"
+	parServiceCIDR                  = "ServiceCIDR"
+	parPodCIDR                      = "PodCIDR"
+	parKubernetesServiceIP          = "KubernetesServiceIP"
+	parDNSServiceIP                 = "DNSServiceIP"
 )
 
 var (
@@ -143,7 +150,7 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 	res[resNameVPC] = map[string]interface{}{
 		"Type": "AWS::EC2::VPC",
 		"Properties": map[string]interface{}{
-			"CidrBlock":          "10.0.0.0/16",
+			"CidrBlock":          newRef(parVPCCIDR),
 			"EnableDnsSupport":   true,
 			"EnableDnsHostnames": true,
 			"InstanceTenancy":    "default",
@@ -197,7 +204,7 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 		"Type": "AWS::EC2::Subnet",
 		"Properties": map[string]interface{}{
 			"AvailabilityZone":    availabilityZone,
-			"CidrBlock":           "10.0.0.0/24",
+			"CidrBlock":           newRef(parInstanceCIDR),
 			"MapPublicIpOnLaunch": true,
 			"VpcId":               newRef(resNameVPC),
 			"Tags": []map[string]interface{}{
@@ -416,7 +423,7 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 			"IamInstanceProfile": newRef(resNameIAMInstanceProfileController),
 			"NetworkInterfaces": []map[string]interface{}{
 				map[string]interface{}{
-					"PrivateIpAddress":         "10.0.0.50",
+					"PrivateIpAddress":         newRef(parControllerIP),
 					"AssociatePublicIpAddress": false,
 					"DeleteOnTermination":      true,
 					"DeviceIndex":              "0",
@@ -600,6 +607,48 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 		"Type":        "String",
 		"Default":     "",
 		"Description": "Specific availability zone (optional)",
+	}
+
+	par[parVPCCIDR] = map[string]interface{}{
+		"Type":        "String",
+		"Default":     DefaultVPCCIDR,
+		"Description": "CIDR for Kubernetes vpc",
+	}
+
+	par[parInstanceCIDR] = map[string]interface{}{
+		"Type":        "String",
+		"Default":     DefaultInstanceCIDR,
+		"Description": "CIDR for Kubernetes subnet",
+	}
+
+	par[parControllerIP] = map[string]interface{}{
+		"Type":        "String",
+		"Default":     DefaultControllerIP,
+		"Description": "IP address for controller in Kubernetes subnet",
+	}
+
+	par[parServiceCIDR] = map[string]interface{}{
+		"Type":        "String",
+		"Default":     DefaultServiceCIDR,
+		"Description": "CIDR for all service IP addresses",
+	}
+
+	par[parPodCIDR] = map[string]interface{}{
+		"Type":        "String",
+		"Default":     DefaultPodCIDR,
+		"Description": "CIDR for all pod IP addresses",
+	}
+
+	par[parKubernetesServiceIP] = map[string]interface{}{
+		"Type":        "String",
+		"Default":     DefaultKubernetesServiceIP,
+		"Description": "IP address for Kubernetes controller service (must be contained by serviceCIDR)",
+	}
+
+	par[parDNSServiceIP] = map[string]interface{}{
+		"Type":        "String",
+		"Default":     DefaultDNSServiceIP,
+		"Description": "IP address of the Kubernetes DNS service (must be contained by serviceCIDR)",
 	}
 
 	regionMap, err := getRegionMap()


### PR DESCRIPTION
hardcodes kubernetes cidr as 10.0.0.0/8
exposes in cluster.yaml and validates on `up`:
	- vpcCidr
	- subnetCidr
	- controllerIp