### PR TITLE
docs: add details on /srv vs. /etc; s/master/controller/ throughout

### DIFF
--- a/Documentation/configure-kubectl.md
+++ b/Documentation/configure-kubectl.md
@@ -29,7 +29,7 @@ $ mv kubectl /usr/local/bin/kubectl
 
 Configure `kubectl` to connect to the target cluster using the following commands, replacing several values as indicated:
 
-* Replace `${MASTER_HOST}` with the address or name of the controller address or name used in previous steps
+* Replace `${MASTER_HOST}` with the master node address or name used in previous steps
 * Replace `${CA_CERT}` with the absolute path to the `ca.pem` created in previous steps
 * Replace `${ADMIN_KEY}` with the absolute path to the `admin-key.pem` created in previous steps
 * Replace `${ADMIN_CERT}` with the absolute path to the `admin.pem` created in previous steps

--- a/Documentation/deploy-workers.md
+++ b/Documentation/deploy-workers.md
@@ -1,4 +1,4 @@
-# Deploy Worker Node(s)
+# Deploy Kubernetes Worker Node(s)
 
 Boot one or more CoreOS nodes which will be used as Kubernetes Workers. You must use a CoreOS version 773.1.0+ on the Alpha or Beta channel for the `kubelet` to be present in the image.
 

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -4,8 +4,8 @@ This guide will walk you through a deployment of a single-master/multi-worker Ku
 
 - configure an etcd cluster for Kubernetes to use
 - generate the required certificates for communication between Kubernetes components
-- deploy our Master nodes
-- deploy our Worker nodes
+- deploy a master node
+- deploy worker nodes
 - configure `kubectl` to work with our cluster
 - deploy the DNS add-on
 
@@ -17,9 +17,9 @@ The following variables will be used throughout this guide. Most of the provided
 
 **MASTER_HOST**=_no default_
 
-The address of the master node. In most cases this will be the publicly routable IP of the master node. Worker nodes must be able to reach the master via this address on port 443. Additionally, external clients (such as an administrator using `kubectl`) will also need access, since this will run the Kubernetes API endpoint.
+The address of the master node. In most cases this will be the publicly routable IP of the node. Worker nodes must be able to reach the master node(s) via this address on port 443. Additionally, external clients (such as an administrator using `kubectl`) will also need access, since this will run the Kubernetes API endpoint.
 
-If you will be running a high-availability control-plane consisting of multiple master nodes, then `MASTER_HOST` will ideally be a network load balancer that sits in front of the master nodes. Alternatively, a DNS name can be configured which will resolve to the master node IPs. How requests are routed to the master nodes will be an important consideration when creating the TLS certificates.
+If you will be running a high-availability control-plane consisting of multiple master nodes, then `MASTER_HOST` will ideally be a network load balancer that sits in front of them. Alternatively, a DNS name can be configured which will resolve to the master IPs. How requests are routed to the master nodes will be an important consideration when creating the TLS certificates.
 
 <hr/>
 
@@ -33,13 +33,13 @@ List of etcd machines (`http://ip:port`), comma separated. If you're running a c
 
 The CIDR network to use for pod IPs.
 Each pod launched in the cluster will be assigned an IP out of this range.
-This network must be routable between all nodes in the cluster. In a default installation, the flannel overlay network will provide routing to this network.
+This network must be routable between all hosts in the cluster. In a default installation, the flannel overlay network will provide routing to this network.
 
 <hr/>
 
 **SERVICE_IP_RANGE**=10.3.0.0/24
 
-The CIDR network to use for service cluster VIPs (Virtual IPs). Each service will be assigned a cluster IP out of this range. This must not overlap with any IP ranges assigned to the `POD_NETWORK`, or other existing network infrastructure. Routing to these VIPs is handled by a local kube-proxy service to each node, and are not required to be routable between nodes.
+The CIDR network to use for service cluster VIPs (Virtual IPs). Each service will be assigned a cluster IP out of this range. This must not overlap with any IP ranges assigned to the `POD_NETWORK`, or other existing network infrastructure. Routing to these VIPs is handled by a local kube-proxy service to each host, and are not required to be routable between hosts.
 
 <hr/>
 
