### PR TITLE
Attempt to improve formatting for commands

### DIFF
--- a/Documentation/kubernetes-on-aws.md
+++ b/Documentation/kubernetes-on-aws.md
@@ -36,24 +36,24 @@ $ tar -xf <file> kube-aws
 
 Configure your local workstation with AWS credentials using one of the following methods:
 
-1. Environment Variables
+#### Method 1: Environment Variables
 
-    Set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to the values of your AWS access and secret keys, respectively:
+Set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to the values of your AWS access and secret keys, respectively:
 
-    ```
-export AWS_ACCESS_KEY_ID=AKID1234567890
-export AWS_SECRET_ACCESS_KEY=MY-SECRET-KEY
-    ```
+```sh
+$ export AWS_ACCESS_KEY_ID=AKID1234567890
+$ export AWS_SECRET_ACCESS_KEY=MY-SECRET-KEY
+```
 
-1. Config File
+#### Method 2: Config File
 
-    Write your credentials into the file `~/.aws/credentials` using the following template:
+Write your credentials into the file `~/.aws/credentials` using the following template:
 
-    ```
+```
 [default]
 aws_access_key_id = AKID1234567890
 aws_secret_access_key = MY-SECRET-KEY
-    ```
+```
 
 ### Configure Cluster
 


### PR DESCRIPTION
The page looks fine in the previous state here on GitHub, but on the coreos.com site the commands inside the triple backticks get bunched up on the same line:
https://coreos.com/kubernetes/docs/latest/kubernetes-on-aws.html

E.g: `[default] aws_access_key_id = AKID1234567890 aws_secret_access_key = MY-SECRET-KEY`.

I'm not sure what causes the difference in how the markdown is rendered on Github vs on the coreos.com site, so if someone more clued in could review or improve the change that'd be great, but wanted to call attention to the issue and try to improve things.