### PR TITLE
stack template: enforce well-formed strings

### DIFF
--- a/multi-node/aws/pkg/cluster/stack_template.go
+++ b/multi-node/aws/pkg/cluster/stack_template.go
@@ -624,73 +624,45 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 	}
 
 	par[parVPCCIDR] = map[string]interface{}{
-		"Type":                  "String",
-		"Default":               DefaultVPCCIDR,
-		"Description":           "CIDR for Kubernetes vpc",
-		"MinLength":             "9",
-		"MaxLength":             "18",
-		"AllowedPattern":        "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
-		"ConstraintDescription": "must be a valid IP CIDR range of the form x.x.x.x/x.",
+		"Type":        "String",
+		"Default":     DefaultVPCCIDR,
+		"Description": "CIDR for Kubernetes vpc",
 	}
 
 	par[parInstanceCIDR] = map[string]interface{}{
-		"Type":                  "String",
-		"Default":               DefaultInstanceCIDR,
-		"Description":           "CIDR for Kubernetes subnet",
-		"MinLength":             "9",
-		"MaxLength":             "18",
-		"AllowedPattern":        "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
-		"ConstraintDescription": "must be a valid IP CIDR range of the form x.x.x.x/x.",
+		"Type":        "String",
+		"Default":     DefaultInstanceCIDR,
+		"Description": "CIDR for Kubernetes subnet",
 	}
 
 	par[parControllerIP] = map[string]interface{}{
-		"Type":                  "String",
-		"Default":               DefaultControllerIP,
-		"Description":           "IP address for controller in Kubernetes subnet",
-		"MinLength":             "7",
-		"MaxLength":             "15",
-		"AllowedPattern":        "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})",
-		"ConstraintDescription": "must be a valid IP address of the form x.x.x.x.",
+		"Type":        "String",
+		"Default":     DefaultControllerIP,
+		"Description": "IP address for controller in Kubernetes subnet",
 	}
 
 	par[parServiceCIDR] = map[string]interface{}{
-		"Type":                  "String",
-		"Default":               DefaultServiceCIDR,
-		"Description":           "CIDR for all service IP addresses",
-		"MinLength":             "9",
-		"MaxLength":             "18",
-		"AllowedPattern":        "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
-		"ConstraintDescription": "must be a valid IP CIDR range of the form x.x.x.x/x.",
+		"Type":        "String",
+		"Default":     DefaultServiceCIDR,
+		"Description": "CIDR for all service IP addresses",
 	}
 
 	par[parPodCIDR] = map[string]interface{}{
-		"Type":                  "String",
-		"Default":               DefaultPodCIDR,
-		"Description":           "CIDR for all pod IP addresses",
-		"MinLength":             "9",
-		"MaxLength":             "18",
-		"AllowedPattern":        "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
-		"ConstraintDescription": "must be a valid IP CIDR range of the form x.x.x.x/x.",
+		"Type":        "String",
+		"Default":     DefaultPodCIDR,
+		"Description": "CIDR for all pod IP addresses",
 	}
 
 	par[parKubernetesServiceIP] = map[string]interface{}{
-		"Type":                  "String",
-		"Default":               DefaultKubernetesServiceIP,
-		"Description":           "IP address for Kubernetes controller service (must be contained by serviceCIDR)",
-		"MinLength":             "7",
-		"MaxLength":             "15",
-		"AllowedPattern":        "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})",
-		"ConstraintDescription": "must be a valid IP address of the form x.x.x.x.",
+		"Type":        "String",
+		"Default":     DefaultKubernetesServiceIP,
+		"Description": "IP address for Kubernetes controller service (must be contained by serviceCIDR)",
 	}
 
 	par[parDNSServiceIP] = map[string]interface{}{
-		"Type":                  "String",
-		"Default":               DefaultDNSServiceIP,
-		"Description":           "IP address of the Kubernetes DNS service (must be contained by serviceCIDR)",
-		"MinLength":             "7",
-		"MaxLength":             "15",
-		"AllowedPattern":        "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})",
-		"ConstraintDescription": "must be a valid IP address of the form x.x.x.x.",
+		"Type":        "String",
+		"Default":     DefaultDNSServiceIP,
+		"Description": "IP address of the Kubernetes DNS service (must be contained by serviceCIDR)",
 	}
 
 	regionMap, err := getRegionMap()

--- a/multi-node/aws/pkg/cluster/stack_template.go
+++ b/multi-node/aws/pkg/cluster/stack_template.go
@@ -564,7 +564,7 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 	}
 
 	par[parNameKeyName] = map[string]interface{}{
-		"Type":        "String",
+		"Type":        "AWS::EC2::KeyPair::KeyName",
 		"Description": "Name of SSH keypair to authorize on each instance",
 	}
 