@@ -139,5 +139,5 @@ admin-key.pem
 <div class="co-m-docs-next-step">
   <p><strong>Is your etcd cluster up and running?</strong> You need the IPs for the next step.</p>
   <p><strong>Did you generate all of the certificates?</strong> You will place these on disk next.</p>
-  <a href="deploy-master.md" class="btn btn-primary btn-icon-right"  data-category="Docs Next" data-event="Kubernetes: Master">Yes, ready to deploy the Master</a>
+  <a href="deploy-master.md" class="btn btn-primary btn-icon-right"  data-category="Docs Next" data-event="Kubernetes: Master">Yes, ready to deploy the master node</a>
 </div>

--- a/Documentation/kubernetes-networking.md
+++ b/Documentation/kubernetes-networking.md
@@ -8,7 +8,7 @@ The Kubernetes network model outlines four methods of component communication:
     * Each Pod in a Kubernetes cluster is assigned an IP in a flat shared networking namespace. This allows for a clean network model where Pods, from a networking perspective, can be treated much like VMs or physical hosts.
 
 * Pod-to-Service Communication
-    * Services are implemented by assigning Virtual IPs which clients can access and are transparently proxied to the Pods grouped by that service. Requests to the Service IPs are intercepted by a kube-proxy process running on all nodes, which is then responsible for routing to the correct Pod.
+    * Services are implemented by assigning Virtual IPs which clients can access and are transparently proxied to the Pods grouped by that service. Requests to the Service IPs are intercepted by a kube-proxy process running on all hosts, which is then responsible for routing to the correct Pod.
 
 * External-to-Internal Communication
     * Accessing services from outside the cluster is generally implemented by configuring external loadbalancers which target all nodes in the cluster. Once traffic arrives at a node, it is routed to the correct Service backends via the kube-proxy.
@@ -21,7 +21,7 @@ See [Kubernetes Networking][kubernetes-network] for more detailed information on
 
 The information below describes a minimum set of port allocations used by Kubernetes components. Some of these allocations will be optional depending on the deployment (e.g. if flannel is being used). Additionally, there are likely additional ports a deployer will need to open on their infrastructure (e.g. 22/ssh).
 
-Controller Node Inbound
+Master Node Inbound
 
 | Protocol | Port Range | Source                                    | Purpose                |
 -----------|------------|-------------------------------------------|------------------------|
@@ -31,9 +31,9 @@ Worker Node Inbound
 
 | Protocol | Port Range  | Source                         | Purpose                                                                |
 -----------|-------------|--------------------------------|------------------------------------------------------------------------|
-| TCP      | 10250       | Control Nodes                  | Worker node Kubelet healthcheck port.                                  |
+| TCP      | 10250       | Master Nodes                   | Worker node Kubelet healthcheck port.                                  |
 | TCP      | 30000-32767 | External Application Consumers | Default port range for [external service][external-service] ports. Typically, these ports would need to be exposed to external load-balancers, or other external consumers of the application itself. |
-| TCP      | ALL         | Worker & Control Nodes         | Intra-cluster communication (unnecessary if flannel is used)           |
+| TCP      | ALL         | Master & Worker Nodes          | Intra-cluster communication (unnecessary if flannel is used)           |
 | UDP      | 8285        | Worker Nodes                   | flannel overlay network - *udp backend*. This is the default netowrk configuration (only required if using flannel) |
 | UDP      | 8472        | Worker Nodes                   | flannel overlay network - *vxlan backend* (only required if using flannel) |
 
@@ -41,7 +41,7 @@ etcd Node Inbound
 
 | Protocol | Port Range | Source        | Purpose                                                  |
 -----------|------------|---------------|----------------------------------------------------------|
