### PR TITLE
kube-aws: configurable instance tenancy

### DIFF
--- a/multi-node/aws/pkg/config/config.go
+++ b/multi-node/aws/pkg/config/config.go
@@ -42,6 +42,7 @@ func newDefaultCluster() *Cluster {
 		HyperkubeImageRepo:       "quay.io/coreos/hyperkube",
 		ContainerRuntime:         "docker",
 		ControllerInstanceType:   "m3.medium",
+		ControllerTenancy:        "default",
 		ControllerRootVolumeType: "gp2",
 		ControllerRootVolumeIOPS: 0,
 		ControllerRootVolumeSize: 30,
@@ -50,6 +51,7 @@ func newDefaultCluster() *Cluster {
 		WorkerRootVolumeType:     "gp2",
 		WorkerRootVolumeIOPS:     0,
 		WorkerRootVolumeSize:     30,
+		WorkerTenancy:            "default",
 		CreateRecordSet:          false,
 		RecordSetTTL:             300,
 		Subnets:                  []Subnet{},
@@ -116,11 +118,13 @@ type Cluster struct {
 	ControllerRootVolumeType string            `yaml:"controllerRootVolumeType,omitempty"`
 	ControllerRootVolumeIOPS int               `yaml:"controllerRootVolumeIOPS,omitempty"`
 	ControllerRootVolumeSize int               `yaml:"controllerRootVolumeSize,omitempty"`
+	ControllerTenancy        string            `yaml:"controllerTenancy,omitempty"`
 	WorkerCount              int               `yaml:"workerCount,omitempty"`
 	WorkerInstanceType       string            `yaml:"workerInstanceType,omitempty"`
 	WorkerRootVolumeType     string            `yaml:"workerRootVolumeType,omitempty"`
 	WorkerRootVolumeIOPS     int               `yaml:"workerRootVolumeIOPS,omitempty"`
 	WorkerRootVolumeSize     int               `yaml:"workerRootVolumeSize,omitempty"`
+	WorkerTenancy            string            `yaml:"workerTenancy,omitempty"`
 	WorkerSpotPrice          string            `yaml:"workerSpotPrice,omitempty"`
 	VPCID                    string            `yaml:"vpcId,omitempty"`
 	RouteTableID             string            `yaml:"routeTableId,omitempty"`

--- a/multi-node/aws/pkg/config/templates/cluster.yaml
+++ b/multi-node/aws/pkg/config/templates/cluster.yaml
@@ -48,6 +48,10 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # Disk size (GiB) for controller node
 #controllerRootVolumeSize: 30
 
+# Tenancy of the controller node. Options are "default" and "dedicated"
+# Documentation: http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/dedicated-instance.html
+# controllerTenancy: default
+
 # Disk type for controller node (one of standard, io1, or gp2)
 #controllerRootVolumeType: gp2
 
@@ -62,6 +66,10 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 
 # Disk size (GiB) for worker nodes
 #workerRootVolumeSize: 30
+
+# Tenancy of the controller node. Options are "default" and "dedicated"
+# Documentation: http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/dedicated-instance.html
+# workerTenancy: default
 
 # Disk type for worker node (one of standard, io1, or gp2)
 #workerRootVolumeType: gp2

--- a/multi-node/aws/pkg/config/templates/stack-template.json
+++ b/multi-node/aws/pkg/config/templates/stack-template.json
@@ -296,6 +296,7 @@
             "Value": "{{.ClusterName}}-kube-aws-controller"
           }
         ],
+        "Tenancy": "{{ .ControllerTenancy }}",
         "UserData": "{{ .UserDataController }}"
       },
       "Type": "AWS::EC2::Instance"
@@ -327,6 +328,8 @@
         ],
         {{if .WorkerSpotPrice}}
         "SpotPrice": {{.WorkerSpotPrice}},
+        {{else}}
+        "PlacementTenancy": "{{.WorkerTenancy}}",
         {{end}}
         "UserData": "{{ .UserDataWorker }}"
       },


### PR DESCRIPTION
We needed dedicated instance workers for compliance reasons, so I did this. While I was at it, I figured I may as well add the ability to run the host as a dedicated instance too.

Hopefully once Amazon allows for dedicated hosts in auto-scaling groups this will work with that too.