@@ -618,51 +618,79 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 	}
 
 	par[parAvailabilityZone] = map[string]interface{}{
-		"Type":        "String",
-		"Default":     "",
+		"Type":        "AWS::EC2::AvailabilityZone::Name",
+		"Default":     "us-east-1",
 		"Description": "Specific availability zone (optional)",
 	}
 
 	par[parVPCCIDR] = map[string]interface{}{
-		"Type":        "String",
-		"Default":     DefaultVPCCIDR,
-		"Description": "CIDR for Kubernetes vpc",
+		"Type":                  "String",
+		"Default":               DefaultVPCCIDR,
+		"Description":           "CIDR for Kubernetes vpc",
+		"MinLength":             "9",
+		"MaxLength":             "18",
+		"AllowedPattern":        "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+		"ConstraintDescription": "must be a valid IP CIDR range of the form x.x.x.x/x.",
 	}
 
 	par[parInstanceCIDR] = map[string]interface{}{
-		"Type":        "String",
-		"Default":     DefaultInstanceCIDR,
-		"Description": "CIDR for Kubernetes subnet",
+		"Type":                  "String",
+		"Default":               DefaultInstanceCIDR,
+		"Description":           "CIDR for Kubernetes subnet",
+		"MinLength":             "9",
+		"MaxLength":             "18",
+		"AllowedPattern":        "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+		"ConstraintDescription": "must be a valid IP CIDR range of the form x.x.x.x/x.",
 	}
 
 	par[parControllerIP] = map[string]interface{}{
-		"Type":        "String",
-		"Default":     DefaultControllerIP,
-		"Description": "IP address for controller in Kubernetes subnet",
+		"Type":                  "String",
+		"Default":               DefaultControllerIP,
+		"Description":           "IP address for controller in Kubernetes subnet",
+		"MinLength":             "7",
+		"MaxLength":             "15",
+		"AllowedPattern":        "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})",
+		"ConstraintDescription": "must be a valid IP address of the form x.x.x.x.",
 	}
 
 	par[parServiceCIDR] = map[string]interface{}{
-		"Type":        "String",
-		"Default":     DefaultServiceCIDR,
-		"Description": "CIDR for all service IP addresses",
+		"Type":                  "String",
+		"Default":               DefaultServiceCIDR,
+		"Description":           "CIDR for all service IP addresses",
+		"MinLength":             "9",
+		"MaxLength":             "18",
+		"AllowedPattern":        "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+		"ConstraintDescription": "must be a valid IP CIDR range of the form x.x.x.x/x.",
 	}
 
 	par[parPodCIDR] = map[string]interface{}{
-		"Type":        "String",
-		"Default":     DefaultPodCIDR,
-		"Description": "CIDR for all pod IP addresses",
+		"Type":                  "String",
+		"Default":               DefaultPodCIDR,
+		"Description":           "CIDR for all pod IP addresses",
+		"MinLength":             "9",
+		"MaxLength":             "18",
+		"AllowedPattern":        "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+		"ConstraintDescription": "must be a valid IP CIDR range of the form x.x.x.x/x.",
 	}
 
 	par[parKubernetesServiceIP] = map[string]interface{}{
-		"Type":        "String",
-		"Default":     DefaultKubernetesServiceIP,
-		"Description": "IP address for Kubernetes controller service (must be contained by serviceCIDR)",
+		"Type":                  "String",
+		"Default":               DefaultKubernetesServiceIP,
+		"Description":           "IP address for Kubernetes controller service (must be contained by serviceCIDR)",
+		"MinLength":             "7",
+		"MaxLength":             "15",
+		"AllowedPattern":        "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})",
+		"ConstraintDescription": "must be a valid IP address of the form x.x.x.x.",
 	}
 
 	par[parDNSServiceIP] = map[string]interface{}{
-		"Type":        "String",
-		"Default":     DefaultDNSServiceIP,
-		"Description": "IP address of the Kubernetes DNS service (must be contained by serviceCIDR)",
+		"Type":                  "String",
+		"Default":               DefaultDNSServiceIP,
+		"Description":           "IP address of the Kubernetes DNS service (must be contained by serviceCIDR)",
+		"MinLength":             "7",
+		"MaxLength":             "15",
+		"AllowedPattern":        "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})",
+		"ConstraintDescription": "must be a valid IP address of the form x.x.x.x.",
 	}
 
 	regionMap, err := getRegionMap()

--- a/multi-node/aws/pkg/cluster/stack_template.go
+++ b/multi-node/aws/pkg/cluster/stack_template.go
@@ -619,7 +619,7 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 
 	par[parAvailabilityZone] = map[string]interface{}{
 		"Type":        "AWS::EC2::AvailabilityZone::Name",
-		"Default":     "us-east-1",
+		"Default":     "us-east-1a",
 		"Description": "Specific availability zone (optional)",
 	}
 

--- a/multi-node/aws/pkg/cluster/stack_template.go
+++ b/multi-node/aws/pkg/cluster/stack_template.go
@@ -619,7 +619,6 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 
 	par[parAvailabilityZone] = map[string]interface{}{
 		"Type":        "AWS::EC2::AvailabilityZone::Name",
-		"Default":     "",
 		"Description": "Specific availability zone (optional)",
 	}
 

--- a/multi-node/aws/pkg/cluster/stack_template.go
+++ b/multi-node/aws/pkg/cluster/stack_template.go
@@ -619,7 +619,7 @@ func StackTemplateBody(defaultArtifactURL string) (string, error) {
 
 	par[parAvailabilityZone] = map[string]interface{}{
 		"Type":        "AWS::EC2::AvailabilityZone::Name",
-		"Default":     "us-east-1a",
+		"Default":     "",
 		"Description": "Specific availability zone (optional)",
 	}
 


### PR DESCRIPTION
stack template: enforce well-formed strings

Try harder to help users choose sensible, well-formed values for key pair name,
IP addresses, availability zone, and CIDR ranges. I know we're already doing
much of this client-side with `net.ParseCIDR()` and `net.ParseIP()`, but it
can't hurt to have CloudFormation double-check for us, and it's handy if/when
these CloudFormation parameter stanzas are copy-pasted elsewhere.

I tested these changes. CloudFormation errors out as expected if invalid
values are used (with helpful error messages!).

Related CloudFormation "best practices" docs:

1. https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/best-practices.html#parmtypes
2. https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/best-practices.html#parmconstraints