### PR TITLE
enable heapster and influxdb by default

### DIFF
--- a/Documentation/kubernetes-on-aws.md
+++ b/Documentation/kubernetes-on-aws.md
@@ -39,16 +39,16 @@ Configure your local workstation with AWS credentials using one of the following
 1. Environment Variables
 
 	Set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to the values of your AWS access and secret keys, respectively:
-	
+
 	```
 	export AWS_ACCESS_KEY_ID=AKID1234567890
 	export AWS_SECRET_ACCESS_KEY=MY-SECRET-KEY
-	```	
+	```
 
 2. Config File
 
 	Write your credentials into the file `~/.aws/credentials` using the following template:
-	
+
 	```
 	[default]
 	aws_access_key_id = AKID1234567890
@@ -126,7 +126,7 @@ This will be used to identify all AWS resources that make the cluster, and must 
 
 #### region
 
-Deploy the CloudFormation stack into a specific region.
+Deploy the CloudFormation stack into a specific EC2 region, for example "us-east-1". You can see the regions, along with their canonical names, in the [AWS Documentation](http://docs.aws.amazon.com/general/latest/gr/rande.html#ec2_region)
 
 #### availabilityZone
 
@@ -135,8 +135,7 @@ If not set, a zone will be chosen for you in the region being used to deploy the
 
 #### keyName
 
-Decide what SSH keypair to authorize across all instances in the cluster.
-The value of this field is the name of a keypair already loaded into the AWS account in use.
+Decide what SSH keypair to authorize across all instances in the cluster.  The value of this field is the name of a keypair already loaded into the AWS account in use. You can see instructions about how to generate or import a keypair into AWS in the [AWS Documentation](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html).
 
 #### workerCount
 
@@ -150,7 +149,8 @@ The coreos-kubernetes artifacts are available at a default location, but the loc
 #### externalDNSName
 
 This DNS name is assumed to be routable from outside the cluster to the Kubernetes API.
-It is automatically added as a Subject Alternative Names (SANs) to the kube-apiserver TLS certificate.
+It is automatically added as a Subject Alternative Names (SANs) to the kube-apiserver TLS certificate. You may not know the IP you want to associate with the name to start with - once your cluster is up and running, you can get the IP you'll need to configure your DNS with `kube-aws status`.
+
 
 ### CloudFormation Template Parameters
 

--- a/multi-node/aws/artifacts/manifests/cluster/heapster-rc.json
+++ b/multi-node/aws/artifacts/manifests/cluster/heapster-rc.json
@@ -1,0 +1,54 @@
+{
+  "apiVersion": "v1",
+  "kind": "ReplicationController",
+  "metadata": {
+    "name": "heapster-v10",
+    "namespace": "kube-system",
+    "labels": {
+      "k8s-app": "heapster",
+      "version": "v10",
+      "kubernetes.io/cluster-service": "true"
+    }
+  },
+  "spec": {
+    "replicas": 1,
+    "selector": {
+      "k8s-app": "heapster",
+      "version": "v10"
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "k8s-app": "heapster",
+          "version": "v10",
+          "kubernetes.io/cluster-service": "true"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "image": "gcr.io/google_containers/heapster:v0.18.2",
+            "name": "heapster",
+            "resources": {
+              "limits": {
+                "cpu": "100m",
+                "memory": "224Mi"
+              },
+              "requests": {
+                "cpu": "100m",
+                "memory": "224Mi"
+              }
+            },
+            "command": [
+              "/heapster",
+              "--source=kubernetes:''",
+              "--sink=influxdb:http://monitoring-influxdb:8086",
+              "--stats_resolution=30s",
+              "--sink_frequency=1m"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/multi-node/aws/artifacts/manifests/cluster/heapster-svc.json
+++ b/multi-node/aws/artifacts/manifests/cluster/heapster-svc.json
@@ -1,0 +1,23 @@
+{
+  "kind": "Service",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "heapster",
+    "namespace": "kube-system",
+    "labels": {
+      "kubernetes.io/cluster-service": "true",
+      "kubernetes.io/name": "Heapster"
+    }
+  },
+  "spec": {
+    "ports": [
+      {
+        "port": 80,
+        "targetPort": 8082
+      }
+    ],
+    "selector": {
+      "k8s-app": "heapster"
+    }
+  }
+}

--- a/multi-node/aws/artifacts/manifests/cluster/influxdb-rc.json
+++ b/multi-node/aws/artifacts/manifests/cluster/influxdb-rc.json
@@ -1,0 +1,69 @@
+{
+  "apiVersion": "v1",
+  "kind": "ReplicationController",
+  "metadata": {
+    "name": "monitoring-influxdb-v2",
+    "namespace": "kube-system",
+    "labels": {
+      "k8s-app": "influxdb",
+      "version": "v2",
+      "kubernetes.io/cluster-service": "true"
+    }
+  },
+  "spec": {
+    "replicas": 1,
+    "selector": {
+      "k8s-app": "influxdb",
+      "version": "v2"
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "k8s-app": "influxdb",
+          "version": "v2",
+          "kubernetes.io/cluster-service": "true"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "image": "gcr.io/google_containers/heapster_influxdb:v0.4",
+            "name": "influxdb",
+            "resources": {
+              "limits": {
+                "cpu": "100m",
+                "memory": "200Mi"
+              },
+              "requests": {
+                "cpu": "100m",
+                "memory": "200Mi"
+              }
+            },
+            "ports": [
+              {
+                "containerPort": 8083,
+                "hostPort": 8083
+              },
+              {
+                "containerPort": 8086,
+                "hostPort": 8086
+              }
+            ],
+            "volumeMounts": [
+              {
+                "name": "influxdb-persistent-storage",
+                "mountPath": "/data"
+              }
+            ]
+          }
+        ],
+        "volumes": [
+          {
+            "name": "influxdb-persistent-storage",
+            "emptyDir": {}
+          }
+        ]
+      }
+    }
+  }
+}

--- a/multi-node/aws/artifacts/manifests/cluster/influxdb-svc.json
+++ b/multi-node/aws/artifacts/manifests/cluster/influxdb-svc.json
@@ -1,0 +1,29 @@
+{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "name": "monitoring-influxdb",
+    "namespace": "kube-system",
+    "labels": {
+      "kubernetes.io/cluster-service": "true",
+      "kubernetes.io/name": "InfluxDB"
+    }
+  },
+  "spec": {
+    "ports": [
+      {
+        "name": "http",
+        "port": 8083,
+        "targetPort": 8083
+      },
+      {
+        "name": "api",
+        "port": 8086,
+        "targetPort": 8086
+      }
+    ],
+    "selector": {
+      "k8s-app": "influxdb"
+    }
+  }
+}

