### PR TITLE
Heed deprecation warning

### DIFF
--- a/multi-node/aws/build
+++ b/multi-node/aws/build
@@ -21,5 +21,5 @@ mkdir -p $link_path
 
 ln -sf ${PWD}/../../ "${link_path}/coreos-kubernetes"
 
-GOPATH=${PWD}/Godeps/_workspace:${PWD}/gopath CGO_ENABLED=0 go build -ldflags "-X main.VERSION ${VERSION}" -a -tags netgo -installsuffix netgo -o bin/kube-aws github.com/coreos/coreos-kubernetes/multi-node/aws/cmd/kube-aws
+GOPATH=${PWD}/Godeps/_workspace:${PWD}/gopath CGO_ENABLED=0 go build -ldflags "-X main.VERSION=${VERSION}" -a -tags netgo -installsuffix netgo -o bin/kube-aws github.com/coreos/coreos-kubernetes/multi-node/aws/cmd/kube-aws
 echo "done"


### PR DESCRIPTION
`go build` emits a deprecation warning if invoking `-X` switch without assignment sign.