### PR TITLE
Fix the formatting for the sh instructions

### DIFF
--- a/Documentation/kubernetes-on-vagrant-single.md
+++ b/Documentation/kubernetes-on-vagrant-single.md
@@ -57,19 +57,19 @@ You can choose from one of the two following options.
 
 1. **Use a custom KUBECONFIG path**
 
-   ```sh
-   $ export KUBECONFIG="${KUBECONFIG}:$(pwd)/kubeconfig"
-   $ kubectl config use-context vagrant-single
-   ```
+```sh
+$ export KUBECONFIG="${KUBECONFIG}:$(pwd)/kubeconfig"
+$ kubectl config use-context vagrant-single
+```
 
 1. **Update the local-user kubeconfig**
 
-   ```sh
-   $ kubectl config set-cluster vagrant-single-cluster --server=https://172.17.4.99:443 --certificate-authority=${PWD}/ssl/ca.pem
-   $ kubectl config set-credentials vagrant-single-admin --certificate-authority=${PWD}/ssl/ca.pem --client-key=${PWD}/ssl/admin-key.pem --client-certificate=${PWD}/ssl/admin.pem
-   $ kubectl config set-context vagrant-single --cluster=vagrant-single-cluster --user=vagrant-single-admin
-   $ kubectl config use-context vagrant-single
-   ```
+```sh
+$ kubectl config set-cluster vagrant-single-cluster --server=https://172.17.4.99:443 --certificate-authority=${PWD}/ssl/ca.pem
+$ kubectl config set-credentials vagrant-single-admin --certificate-authority=${PWD}/ssl/ca.pem --client-key=${PWD}/ssl/admin-key.pem --client-certificate=${PWD}/ssl/admin.pem
+$ kubectl config set-context vagrant-single --cluster=vagrant-single-cluster --user=vagrant-single-admin
+$ kubectl config use-context vagrant-single
+```
 
 Check that your client is configured properly by using `kubectl` to inspect your cluster:
 

--- a/Documentation/kubernetes-on-vagrant-single.md
+++ b/Documentation/kubernetes-on-vagrant-single.md
@@ -55,14 +55,14 @@ Once in the `coreos-kubernetes/single-node/` directory, configure your local Kub
 
 You can choose from one of the two following options.
 
-2\. **Use a custom KUBECONFIG path**
+1. **Use a custom KUBECONFIG path**
 
 ```sh
 $ export KUBECONFIG="${KUBECONFIG}:$(pwd)/kubeconfig"
 $ kubectl config use-context vagrant-single
 ```
 
-1. **Update the local-user kubeconfig**
+2\. **Update the local-user kubeconfig**
 
 ```sh
 $ kubectl config set-cluster vagrant-single-cluster --server=https://172.17.4.99:443 --certificate-authority=${PWD}/ssl/ca.pem

--- a/Documentation/kubernetes-on-vagrant-single.md
+++ b/Documentation/kubernetes-on-vagrant-single.md
@@ -55,7 +55,7 @@ Once in the `coreos-kubernetes/single-node/` directory, configure your local Kub
 
 You can choose from one of the two following options.
 
-1. **Use a custom KUBECONFIG path**
+2\. **Use a custom KUBECONFIG path**
 
 ```sh
 $ export KUBECONFIG="${KUBECONFIG}:$(pwd)/kubeconfig"


### PR DESCRIPTION
The HTML that is being generated from this markdown file is a bit malformed. 

<img width="1600" alt="screen shot 2016-02-08 at 4 11 13 pm" src="https://cloud.githubusercontent.com/assets/2156866/12899305/a22cbd58-ce7e-11e5-82c4-a4441f47ccbf.png">

This should fix things up.