--- a/multi-node/aws/artifacts/scripts/install-controller.sh
+++ b/multi-node/aws/artifacts/scripts/install-controller.sh
@@ -123,6 +123,11 @@ EOF
 	template manifests/cluster/kube-dns-rc.json /srv/kubernetes/manifests/kube-dns-rc.json
 	template manifests/cluster/kube-dns-svc.json /srv/kubernetes/manifests/kube-dns-svc.json
 
+	template manifests/cluster/heapster-rc.json /srv/kubernetes/manifests/heapster-rc.json
+	template manifests/cluster/heapster-svc.json /srv/kubernetes/manifests/heapster-svc.json
+	template manifests/cluster/influxdb-rc.json /srv/kubernetes/manifests/influxdb-rc.json
+	template manifests/cluster/influxdb-svc.json /srv/kubernetes/manifests/influxdb-svc.json
+
 	local TEMPLATE=/etc/flannel/options.env
 	[ -f $TEMPLATE ] || {
 		echo "TEMPLATE: $TEMPLATE"
@@ -167,6 +172,13 @@ function start_addons {
 	echo "K8S: DNS addon"
 	curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
 	curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
+
+	echo "K8S: Monitoring addon"
+	curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
+	curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/influxdb-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
+	curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
+	curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/influxdb-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
+
 }
 
 init_config

--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -520,6 +520,216 @@ EOF
 EOF
     }
 