-| TCP      | 2379-2380  | Control Nodes | etcd server client API                                   |
+| TCP      | 2379-2380  | Master Nodes  | etcd server client API                                   |
 | TCP      | 2379-2380  | Worker Nodes  | etcd server client API (only required if using flannel). |
 
 [external-service]: http://kubernetes.io/v1.1/docs/user-guide/services.html#external-services

--- a/Documentation/kubernetes-on-aws.md
+++ b/Documentation/kubernetes-on-aws.md
@@ -11,7 +11,7 @@ Choose one of the following paths to get started:
 
 	Use the `kube-aws` CLI tool to automate cluster deployment. See the [kube-aws Quickstart section](#kube-aws-quickstart) below.
 
-2. Launch Stack & Configuration Guide
+1. Launch Stack & Configuration Guide
 
 	Click the following Launch Stack button, then use the [Configuration Guide](#cloudformation-template-parameters) later in this document to decide how to set the CloudFormation template parameters:
 
@@ -45,7 +45,7 @@ Configure your local workstation with AWS credentials using one of the following
 	export AWS_SECRET_ACCESS_KEY=MY-SECRET-KEY
 	```	
 
-2. Config File
+1. Config File
 
 	Write your credentials into the file `~/.aws/credentials` using the following template:
 	
@@ -77,7 +77,7 @@ Once the AWS resources are created, Kubernetes will start up automatically.
 Each component certificate is only valid for 90 days, while the CA is valid for 365 days.
 If deploying a production Kubernetes cluster, consider establishing PKI independently of this tool first.
 
-Navigate to the DNS registrar hosting the zone for the provided external DNS name and ensure a single A record exists, routing the value of `externalDNSName` defined in `cluster.yaml` to the externally-accessible IP of the controller instance.
+Navigate to the DNS registrar hosting the zone for the provided external DNS name and ensure a single A record exists, routing the value of `externalDNSName` defined in `cluster.yaml` to the externally-accessible IP of the master node instance.
 You may use `kube-aws status` to get this value after cluster creation, if necessary.
 
 A kubectl config file will be written to `./clusters/<cluster-name>/kubeconfig`, which can be used to interact with your Kubernetes cluster like so:
@@ -98,7 +98,7 @@ This includes the certificate authority, signed server certificates for the Kube
 The API server certificate will be valid for the value of `externalDNSName`, as well as a the DNS names used to route Kubernetes API requests inside the cluster.
 
 `kube-aws` does *not* manage a DNS zone for the cluster.
-This means that the deployer is responsible for ensuring the routability of the external DNS name to the public IP of the controller instance.
+This means that the deployer is responsible for ensuring the routability of the external DNS name to the public IP of the master node instance.
 
 After generating the necessary TLS infrastructure, `kube-aws` creates a new CloudFormation, pointing to a CloudFormation template managed by this project.
 The CloudFormation template encompasses everything necessary to deploy the cluster.
@@ -173,7 +173,7 @@ The value of this field is the name of a keypair already loaded into the AWS acc
 
 #### ControllerInstanceType, WorkerInstanceType
 
-These fields are the names of the EC2 instance types to use for the controller and worker instances, respectively.
+These fields are the names of the EC2 instance types to use for the master node and worker node instances, respectively.
 It is recommended that instances have 3GB+ of RAM.
 More resources allocated to the worker instances directly increases the scheduleable capacity of the Kubernetes cluster.
 

--- a/Documentation/kubernetes-on-baremetal.md
+++ b/Documentation/kubernetes-on-baremetal.md
@@ -7,7 +7,7 @@ After completing this guide, a deployer will be able to interact with the Kubern
 
 ### CoreOS Installation
 
-For all nodes running Kubernetes components (controller & workers), you must use CoreOS version 773.1.0+ on the Alpha or Beta channel for the kubelet to be present in the image.
+For all nodes running Kubernetes components (masters & workers), you must use CoreOS version 773.1.0+ on the Alpha or Beta channel for the kubelet to be present in the image.
 
 Use the official CoreOS bare metal guides for installation instructions:
 
@@ -15,7 +15,7 @@ Use the official CoreOS bare metal guides for installation instructions:
 * [Booting with PXE][coreos-pxe]
 * [Installing to Disk][coreos-ondisk]
 
-Mixing multiple methods is possible. For example, doing an install to disk for the machines running the etcd cluster and Kubernetes Controllers, but PXE-booting the worker machines.
+Mixing multiple methods is possible. For example, doing an install to disk for the machines running the etcd cluster and Kubernetes master nodes, but PXE-booting the worker machines.
 
 [coreos-ipxe]: https://coreos.com/os/docs/latest/booting-with-ipxe.html
 [coreos-pxe]: https://coreos.com/os/docs/latest/booting-with-pxe.html

--- a/Documentation/kubernetes-on-vagrant-single.md
+++ b/Documentation/kubernetes-on-vagrant-single.md
@@ -61,7 +61,7 @@ You can choose from one of the two following options.
    kubectl config use-context vagrant-single
    ```
 
-2. **Update the local-user kubeconfig**
+1. **Update the local-user kubeconfig**
    ```sh
    $ kubectl config set-cluster vagrant-single-cluster --server=https://172.17.4.99:443 --certificate-authority=${PWD}/ssl/ca.pem
    $ kubectl config set-credentials vagrant-single-admin --certificate-authority=${PWD}/ssl/ca.pem --client-key=${PWD}/ssl/admin-key.pem --client-certificate=${PWD}/ssl/admin.pem

--- a/Documentation/kubernetes-on-vagrant.md
+++ b/Documentation/kubernetes-on-vagrant.md
@@ -45,7 +45,7 @@ $ cd coreos-kubernetes/multi-node/vagrant
 
 ## Start the Machines
 
-The default cluster configuration is to start a virtual machine for each role &mdash; controller, worker, and etcd server. However, you can modify the default cluster settings by copying `config.rb.sample` to `config.rb` and modifying configuration values.
+The default cluster configuration is to start a virtual machine for each role &mdash; master node, worker node, and etcd server. However, you can modify the default cluster settings by copying `config.rb.sample` to `config.rb` and modifying configuration values.
 
 ```
 #$update_channel="alpha"
@@ -73,7 +73,7 @@ You can choose from one of the two following options.
 	kubectl config use-context vagrant-multi
 	```
 
-2. **Update the local-user kubeconfig**
+1. **Update the local-user kubeconfig**
 
 	Configure your local Kubernetes client using the following commands:
 

--- a/Documentation/kubernetes-upgrade.md
+++ b/Documentation/kubernetes-upgrade.md
@@ -33,13 +33,13 @@ To: `image: gcr.io/google_containers/hyperkube:v1.0.7`
 
 The kubelet would then restart the pod, and the new image version would be used.
 
-**NOTE:** If you are running a multi-master high-availabililty cluster, please see the next section on upgrading the remaining master components. Otherwise you can upgrade the remaining static pods (controller-manager, scheduler) using the same process described above.
+**NOTE:** If you are running a multi-master high-availabililty cluster, please see the next section on upgrading the remaining master node components. Otherwise you can upgrade the remaining static pods (controller-manager, scheduler) using the same process described above.
 
-### Upgrading Remaining Master Components (high-availability)
+### Upgrading Remaining Master Node Components (High-Availability)
 
 The kube-controller-manager, kube-scheduler, and kube-podmaster are all also deployed as static pods in `/etc/kubernetes/manifests`. However, in high-availability deployments, the kube-podmaster is responsible for making sure only a single copy of the controller-manager and scheduler are running cluster-wide.
 
-To accomplish this the kube-podmaster on each node, if master-elected, will copy the static manifest from `/srv/kubernetes/manifets` into `/etc/kubernetes/manifests` and the kubelet will pick up the manifest and run the pod. If the kube-podmaster loses its status as master, it will remove the static pod from `/etc/kubernetes/manifests/` and the kubelet will shut down the pod.
+To accomplish this the kube-podmaster on each master node, if leader-elected, will copy the static manifest from `/srv/kubernetes/manifests` into `/etc/kubernetes/manifests` and the kubelet will pick up the manifest and run the pod. If the kube-podmaster loses its status as leader, it will remove the static pod from `/etc/kubernetes/manifests/` and the kubelet will shut down the pod.
 
 This configuration means upgrading of these components will take a little more coordination.
 
@@ -50,7 +50,7 @@ To upgrade the kube-controller-manager and kube-scheduler:
    1. Remove the existing manifests (if present) from `/etc/kubernetes/manifests`
    1. The kube-podmaster will automatically fetch the new manifest from `/srv/kubernetes/manifests` and copy it to `/etc/kubernetes/manifests` and the new pod will be started.
 
-**NOTE:** Because a particular master node may not be elected to run a particular component (e.g. kube-scheduler), updating the local manifest may not update the currently active instance. You should update the manifests on all master nodes to ensure that no matter which is active, all will reflect the updated manifest.
+**NOTE:** Because a particular master node may not be elected to run a particular component (e.g. kube-scheduler), updating the local manifest may not update the currently active instance of the Pod. You should update the manifests on all master nodes to ensure that no matter which is active, all will reflect the updated manifest.
 
 ### Upgrading Worker Nodes
 
@@ -69,5 +69,4 @@ The kube-proxy is run as a "static pod". To upgrade the pod definition, simply m
 1. For each master node:
     1. Back up existing manifests
     1. Update manifests
-1. Repeat same steps above for each worker node
-
+1. Repeat item 3 for each worker node

--- a/Documentation/openssl.md
+++ b/Documentation/openssl.md
@@ -10,9 +10,9 @@ The following variables will be used throughout this guide. The default for `K8S
 
 **MASTER_HOST**=_no default_
 
-The address of the master node. In most cases this will be the publicly routable IP or hostname of the master cluster. Worker nodes must be able to reach the master node(s) via this address on port 443. Additionally, external clients (such as an administrator using `kubectl`) will also need access, since this will run the Kubernetes API endpoint.
+The address of the master node. In most cases this will be the publicly routable IP or hostname of the node. Worker nodes must be able to reach the master node(s) via this address on port 443. Additionally, external clients (such as an administrator using `kubectl`) will also need access, since this will run the Kubernetes API endpoint.
 
-If you will be running a highly-available control-plane consisting of multiple master nodes, then `MASTER_HOST` will ideally be a network load balancer that sits in front of the master nodes. Alternatively, a DNS name can be configured to resolve to the master node IPs. In either case, the certificates generated below must have the appropriate CommonName and/or SubjectAlternateNames.
+If you will be running a highly-available control-plane consisting of multiple master nodes, then `MASTER_HOST` will ideally be a network load balancer that sits in front of them. Alternatively, a DNS name can be configured to resolve to the master IPs. In either case, the certificates generated below must have the appropriate CommonName and/or SubjectAlternateNames.
 
 ---
 
@@ -127,6 +127,6 @@ $ openssl req -new -key admin-key.pem -out admin.csr -subj "/CN=kube-admin"
 $ openssl x509 -req -in admin.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out admin.pem -days 365
 ```
 
-You are now ready to return to the [deployment guide][deployment-guide] and configure your Master machine, Workers, and `kubectl` on your local machine.
+You are now ready to return to the [deployment guide][deployment-guide] and configure your master node(s), worker nodes, and `kubectl` on your local machine.
 
 [deployment-guide]: getting-started.md


### PR DESCRIPTION
Added more details on the distinction between /srv/kubernetes and
/etc/kubernetes at the top of the master deployment instructions.

Updated docs to use "controller" instead of "master" to conform with
current terminology, and to use "node" to refer specifically to worker
nodes in most places.  (Variable names and directory path references
left unchanged to avoid inadvertently breaking other docs.)

Fixes #203