### PR TITLE
kube-aws: fix network defaults bug

### DIFF
--- a/multi-node/aws/pkg/cluster/config_test.go
+++ b/multi-node/aws/pkg/cluster/config_test.go
@@ -1,0 +1,90 @@
+package cluster
+
+import (
+	"testing"
+)
+
+const testVer = "1"
+const minimalConfigYaml = `externalDNSName: test-external-dns-name
+keyName: test-key-name
+region: test-region
+clusterName: test-cluster-name
+`
+
+var goodNetworkingConfigs []string = []string{
+	``, //Tests validity of default network config values
+	`
+vpcCIDR: 10.4.3.0/24
+instanceCIDR: 10.4.3.0/24
+controllerIP: 10.4.3.5
+podCIDR: 172.4.0.0/16
+serviceCIDR: 172.5.0.0/16
+kubernetesServiceIP: 172.5.100.100
+dnsServiceIP: 172.5.100.101
+`, `
+vpcCIDR: 10.4.0.0/16
+instanceCIDR: 10.4.3.0/24
+controllerIP: 10.4.3.5
+podCIDR: 10.6.0.0/16
+serviceCIDR: 10.5.0.0/16
+kubernetesServiceIP: 10.5.100.100
+dnsServiceIP: 10.5.100.101
+`,
+}
+
+var incorrectNetworkingConfigs []string = []string{
+	`
+vpcCIDR: 10.4.0.0/16
+instanceCIDR: 10.5.3.0/24 #instanceCIDR not in vpcCIDR
+controllerIP: 10.5.3.5
+podCIDR: 10.6.0.0/16
+serviceCIDR: 10.5.0.0/16
+kubernetesServiceIP: 10.5.100.100
+dnsServiceIP: 10.5.100.101
+`, `
+vpcCIDR: 10.4.3.0/16
+instanceCIDR: 10.4.3.0/24
+controllerIP: 10.4.3.5
+podCIDR: 172.4.0.0/16
+serviceCIDR: 172.5.0.0/16
+kubernetesServiceIP: 172.10.100.100 #kubernetesServiceIP not in service CIDR
+dnsServiceIP: 172.5.100.101
+`, `
+vpcCIDR: 10.4.3.0/16
+instanceCIDR: 10.4.3.0/24
+controllerIP: 10.4.3.5
+podCIDR: 10.4.0.0/16 #vpcCIDR overlaps with podCIDR
+serviceCIDR: 172.5.0.0/16
+kubernetesServiceIP: 172.5.100.100
+dnsServiceIP: 172.5.100.101
+
+`, `
+vpcCIDR: 10.4.3.0/16
+instanceCIDR: 10.4.3.0/24
+controllerIP: 10.4.3.5
+podCIDR: 172.4.0.0/16
+serviceCIDR: 172.5.0.0/16
+kubernetesServiceIP: 172.5.100.100
+dnsServiceIP: 172.6.100.101 #dnsServiceIP not in service CIDR
+`,
+}
+
+func TestNetworkValidation(t *testing.T) {
+
+	for _, networkConfig := range goodNetworkingConfigs {
+		config := NewDefaultConfig(testVer)
+		configBody := minimalConfigYaml + networkConfig
+		if err := decodeConfigBytes(config, []byte(configBody)); err != nil {
+			t.Errorf("Correct config tested invalid: %s\n%s", err, networkConfig)
+		}
+	}
+
+	for _, networkConfig := range incorrectNetworkingConfigs {
+		config := NewDefaultConfig(testVer)
+		configBody := minimalConfigYaml + networkConfig
+		if err := decodeConfigBytes(config, []byte(configBody)); err == nil {
+			t.Errorf("Incorrect config tested valid, expected error:\n%s", networkConfig)
+		}
+	}
+
+}


### PR DESCRIPTION
make sure default network configuration values are applied to the configuration struct at parse time. the defaults were being validated if the supplied value is empty, but the default value was not being written back to the configuration struct.

this is important so that the inferred default values are set before
- the network toplogy is validated
- ssl certificates are generated

fixes #226 