### PR TITLE
Add aws-vpc support to flannel & IAM rules

### DIFF
--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -30,7 +30,7 @@ coreos:
           content: |
             [Service]
             ExecStartPre=/usr/bin/curl --silent -X PUT -d \
-            "value={\"Network\" : \"{{.PodCIDR}}\"}" \
+            "value={\"Network\" : \"{{.PodCIDR}}\", \"Backend\": {\"Type\": \"aws-vpc\"} }" \
             http://localhost:2379/v2/keys/coreos.com/network/config?prevExist=false
     - name: kubelet.service
       command: start
@@ -82,22 +82,30 @@ coreos:
         Restart=on-failure
         ExecStartPre=/usr/bin/curl http://127.0.0.1:8080/version
         ExecStart=/opt/bin/install-kube-system
-
+    - name: sourcedestcheck.service
+      command: start
+      content: |
+        [Unit]
+        Description=Set AWS source/dest check to false
+        [Service]\n",
+        Type=oneshot\n",
+        ExecStartPre=/usr/bin/docker pull quay.io/coreos/awscli
+        ExecStart=/bin/sh -c 'docker run quay.io/coreos/awscli aws ec2 --region {{.Region}} modify-instance-attribute --attribute sourceDestCheck --value false --instance-id $(curl --silent http://169.254.169.254/latest/meta-data/instance-id)'
 write_files:
   - path: /opt/bin/install-kube-system
     permissions: 0700
     owner: root:root
     content: |
       #!/bin/bash -e
-      /usr/bin/curl -XPOST -d @"/srv/kubernetes/manifests/kube-system.json" "http://127.0.0.1:8080/api/v1/namespaces"
+      /usr/bin/curl -H"Content-Type: application/json" -XPOST -d @"/srv/kubernetes/manifests/kube-system.json" "http://127.0.0.1:8080/api/v1/namespaces"
 
       for manifest in {kube-dns,heapster,influxdb}-rc.json;do
-          /usr/bin/curl -XPOST \
+          /usr/bin/curl -H"Content-Type: application/json" -XPOST \
           -d @"/srv/kubernetes/manifests/$manifest" \
           "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers"
       done
       for manifest in {kube-dns,heapster,influxdb}-svc.json;do
-          /usr/bin/curl -XPOST \
+          /usr/bin/curl -H"Content-Type: application/json" -XPOST \
           -d @"/srv/kubernetes/manifests/$manifest" \
           "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services"
       done
@@ -110,7 +118,7 @@ write_files:
 
       for encKey in $(find /etc/kubernetes/ssl/*.pem);do
         tmpPath="/tmp/$(basename $encKey).tmp"
-        docker run --rm -v /etc/kubernetes/ssl:/etc/kubernetes/ssl --rm quay.io/coreos/awscli aws --region {{.Region}} kms decrypt --ciphertext-blob fileb://$encKey --output text --query Plaintext | base64 --decode > $tmpPath
+        docker run -v /etc/kubernetes/ssl:/etc/kubernetes/ssl quay.io/coreos/awscli aws --region {{.Region}} kms decrypt --ciphertext-blob fileb://$encKey --output text --query Plaintext | base64 --decode > $tmpPath
         mv  $tmpPath $encKey
       done
 

--- a/multi-node/aws/pkg/config/templates/cloud-config-worker
+++ b/multi-node/aws/pkg/config/templates/cloud-config-worker
@@ -58,6 +58,16 @@ coreos:
         [Install]
         RequiredBy=kubelet.service
 
+    - name: sourcedestcheck.service
+      command: start
+      content: |
+        [Unit]
+        Description=Set AWS source/dest check to false
+        [Service]\n",
+        Type=oneshot\n",
+        ExecStartPre=/usr/bin/docker pull quay.io/coreos/awscli
+        ExecStart=/bin/sh -c 'docker run quay.io/coreos/awscli aws ec2 --region {{.Region}} modify-instance-attribute --attribute sourceDestCheck --value false --instance-id $(curl --silent http://169.254.169.254/latest/meta-data/instance-id)'
+
 write_files:
   - path: /etc/kubernetes/ssl/worker.pem
     encoding: gzip+base64

--- a/multi-node/aws/pkg/config/templates/stack-template.json
+++ b/multi-node/aws/pkg/config/templates/stack-template.json
@@ -70,7 +70,7 @@
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "UpdatePolicy" : {
-	    "AutoScalingRollingUpdate" : {
+      "AutoScalingRollingUpdate" : {
           "MinInstancesInService" :
           {{if .WorkerSpotPrice}}
             "0"
@@ -79,7 +79,7 @@
           {{end}},
           "MaxBatchSize" : "1",
           "PauseTime" : "PT2M"
-	    }
+      }
       }
     },
     "EIPController": {
@@ -137,6 +137,24 @@
             "PolicyDocument": {
               "Statement": [
                 {
+                  "Action": [
+                    "ecr:GetAuthorizationToken",
+                    "ecr:BatchCheckLayerAvailability",
+                    "ecr:GetDownloadUrlForLayer",
+                    "ecr:GetRepositoryPolicy",
+                    "ecr:DescribeRepositories",
+                    "ecr:ListImages",
+                    "ecr:BatchGetImage"
+                ],
+                  "Effect": "Allow",
+                  "Resource": "*"
+                },
+                {
+                  "Action": "ec2:*",
+                  "Effect": "Allow",
+                  "Resource": "*"
+                },
+                {
                   "Action": "ec2:*",
                   "Effect": "Allow",
                   "Resource": "*"
@@ -146,11 +164,11 @@
                   "Effect": "Allow",
                   "Resource": "*"
                 },
-		{
-		  "Action" : "kms:Decrypt",
-		  "Effect" : "Allow",
-		  "Resource" : "{{.KMSKeyARN}}"
-		}
+                {
+                  "Action" : "kms:Decrypt",
+                  "Effect" : "Allow",
+                  "Resource" : "{{.KMSKeyARN}}"
+                }
               ],
               "Version": "2012-10-17"
             },
@@ -189,6 +207,16 @@
                   "Resource": "*"
                 },
                 {
+                  "Action": [
+                    "ec2:CreateRoute",
+                    "ec2:DeleteRoute",
+                    "ec2:ReplaceRoute",
+                    "ec2:ModifyInstanceAttribute"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*"
+                },
+                {
                   "Action": "ec2:AttachVolume",
                   "Effect": "Allow",
                   "Resource": "*"
@@ -198,11 +226,11 @@
                   "Effect": "Allow",
                   "Resource": "*"
                 },
-		{
-		  "Action" : "kms:Decrypt",
-		  "Effect" : "Allow",
-		  "Resource" : "{{.KMSKeyARN}}"
-		}
+                {
+                  "Action" : "kms:Decrypt",
+                  "Effect" : "Allow",
+                  "Resource" : "{{.KMSKeyARN}}"
+                }
               ],
               "Version": "2012-10-17"
             },


### PR DESCRIPTION
Add a bunch of aws specific features & minor nits/bugs

Features:
  - Use aws-vpc plugin for flannel (and set up IAM rules) for VPC
    fabric native pod routing
  - Add IAM rules for ECR

Bugfix/workaround:
  - Let hosts set their own source/dest check (required for new flannel
    setup)
  - Set Content-Type header when submitting resources to the kubernetes
    apiserver (fails on >v1.2.0)