+    # For one controller and one worker node, fix memory at
+    # 224Mi. Multiple node clusters should scale up their memory by
+    # about 12Mi per node
+    local TEMPLATE=/srv/kubernetes/manifests/heapster-rc.json
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+{
+  "apiVersion": "v1",
+  "kind": "ReplicationController",
+  "metadata": {
+    "name": "heapster-v10",
+    "namespace": "kube-system",
+    "labels": {
+      "k8s-app": "heapster",
+      "version": "v10",
+      "kubernetes.io/cluster-service": "true"
+    }
+  },
+  "spec": {
+    "replicas": 1,
+    "selector": {
+      "k8s-app": "heapster",
+      "version": "v10"
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "k8s-app": "heapster",
+          "version": "v10",
+          "kubernetes.io/cluster-service": "true"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "image": "gcr.io/google_containers/heapster:v0.18.2",
+            "name": "heapster",
+            "resources": {
+              "limits": {
+                "cpu": "100m",
+                "memory": "224Mi"
+              },
+              "requests": {
+                "cpu": "100m",
+                "memory": "224Mi"
+              }
+            },
+            "command": [
+              "/heapster",
+              "--source=kubernetes:''",
+              "--sink=influxdb:http://monitoring-influxdb:8086",
+              "--stats_resolution=30s",
+              "--sink_frequency=1m"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}
+EOF
+    }
+
+    local TEMPLATE=/srv/kubernetes/manifests/influxdb-rc.json
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+{
+  "apiVersion": "v1",
+  "kind": "ReplicationController",
+  "metadata": {
+    "name": "monitoring-influxdb-v2",
+    "namespace": "kube-system",
+    "labels": {
+      "k8s-app": "influxdb",
+      "version": "v2",
+      "kubernetes.io/cluster-service": "true"
+    }
+  },
+  "spec": {
+    "replicas": 1,
+    "selector": {
+      "k8s-app": "influxdb",
+      "version": "v2"
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "k8s-app": "influxdb",
+          "version": "v2",
+          "kubernetes.io/cluster-service": "true"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "image": "gcr.io/google_containers/heapster_influxdb:v0.4",
+            "name": "influxdb",
+            "resources": {
+              "limits": {
+                "cpu": "100m",
+                "memory": "200Mi"
+              },
+              "requests": {
+                "cpu": "100m",
+                "memory": "200Mi"
+              }
+            },
+            "ports": [
+              {
+                "containerPort": 8083,
+                "hostPort": 8083
+              },
+              {
+                "containerPort": 8086,
+                "hostPort": 8086
+              }
+            ],
+            "volumeMounts": [
+              {
+                "name": "influxdb-persistent-storage",
+                "mountPath": "/data"
+              }
+            ]
+          }
+        ],
+        "volumes": [
+          {
+            "name": "influxdb-persistent-storage",
+            "emptyDir": {}
+          }
+        ]
+      }
+    }
+  }
+}
+EOF
+    }
+
+    local TEMPLATE=/srv/kubernetes/manifests/heapster-svc.json
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+{
+  "kind": "Service",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "heapster",
+    "namespace": "kube-system",
+    "labels": {
+      "kubernetes.io/cluster-service": "true",
+      "kubernetes.io/name": "Heapster"
+    }
+  },
+  "spec": {
+    "ports": [
+      {
+        "port": 80,
+        "targetPort": 8082
+      }
+    ],
+    "selector": {
+      "k8s-app": "heapster"
+    }
+  }
+}
+EOF
+    }
+
+    local TEMPLATE=/srv/kubernetes/manifests/influxdb-svc.json
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "name": "monitoring-influxdb",
+    "namespace": "kube-system",
+    "labels": {
+      "kubernetes.io/cluster-service": "true",
+      "kubernetes.io/name": "InfluxDB"
+    }
+  },
+  "spec": {
+    "ports": [
+      {
+        "name": "http",
+        "port": 8083,
+        "targetPort": 8083
+      },
+      {
+        "name": "api",
+        "port": 8086,
+        "targetPort": 8086
+      }
+    ],
+    "selector": {
+      "k8s-app": "influxdb"
+    }
+  }
+}
+EOF
+    }
+
     local TEMPLATE=/etc/flannel/options.env
     [ -f $TEMPLATE ] || {
         echo "TEMPLATE: $TEMPLATE"
@@ -565,6 +775,10 @@ function start_addons {
     echo "K8S: DNS addon"
     curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
     curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
+    curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
+    curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/influxdb-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
+    curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
+    curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/influxdb-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
 }
 
 init_config

--- a/multi-node/vagrant/Vagrantfile
+++ b/multi-node/vagrant/Vagrantfile
@@ -12,13 +12,17 @@ $update_channel = "alpha"
 $controller_count = 1
 $controller_vm_memory = 512
 $worker_count = 1
-$worker_vm_memory = 512
+$worker_vm_memory = 1024
 $etcd_count = 1
 $etcd_vm_memory = 512
 
 CONFIG = File.expand_path("config.rb")
 if File.exist?(CONFIG)
   require CONFIG
+end
+
+if $worker_vm_memory < 1024
+  puts "Workers should have at least 1024 MB of memory"
 end
 
 CONTROLLER_CLUSTER_IP="10.3.0.1"

--- a/multi-node/vagrant/config.rb.sample
+++ b/multi-node/vagrant/config.rb.sample
@@ -4,7 +4,7 @@
 #$controller_vm_memory=512
 
 #$worker_count=1
-#$worker_vm_memory=512
+#$worker_vm_memory=1024
 
 #$etcd_count=1
 #$etcd_vm_memory=512

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -459,6 +459,215 @@ EOF
 EOF
     }
 
