### PR TITLE
kube-aws: add parameter for spot price

### DIFF
--- a/multi-node/aws/cluster.yaml.example
+++ b/multi-node/aws/cluster.yaml.example
@@ -33,6 +33,9 @@ externalDNSName:
 # Disk size (GiB) for worker nodes
 #workerRootVolumeSize: 30
 
+# Price (Dollars) to bid for spot instances. Omit for on-demand instances.
+# workerSpotPrice: "0.05"
+
 # Location of kube-aws artifacts used to deploy a new
 # Kubernetes cluster. The necessary artifacts are already
 # available in a public S3 bucket matching the version

--- a/multi-node/aws/pkg/cluster/cluster.go
+++ b/multi-node/aws/pkg/cluster/cluster.go
@@ -156,6 +156,14 @@ func (c *Cluster) Create(tlsConfig *TLSConfig) error {
 		})
 	}
 
+	if c.cfg.WorkerSpotPrice != "" {
+		parameters = append(parameters, &cloudformation.Parameter{
+			ParameterKey:     aws.String(parWorkerSpotPrice),
+			ParameterValue:   aws.String(c.cfg.WorkerSpotPrice),
+			UsePreviousValue: aws.Bool(true),
+		})
+	}
+
 	if c.cfg.AvailabilityZone != "" {
 		parameters = append(parameters, &cloudformation.Parameter{
 			ParameterKey:     aws.String(parAvailabilityZone),

--- a/multi-node/aws/pkg/cluster/config.go
+++ b/multi-node/aws/pkg/cluster/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	WorkerCount              int    `yaml:"workerCount"`
 	WorkerInstanceType       string `yaml:"workerInstanceType"`
 	WorkerRootVolumeSize     int    `yaml:"workerRootVolumeSize"`
+	WorkerSpotPrice          string `yaml:"workerSpotPrice"`
 	VPCCIDR                  string `yaml:"vpcCIDR"`
 	InstanceCIDR             string `yaml:"instanceCIDR"`
 	ControllerIP             string `yaml:"controllerIP"`

--- a/multi-node/aws/pkg/cluster/stack_template.go
+++ b/multi-node/aws/pkg/cluster/stack_template.go
@@ -42,6 +42,7 @@ const (
 	parWorkerKey                    = "WorkerKey"
 	parWorkerCount                  = "WorkerCount"
 	parNameWorkerRootVolumeSize     = "WorkerRootVolumeSize"
+	parWorkerSpotPrice              = "WorkerSpotPrice"
 	parAvailabilityZone             = "AvailabilityZone"
 	parVPCCIDR                      = "VPCCIDR"
 	parInstanceCIDR                 = "InstanceCIDR"
@@ -500,6 +501,13 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 					},
 				},
 			},
+			"SpotPrice": map[string]interface{}{
+				"Fn::If": []interface{}{
+					"UseWorkerSpotInstances",
+					newRef(parWorkerSpotPrice),
+					newRef("AWS::NoValue"),
+				},
+			},
 		},
 	}
 
@@ -603,6 +611,12 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 		"Description": "Worker root volume size (GiB)",
 	}
 
+	par[parWorkerSpotPrice] = map[string]interface{}{
+		"Type":        "String",
+		"Default":     "",
+		"Description": "Spot instance price for workers (optional, omit for on-demand instances)",
+	}
+
 	par[parAvailabilityZone] = map[string]interface{}{
 		"Type":        "String",
 		"Default":     "",
@@ -666,6 +680,16 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 			"Fn::Equals": []interface{}{
 				newRef(parAvailabilityZone),
 				"",
+			},
+		},
+		"UseWorkerSpotInstances": map[string]interface{}{
+			"Fn::Not": []interface{}{
+				map[string]interface{}{
+					"Fn::Equals": []interface{}{
+						newRef(parWorkerSpotPrice),
+						"",
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
I made the parameter a string, 'cause I'm scared about the floating-point math from YAML through Go to AWS. It appears to be a string in the AWS API, in any event.