### PR TITLE
Update openssl.md

### DIFF
--- a/Documentation/openssl.md
+++ b/Documentation/openssl.md
@@ -54,6 +54,8 @@ subjectAltName = @alt_names
 [alt_names]
 DNS.1 = kubernetes
 DNS.2 = kubernetes.default
+DNS.3 = kubernetes.default.svc
+DNS.4 = kubernetes.default.svc.cluster.local
 IP.1 = ${K8S_SERVICE_IP}
 IP.2 = ${MASTER_HOST}
 ```
@@ -63,7 +65,7 @@ If you are deploying multiple master nodes in an HA configuration, you may need 
 Example:
 
 ```
-DNS.3 = ${MASTER_DNS_NAME}
+DNS.5 = ${MASTER_DNS_NAME}
 IP.3 = ${MASTER_IP}
 IP.4 = ${MASTER_LOADBALANCER_IP}
 ```


### PR DESCRIPTION
https://coreos.com/kubernetes/docs/latest/kubernetes-on-aws.html descibes the open-ssl config with  

kubernetes.default.svc
kubernetes.default.svc.cluster.local

in the certificate. Furthermore other project use kubernetes.default.svc . See https://github.com/pires/kubernetes-elasticsearch-cluster/issues/27