+    # For single node, fix memory at 212Mi. Multiple node clusters
+    # should scale up their memory by about 12Mi per node
+    local TEMPLATE=/srv/kubernetes/manifests/heapster-rc.json
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+{
+  "apiVersion": "v1",
+  "kind": "ReplicationController",
+  "metadata": {
+    "name": "heapster-v10",
+    "namespace": "kube-system",
+    "labels": {
+      "k8s-app": "heapster",
+      "version": "v10",
+      "kubernetes.io/cluster-service": "true"
+    }
+  },
+  "spec": {
+    "replicas": 1,
+    "selector": {
+      "k8s-app": "heapster",
+      "version": "v10"
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "k8s-app": "heapster",
+          "version": "v10",
+          "kubernetes.io/cluster-service": "true"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "image": "gcr.io/google_containers/heapster:v0.18.2",
+            "name": "heapster",
+            "resources": {
+              "limits": {
+                "cpu": "100m",
+                "memory": "212Mi"
+              },
+              "requests": {
+                "cpu": "100m",
+                "memory": "212Mi"
+              }
+            },
+            "command": [
+              "/heapster",
+              "--source=kubernetes:''",
+              "--sink=influxdb:http://monitoring-influxdb:8086",
+              "--stats_resolution=30s",
+              "--sink_frequency=1m"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}
+EOF
+    }
+
+    local TEMPLATE=/srv/kubernetes/manifests/influxdb-rc.json
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+{
+  "apiVersion": "v1",
+  "kind": "ReplicationController",
+  "metadata": {
+    "name": "monitoring-influxdb-v2",
+    "namespace": "kube-system",
+    "labels": {
+      "k8s-app": "influxdb",
+      "version": "v2",
+      "kubernetes.io/cluster-service": "true"
+    }
+  },
+  "spec": {
+    "replicas": 1,
+    "selector": {
+      "k8s-app": "influxdb",
+      "version": "v2"
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "k8s-app": "influxdb",
+          "version": "v2",
+          "kubernetes.io/cluster-service": "true"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "image": "gcr.io/google_containers/heapster_influxdb:v0.4",
+            "name": "influxdb",
+            "resources": {
+              "limits": {
+                "cpu": "100m",
+                "memory": "200Mi"
+              },
+              "requests": {
+                "cpu": "100m",
+                "memory": "200Mi"
+              }
+            },
+            "ports": [
+              {
+                "containerPort": 8083,
+                "hostPort": 8083
+              },
+              {
+                "containerPort": 8086,
+                "hostPort": 8086
+              }
+            ],
+            "volumeMounts": [
+              {
+                "name": "influxdb-persistent-storage",
+                "mountPath": "/data"
+              }
+            ]
+          }
+        ],
+        "volumes": [
+          {
+            "name": "influxdb-persistent-storage",
+            "emptyDir": {}
+          }
+        ]
+      }
+    }
+  }
+}
+EOF
+    }
+
+    local TEMPLATE=/srv/kubernetes/manifests/heapster-svc.json
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+{
+  "kind": "Service",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "heapster",
+    "namespace": "kube-system",
+    "labels": {
+      "kubernetes.io/cluster-service": "true",
+      "kubernetes.io/name": "Heapster"
+    }
+  },
+  "spec": {
+    "ports": [
+      {
+        "port": 80,
+        "targetPort": 8082
+      }
+    ],
+    "selector": {
+      "k8s-app": "heapster"
+    }
+  }
+}
+EOF
+    }
+
+    local TEMPLATE=/srv/kubernetes/manifests/influxdb-svc.json
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "name": "monitoring-influxdb",
+    "namespace": "kube-system",
+    "labels": {
+      "kubernetes.io/cluster-service": "true",
+      "kubernetes.io/name": "InfluxDB"
+    }
+  },
+  "spec": {
+    "ports": [
+      {
+        "name": "http",
+        "port": 8083,
+        "targetPort": 8083
+      },
+      {
+        "name": "api",
+        "port": 8086,
+        "targetPort": 8086
+      }
+    ],
+    "selector": {
+      "k8s-app": "influxdb"
+    }
+  }
+}
+EOF
+    }
+
     local TEMPLATE=/etc/flannel/options.env
     [ -f $TEMPLATE ] || {
         echo "TEMPLATE: $TEMPLATE"
@@ -489,7 +698,6 @@ Requires=flanneld.service
 After=flanneld.service
 EOF
     }
-
 }
 
 function start_addons {
@@ -504,6 +712,10 @@ function start_addons {
     echo "K8S: DNS addon"
     curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
     curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
+    curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
+    curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/influxdb-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
+    curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
+    curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/influxdb-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
 }
 
 init_config


### PR DESCRIPTION
This change pulls in the heapster, influxdb, and grafana addons from Kubernetes and deploys them to the single node vagrant cluster by default. If the approach seems acceptable, I'll submit similar changes for our multi-node tools.