### PR TITLE
kube-aws: better support for AWS credentials file

### DIFF
--- a/multi-node/aws/cmd/kube-aws/main.go
+++ b/multi-node/aws/cmd/kube-aws/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/spf13/cobra"
 
 	"github.com/coreos/coreos-kubernetes/multi-node/aws/pkg/cluster"
@@ -42,6 +43,7 @@ func stderr(msg string, args ...interface{}) {
 
 func newAWSConfig(cfg *cluster.Config) *aws.Config {
 	c := aws.NewConfig()
+	c = c.WithCredentials(credentials.NewSharedCredentials("", ""))
 	c = c.WithRegion(cfg.Region)
 	if rootOpts.AWSDebug {
 		c = c.WithLogLevel(aws.LogDebug)


### PR DESCRIPTION
Using the SharedCredentials codepath allows the user to better
control what AWS credentials are used. Specifically, the ability
to set AWS_PROFILE=<profile> is desireable so that users do not
have to export credentials into environment variables, and are
no longer required to set credentials to the "default" profile
in ~/.aws/credentials.