### PR TITLE
upgrade from v1.1.8 to v1.2.0

### DIFF
--- a/Documentation/configure-kubectl.md
+++ b/Documentation/configure-kubectl.md
@@ -9,13 +9,13 @@ Download `kubectl` from the Kubernetes release artifact site with the `curl` too
 The linux `kubectl` binary can be fetched with a command like:
 
 ```sh
-$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.1.8/bin/linux/amd64/kubectl
+$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.2.0/bin/linux/amd64/kubectl
 ```
 
 On an OS X workstation, replace `linux` in the URL above with `darwin`:
 
 ```sh
-$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.1.8/bin/darwin/amd64/kubectl
+$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.2.0/bin/darwin/amd64/kubectl
 ```
 
 After downloading the binary, ensure it is executable and move it into your `PATH`:

--- a/Documentation/conformance-tests.md
+++ b/Documentation/conformance-tests.md
@@ -44,7 +44,7 @@ $ make quick-release
 Modify the `WORKERS` count to match the deployment you are testing:
 
 ```sh
-$ WORKERS=1; sed -i '' "s/NUM_MINIONS=[0-9]/NUM_MINIONS=${WORKERS}/" hack/conformance-test.sh
+$ WORKERS=1; sed -i '' "s/NUM_NODES=[0-9]/NUM_NODES=${WORKERS}/" hack/conformance-test.sh
 ```
 
 ### Run Conformance Tests

--- a/Documentation/conformance-tests.md
+++ b/Documentation/conformance-tests.md
@@ -27,7 +27,7 @@ Next, checkout the branch or release you'd like to test against:
 
 ```sh
 $ cd kubernetes
-$ git checkout v1.1.8
+$ git checkout v1.2.0
 ```
 
 ### Create Kubernetes Binaries

--- a/Documentation/deploy-addons.md
+++ b/Documentation/deploy-addons.md
@@ -140,7 +140,7 @@ spec:
             cpu: 10m
             memory: 20Mi
         args:
-        - -cmd=nslookup kubernetes.default.svc.cluster.local localhost >/dev/null
+        - -cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1 >/dev/null
         - -port=8080
         ports:
         - containerPort: 8080

--- a/Documentation/deploy-addons.md
+++ b/Documentation/deploy-addons.md
@@ -172,5 +172,5 @@ $ kubectl get pods --namespace=kube-system | grep kube-dns-v11
 <div class="co-m-docs-next-step">
   <p>Now that you have a working Kubernetes cluster with a functional CLI tool, you are free to deploy Kubernetes-ready applications.</p>
   <p>Start with a multi-tier web application (Guestbook) from the official Kubernetes documentation to visualize how the various Kubernetes components fit together.</p>
-  <a href="https://github.com/kubernetes/kubernetes/blob/release-1.1/examples/guestbook-go/README.md" class="btn btn-default btn-icon-right" data-category="Docs Next" data-event="kubernetes.io: Guestbook">Deploy the Guestbook Sample app</a>
+  <a href="https://github.com/kubernetes/kubernetes/blob/release-1.2/examples/guestbook/README.md" class="btn btn-default btn-icon-right" data-category="Docs Next" data-event="kubernetes.io: Guestbook">Deploy the Guestbook Sample app</a>
 </div>

--- a/Documentation/deploy-addons.md
+++ b/Documentation/deploy-addons.md
@@ -6,7 +6,7 @@ Add-ons are built on the same Kubernetes components as user-submitted jobs &mdas
 
 First create `dns-addon.yml` on your local machine and replace the variable. There is a lot going on in there, so let's break it down after you create it.
 
-[k8s-dns]: http://kubernetes.io/v1.1/docs/admin/dns.html
+[k8s-dns]: http://kubernetes.io/docs/admin/dns.html
 
 * Replace `${DNS_SERVICE_IP}`
 
@@ -39,29 +39,32 @@ spec:
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: kube-dns-v9
+  name: kube-dns-v11
   namespace: kube-system
   labels:
     k8s-app: kube-dns
-    version: v9
+    version: v11
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
   selector:
     k8s-app: kube-dns
-    version: v9
+    version: v11
   template:
     metadata:
       labels:
         k8s-app: kube-dns
-        version: v9
+        version: v11
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
       - name: etcd
-        image: gcr.io/google_containers/etcd:2.0.9
+        image: gcr.io/google_containers/etcd-amd64:2.2.1
         resources:
           limits:
+            cpu: 100m
+            memory: 500Mi
+          requests:
             cpu: 100m
             memory: 50Mi
         command:
@@ -78,24 +81,47 @@ spec:
         - name: etcd-storage
           mountPath: /var/etcd/data
       - name: kube2sky
-        image: gcr.io/google_containers/kube2sky:1.11
+        image: gcr.io/google_containers/kube2sky:1.14
         resources:
           limits:
             cpu: 100m
+            memory: 200Mi
+          requests:
+            cpu: 100m
             memory: 50Mi
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
         args:
         # command = "/kube2sky"
-        - -domain=cluster.local
+        - --domain=cluster.local
       - name: skydns
-        image: gcr.io/google_containers/skydns:2015-03-11-001
+        image: gcr.io/google_containers/skydns:2015-10-13-8c72f8c
         resources:
           limits:
+            cpu: 100m
+            memory: 200Mi
+          requests:
             cpu: 100m
             memory: 50Mi
         args:
         # command = "/skydns"
-        - -machines=http://localhost:4001
+        - -machines=http://127.0.0.1:4001
         - -addr=0.0.0.0:53
+        - -ns-rotate=false
         - -domain=cluster.local.
         ports:
         - containerPort: 53
@@ -104,24 +130,13 @@ spec:
         - containerPort: 53
           name: dns-tcp
           protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 30
-          timeoutSeconds: 5
-        readinessProbe:
-          httpGet:
-            path: /healthz
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 1
-          timeoutSeconds: 5
       - name: healthz
         image: gcr.io/google_containers/exechealthz:1.0
         resources:
           limits:
+            cpu: 10m
+            memory: 20Mi
+          requests:
             cpu: 10m
             memory: 20Mi
         args:
@@ -148,10 +163,10 @@ Next, start the DNS add-on:
 $ kubectl create -f dns-addon.yml
 ```
 
-And check for `kube-dns-v9-*` pod up and running:
+And check for `kube-dns-v11-*` pod up and running:
 
 ```sh
-$ kubectl get pods --namespace=kube-system | grep kube-dns-v9
+$ kubectl get pods --namespace=kube-system | grep kube-dns-v11
 ```
 
 <div class="co-m-docs-next-step">

--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -87,7 +87,7 @@ After=flanneld.service
 
 ### Create the kubelet Unit
 
-The [kubelet](http://kubernetes.io/v1.1/docs/admin/kubelet.html) is the agent on each machine that starts and stops Pods and other machine-level tasks. The kubelet communicates with the API server (also running on the master nodes) with the TLS certificates we placed on disk earlier.
+The [kubelet](http://kubernetes.io/docs/admin/kubelet.html) is the agent on each machine that starts and stops Pods and other machine-level tasks. The kubelet communicates with the API server (also running on the master nodes) with the TLS certificates we placed on disk earlier.
 
 On the master node, the kubelet is configured to communicate with the API server, but not register for cluster work, as shown in the `--register-node=false` line in the YAML excerpt below. This prevents user pods being scheduled on the master nodes, and ensures cluster work is routed only to task-specific worker nodes.
 
@@ -142,7 +142,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-apiserver
-    image: quay.io/coreos/hyperkube:v1.1.8_coreos.0
+    image: quay.io/coreos/hyperkube:v1.2.0_coreos.1
     command:
     - /hyperkube
     - apiserver
@@ -200,7 +200,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-proxy
-    image: quay.io/coreos/hyperkube:v1.1.8_coreos.0
+    image: quay.io/coreos/hyperkube:v1.2.0_coreos.1
     command:
     - /hyperkube
     - proxy
@@ -302,7 +302,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-controller-manager
-    image: quay.io/coreos/hyperkube:v1.1.8_coreos.0
+    image: quay.io/coreos/hyperkube:v1.2.0_coreos.1
     command:
     - /hyperkube
     - controller-manager
@@ -350,7 +350,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-scheduler
-    image: quay.io/coreos/hyperkube:v1.1.8_coreos.0
+    image: quay.io/coreos/hyperkube:v1.2.0_coreos.1
     command:
     - /hyperkube
     - scheduler

--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -89,7 +89,7 @@ After=flanneld.service
 
 The [kubelet](http://kubernetes.io/docs/admin/kubelet.html) is the agent on each machine that starts and stops Pods and other machine-level tasks. The kubelet communicates with the API server (also running on the master nodes) with the TLS certificates we placed on disk earlier.
 
-On the master node, the kubelet is configured to communicate with the API server, but not register for cluster work, as shown in the `--register-node=false` line in the YAML excerpt below. This prevents user pods being scheduled on the master nodes, and ensures cluster work is routed only to task-specific worker nodes.
+On the master node, the kubelet is configured to communicate with the API server, but not register for cluster work, as shown in the `--register-schedulable=false` line in the YAML excerpt below. This prevents user pods being scheduled on the master nodes, and ensures cluster work is routed only to task-specific worker nodes.
 
 Note that the kubelet running on a master node may log repeated attempts to post its status to the API server. These warnings are expected behavior and can be ignored. Future Kubernetes releases plan to [handle this common deployment consideration more gracefully](https://github.com/kubernetes/kubernetes/issues/14140#issuecomment-142126864).
 
@@ -106,7 +106,7 @@ ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
 Environment=KUBELET_VERSION=${K8S_VER}
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=http://127.0.0.1:8080 \
-  --register-node=false \
+  --register-schedulable=false \
   --allow-privileged=true \
   --config=/etc/kubernetes/manifests \
   --hostname-override=${ADVERTISE_IP} \

--- a/Documentation/deploy-workers.md
+++ b/Documentation/deploy-workers.md
@@ -124,7 +124,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-proxy
-    image: quay.io/coreos/hyperkube:v1.1.8_coreos.0
+    image: quay.io/coreos/hyperkube:v1.2.0_coreos.1
     command:
     - /hyperkube
     - proxy

--- a/Documentation/kubelet-wrapper.md
+++ b/Documentation/kubelet-wrapper.md
@@ -19,7 +19,7 @@ An example systemd kubelet.service file which takes advantage of the kubelet-wra
 
 ```yaml
 [Service]
-Environment=KUBELET_VERSION=v1.1.8_coreos.0
+Environment=KUBELET_VERSION=v1.2.0_coreos.1
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=http://127.0.0.1:8080 \
   --config=/etc/kubernetes/manifests
@@ -40,7 +40,7 @@ For example:
 
 ```yaml
 [Service]
-Environment=KUBELET_VERSION=v1.1.8_coreos.0
+Environment=KUBELET_VERSION=v1.2.0_coreos.1
 ExecStart=/opt/bin/kubelet-wrapper \
   --api-servers=http://127.0.0.1:8080 \
   --config=/etc/kubernetes/manifests

--- a/Documentation/kubernetes-networking.md
+++ b/Documentation/kubernetes-networking.md
@@ -15,7 +15,7 @@ The Kubernetes network model outlines four methods of component communication:
 
 See [Kubernetes Networking][kubernetes-network] for more detailed information on the Kubernetes network model and motiviation.
 
-[kubernetes-network]: http://kubernetes.io/v1.1/docs/admin/networking.html
+[kubernetes-network]: http://kubernetes.io/docs/admin/networking.html
 
 ## Port allocation
 
@@ -44,7 +44,7 @@ etcd Node Inbound
 | TCP      | 2379-2380  | Master Nodes  | etcd server client API                                   |
 | TCP      | 2379-2380  | Worker Nodes  | etcd server client API (only required if using flannel). |
 
-[external-service]: http://kubernetes.io/v1.1/docs/user-guide/services.html#external-services
+[external-service]: http://kubernetes.io/docs/user-guide/services/#publishing-services---service-types
 
 ## Advanced Configuration
 
@@ -76,7 +76,7 @@ The actual allocation of Pod IPs on the host can be achieved by configuring Dock
 
 To achieve this network model, there are various methods that can be used. See the [Kubernetes Networking][how-to-achieve] documentation for more detail.
 
-[how-to-achieve]: http://kubernetes.io/v1.1/docs/admin/networking.html#how-to-achieve-this
+[how-to-achieve]: http://kubernetes.io/docs/admin/networking.html#how-to-achieve-this
 
 ### Pod-to-Service Communication
 
@@ -90,5 +90,5 @@ IP addresses assigned on the pod network are typically not routable outside of t
 
 In a manually configured network, it may be necessary to open a range of ports to outside clients (default 30000-32767) for use with "external services". See the [Kubernetes Service][kube-service] documentation for more information on external services.
 
-[kube-service]: http://kubernetes.io/v1.1/docs/user-guide/services.html#external-services
+[kube-service]: http://kubernetes.io/docs/user-guide/services/#publishing-services---service-types
 

--- a/Documentation/kubernetes-on-baremetal.md
+++ b/Documentation/kubernetes-on-baremetal.md
@@ -29,7 +29,7 @@ However, bare metal is a common platform where a self-managed network is used, d
 See the [Kubernetes networking](kubernetes-networking.md) documentation for more information on self-managed networking options.
 
 [coreos-flannel]: https://coreos.com/flannel/docs/latest/flannel-config.html
-[pod-network]: http://kubernetes.io/v1.1/docs/design/networking.html#pod-to-pod
+[pod-network]: https://github.com/kubernetes/kubernetes/blob/release-1.2/docs/design/networking.md#pod-to-pod
 
 <div class="co-m-docs-next-step">
   <p><strong>Did you install CoreOS on your machines?</strong> An SSH connection to each machine is all that's needed. We'll start the configuration next.</p>

--- a/Documentation/kubernetes-on-vagrant-single.md
+++ b/Documentation/kubernetes-on-vagrant-single.md
@@ -19,13 +19,13 @@ Navigate to the [Vagrant downloads page][vagrant-downloads] and grab the appropr
 The linux `kubectl` binary can be fetched with a command like:
 
 ```sh
-$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.1.8/bin/linux/amd64/kubectl
+$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.2.0/bin/linux/amd64/kubectl
 ```
 
 On an OS X workstation, replace `linux` in the URL above with `darwin`:
 
 ```sh
-$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.1.8/bin/darwin/amd64/kubectl
+$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.2.0/bin/darwin/amd64/kubectl
 ```
 
 After downloading the binary, ensure it is executable and move it into your PATH:
@@ -82,6 +82,6 @@ NAME          LABELS                               STATUS
 <div class="co-m-docs-next-step">
   <p><strong>Is kubectl working correctly?</strong></p>
   <p>Now that you've got a working Kubernetes cluster with a functional CLI tool, you are free to deploy Kubernetes-ready applications.
-Start with a <a href="https://github.com/kubernetes/kubernetes/blob/release-1.1/examples/guestbook-go/README.md" data-category="Docs Next" data-event="kubernetes.io: Guestbook">multi-tier web application</a> from the official Kubernetes documentation to visualize how the various Kubernetes components fit together.</p>
-  <a href="https://github.com/kubernetes/kubernetes/blob/release-1.1/examples/guestbook-go/README.md" class="btn btn-default btn-icon-right" data-category="Docs Next" data-event="kubernetes.io: Guestbook">View the Guestbook example app</a>
+Start with a <a href="https://github.com/kubernetes/kubernetes/blob/release-1.2/examples/guestbook/README.md" data-category="Docs Next" data-event="kubernetes.io: Guestbook">multi-tier web application</a> from the official Kubernetes documentation to visualize how the various Kubernetes components fit together.</p>
+  <a href="https://github.com/kubernetes/kubernetes/blob/release-1.2/examples/guestbook/README.md" class="btn btn-default btn-icon-right" data-category="Docs Next" data-event="kubernetes.io: Guestbook">View the Guestbook example app</a>
 </div>

--- a/Documentation/kubernetes-on-vagrant.md
+++ b/Documentation/kubernetes-on-vagrant.md
@@ -18,13 +18,13 @@ Navigate to the [Vagrant downloads page][vagrant-downloads] and grab the appropr
 The linux `kubectl` binary can be fetched with a command like:
 
 ```sh
-$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.1.8/bin/linux/amd64/kubectl
+$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.2.0/bin/linux/amd64/kubectl
 ```
 
 On an OS X workstation, replace `linux` in the URL above with `darwin`:
 
 ```sh
-$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.1.8/bin/darwin/amd64/kubectl
+$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.2.0/bin/darwin/amd64/kubectl
 ```
 
 After downloading the binary, ensure it is executable and move it into your PATH:
@@ -95,6 +95,6 @@ NAME          LABELS                               STATUS
 <div class="co-m-docs-next-step">
   <p><strong>Is kubectl working correctly?</strong></p>
   <p>Now that you've got a working Kubernetes cluster with a functional CLI tool, you are free to deploy Kubernetes-ready applications.
-Start with a <a href="https://github.com/kubernetes/kubernetes/blob/release-1.1/examples/guestbook-go/README.md" data-category="Docs Next" data-event="kubernetes.io: Guestbook">multi-tier web application</a> from the official Kubernetes documentation to visualize how the various Kubernetes components fit together.</p>
-  <a href="https://github.com/kubernetes/kubernetes/blob/release-1.1/examples/guestbook-go/README.md" class="btn btn-default btn-icon-right" data-category="Docs Next" data-event="kubernetes.io: Guestbook">View the Guestbook example app</a>
+Start with a <a href="https://github.com/kubernetes/kubernetes/blob/release-1.2/examples/guestbook/README.md" data-category="Docs Next" data-event="kubernetes.io: Guestbook">multi-tier web application</a> from the official Kubernetes documentation to visualize how the various Kubernetes components fit together.</p>
+  <a href="https://github.com/kubernetes/kubernetes/blob/release-1.2/examples/guestbook/README.md" class="btn btn-default btn-icon-right" data-category="Docs Next" data-event="kubernetes.io: Guestbook">View the Guestbook example app</a>
 </div>

--- a/Documentation/kubernetes-upgrade.md
+++ b/Documentation/kubernetes-upgrade.md
@@ -1,6 +1,6 @@
 # Upgrading Kubernetes
 
-This document describes upgrading the Kubernetes components on a cluster's master and worker nodes. For general information on Kubernetes cluster management, upgrades (including more advanced topics such as major API version upgrades) see the [Kubernetes upstream documentation](http://kubernetes.io/v1.1/docs/admin/cluster-management.html) and [version upgrade notes](http://kubernetes.io/v1.1/docs/design/versioning.html#upgrades)
+This document describes upgrading the Kubernetes components on a cluster's master and worker nodes. For general information on Kubernetes cluster management, upgrades (including more advanced topics such as major API version upgrades) see the [Kubernetes upstream documentation](http://kubernetes.io/docs/admin/cluster-management.html) and [version upgrade notes](https://github.com/kubernetes/kubernetes/blob/release-1.2/docs/design/versioning.md#upgrades)
 
 **NOTE:** The following upgrade documentation is for installations based on the CoreOS + Kubernetes step-by-step [installation guide](https://coreos.com/kubernetes/docs/latest/getting-started.html). Upgrade documentation for the AWS cloud-formation based installation is forthcoming.
 
@@ -15,7 +15,7 @@ For example, modifying the `KUBELET_VERSION` environment variable in the followi
 **/etc/systemd/system/kubelet.service**
 
 ```
-Environment=KUBELET_VERSION=v1.1.8_coreos.0
+Environment=KUBELET_VERSION=v1.2.0_coreos.1
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=https://master [...]
 ```

--- a/multi-node/aws/README.md
+++ b/multi-node/aws/README.md
@@ -30,7 +30,7 @@ export AWS_SECRET_ACCESS_KEY=MY-SECRET-KEY
 Creating a KMS key can be done via the AWS web console or via the AWS cli tool.
 
 ```shell
-$ aws kms --region=<your-region> create-key --description="kube-aws assets"
+$ aws kms --region=us-west-1 create-key --description="kube-aws assets"
 {
     "KeyMetadata": {
         "CreationDate": 1458235139.724,
@@ -54,7 +54,7 @@ $ kube-aws init --cluster-name=my-cluster-name \
 --external-dns-name=my-cluster-endpoint \
 --region=us-west-1 \
 --availability-zone=us-west-1c \
---key-name=key-pair-name \
+--key-name=<key-pair-name> \
 --kms-key-arn="arn:aws:kms:us-west-1:xxxxxxxxxx:key/xxxxxxxxxxxxxxxxxxx"
 ```
 

--- a/multi-node/aws/pkg/config/config.go
+++ b/multi-node/aws/pkg/config/config.go
@@ -36,7 +36,7 @@ func newDefaultCluster() *Cluster {
 		PodCIDR:                  "10.2.0.0/16",
 		ServiceCIDR:              "10.3.0.0/24",
 		DNSServiceIP:             "10.3.0.10",
-		K8sVer:                   "v1.1.8_coreos.0",
+		K8sVer:                   "v1.2.0_coreos.1",
 		HyperkubeImageRepo:       "quay.io/coreos/hyperkube",
 		ControllerInstanceType:   "m3.medium",
 		ControllerRootVolumeSize: 30,

--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -326,23 +326,23 @@ write_files:
             "labels": {
               "k8s-app": "kube-dns",
               "kubernetes.io/cluster-service": "true",
-              "version": "v9"
+              "version": "v11"
             },
-            "name": "kube-dns-v9",
+            "name": "kube-dns-v11",
             "namespace": "kube-system"
           },
           "spec": {
             "replicas": 1,
             "selector": {
               "k8s-app": "kube-dns",
-              "version": "v9"
+              "version": "v11"
             },
             "template": {
               "metadata": {
                 "labels": {
                   "k8s-app": "kube-dns",
                   "kubernetes.io/cluster-service": "true",
-                  "version": "v9"
+                  "version": "v11"
                 }
               },
               "spec": {
@@ -359,9 +359,13 @@ write_files:
                       "-initial-cluster-token",
                       "skydns-etcd"
                     ],
-                    "image": "gcr.io/google_containers/etcd:2.0.9",
+                    "image": "gcr.io/google_containers/etcd-amd64:2.2.1",
                     "name": "etcd",
                     "resources": {
+                      "requests": {
+                        "cpu": "100m", 
+                        "memory": "50Mi"
+                      }, 
                       "limits": {
                         "cpu": "100m",
                         "memory": "50Mi"
@@ -376,14 +380,38 @@ write_files:
                   },
                   {
                     "args": [
-                      "-domain=cluster.local"
+                      "--domain=cluster.local"
                     ],
-                    "image": "gcr.io/google_containers/kube2sky:1.11",
+                    "image": "gcr.io/google_containers/kube2sky:1.14",
                     "name": "kube2sky",
+                    "livenessProbe": {
+                      "successThreshold": 1, 
+                      "initialDelaySeconds": 60, 
+                      "httpGet": {
+                        "path": "/healthz", 
+                        "scheme": "HTTP", 
+                        "port": 8080
+                      }, 
+                      "timeoutSeconds": 5, 
+                      "failureThreshold": 5
+                    }, 
+                    "readinessProbe": {
+                      "initialDelaySeconds": 30, 
+                      "httpGet": {
+                        "path": "/readiness", 
+                        "scheme": "HTTP", 
+                        "port": 8081
+                      }, 
+                      "timeoutSeconds": 5
+                    }, 
                     "resources": {
+                      "requests": {
+                        "cpu": "100m", 
+                        "memory": "50Mi"
+                      }, 
                       "limits": {
                         "cpu": "100m",
-                        "memory": "50Mi"
+                        "memory": "200Mi"
                       }
                     }
                   },
@@ -391,9 +419,10 @@ write_files:
                     "args": [
                       "-machines=http://localhost:4001",
                       "-addr=0.0.0.0:53",
+                      "-ns-rotate=false", 
                       "-domain=cluster.local."
                     ],
-                    "image": "gcr.io/google_containers/skydns:2015-03-11-001",
+                    "image": "gcr.io/google_containers/skydns:2015-10-13-8c72f8c",
                     "livenessProbe": {
                       "httpGet": {
                         "path": "/healthz",
@@ -416,19 +445,14 @@ write_files:
                         "protocol": "TCP"
                       }
                     ],
-                    "readinessProbe": {
-                      "httpGet": {
-                        "path": "/healthz",
-                        "port": 8080,
-                        "scheme": "HTTP"
-                      },
-                      "initialDelaySeconds": 1,
-                      "timeoutSeconds": 5
-                    },
                     "resources": {
+                      "requests": {
+                        "cpu": "100m", 
+                        "memory": "50Mi"
+                      }, 
                       "limits": {
                         "cpu": "100m",
-                        "memory": "50Mi"
+                        "memory": "200Mi"
                       }
                     }
                   },
@@ -446,6 +470,10 @@ write_files:
                       }
                     ],
                     "resources": {
+                      "requests": {
+                        "cpu": "10m", 
+                        "memory": "20Mi"
+                      }, 
                       "limits": {
                         "cpu": "10m",
                         "memory": "20Mi"

--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -41,7 +41,7 @@ coreos:
         Environment=KUBELET_ACI={{.HyperkubeImageRepo}}
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
         --api-servers=http://localhost:8080 \
-        --register-node=false \
+        --register-schedulable=false \
         --allow-privileged=true \
         --config=/etc/kubernetes/manifests \
         --cluster_dns={{.DNSServiceIP}} \

--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -193,55 +193,6 @@ write_files:
             path: /usr/share/ca-certificates
           name: ssl-certs-host
 
-  - path: /etc/kubernetes/manifests/kube-podmaster.yaml
-    content: |
-      apiVersion: v1
-      kind: Pod
-      metadata:
-        name: kube-podmaster
-        namespace: kube-system
-      spec:
-        hostNetwork: true
-        containers:
-        - name: scheduler-elector
-          image: gcr.io/google_containers/podmaster:1.1
-          command:
-          - /podmaster
-          - --etcd-servers=http://localhost:2379
-          - --key=scheduler
-          - --whoami=$private_ipv4
-          - --source-file=/src/manifests/kube-scheduler.yaml
-          - --dest-file=/dst/manifests/kube-scheduler.yaml
-          volumeMounts:
-          - mountPath: /src/manifests
-            name: manifest-src
-            readOnly: true
-          - mountPath: /dst/manifests
-            name: manifest-dst
-        - name: controller-manager-elector
-          image: gcr.io/google_containers/podmaster:1.1
-          command:
-          - /podmaster
-          - --etcd-servers=http://localhost:2379
-          - --key=controller
-          - --whoami=$private_ipv4
-          - --source-file=/src/manifests/kube-controller-manager.yaml
-          - --dest-file=/dst/manifests/kube-controller-manager.yaml
-          terminationMessagePath: /dev/termination-log
-          volumeMounts:
-          - mountPath: /src/manifests
-            name: manifest-src
-            readOnly: true
-          - mountPath: /dst/manifests
-            name: manifest-dst
-        volumes:
-        - hostPath:
-            path: /srv/kubernetes/manifests
-          name: manifest-src
-        - hostPath:
-            path: /etc/kubernetes/manifests
-          name: manifest-dst
-
   - path: /etc/kubernetes/manifests/kube-controller-manager.yaml
     content: |
       apiVersion: v1
@@ -257,6 +208,7 @@ write_files:
           - /hyperkube
           - controller-manager
           - --master=http://127.0.0.1:8080
+          - --leader-elect=true
           - --service-account-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
           - --root-ca-file=/etc/kubernetes/ssl/ca.pem
           - --cloud-provider=aws
@@ -299,6 +251,7 @@ write_files:
           - /hyperkube
           - scheduler
           - --master=http://127.0.0.1:8080
+          - --leader-elect=true
           livenessProbe:
             httpGet:
               host: 127.0.0.1

--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -39,6 +39,7 @@ coreos:
         [Service]
         Environment=KUBELET_VERSION={{.K8sVer}}
         Environment=KUBELET_ACI={{.HyperkubeImageRepo}}
+        Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf --mount volume=dns,target=/etc/resolv.conf"
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
         --api-servers=http://localhost:8080 \
         --register-schedulable=false \

--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -91,12 +91,12 @@ write_files:
       #!/bin/bash -e
       /usr/bin/curl -H "Content-Type: application/json" -XPOST -d @"/srv/kubernetes/manifests/kube-system.json" "http://127.0.0.1:8080/api/v1/namespaces"
 
-      for manifest in {kube-dns,heapster,influxdb}-rc.json;do
+      for manifest in {kube-dns,heapster}-rc.json;do
           /usr/bin/curl  -H "Content-Type: application/json" -XPOST \
           -d @"/srv/kubernetes/manifests/$manifest" \
           "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers"
       done
-      for manifest in {kube-dns,heapster,influxdb}-svc.json;do
+      for manifest in {kube-dns,heapster}-svc.json;do
           /usr/bin/curl  -H "Content-Type: application/json" -XPOST \
           -d @"/srv/kubernetes/manifests/$manifest" \
           "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services"
@@ -315,11 +315,11 @@ write_files:
                     "image": "gcr.io/google_containers/etcd-amd64:2.2.1",
                     "name": "etcd",
                     "resources": {
-                      "requests": {
-                        "cpu": "100m", 
-                        "memory": "50Mi"
-                      }, 
                       "limits": {
+                        "cpu": "100m",
+                        "memory": "500Mi"
+                      },
+                      "requests": {
                         "cpu": "100m",
                         "memory": "50Mi"
                       }
@@ -336,55 +336,46 @@ write_files:
                       "--domain=cluster.local"
                     ],
                     "image": "gcr.io/google_containers/kube2sky:1.14",
-                    "name": "kube2sky",
                     "livenessProbe": {
-                      "successThreshold": 1, 
-                      "initialDelaySeconds": 60, 
-                      "httpGet": {
-                        "path": "/healthz", 
-                        "scheme": "HTTP", 
-                        "port": 8080
-                      }, 
-                      "timeoutSeconds": 5, 
-                      "failureThreshold": 5
-                    }, 
-                    "readinessProbe": {
-                      "initialDelaySeconds": 30, 
-                      "httpGet": {
-                        "path": "/readiness", 
-                        "scheme": "HTTP", 
-                        "port": 8081
-                      }, 
-                      "timeoutSeconds": 5
-                    }, 
-                    "resources": {
-                      "requests": {
-                        "cpu": "100m", 
-                        "memory": "50Mi"
-                      }, 
-                      "limits": {
-                        "cpu": "100m",
-                        "memory": "200Mi"
-                      }
-                    }
-                  },
-                  {
-                    "args": [
-                      "-machines=http://localhost:4001",
-                      "-addr=0.0.0.0:53",
-                      "-ns-rotate=false", 
-                      "-domain=cluster.local."
-                    ],
-                    "image": "gcr.io/google_containers/skydns:2015-10-13-8c72f8c",
-                    "livenessProbe": {
+                      "failureThreshold": 5,
                       "httpGet": {
                         "path": "/healthz",
                         "port": 8080,
                         "scheme": "HTTP"
                       },
+                      "initialDelaySeconds": 60,
+                      "successThreshold": 1,
+                      "timeoutSeconds": 5
+                    },
+                    "name": "kube2sky",
+                    "readinessProbe": {
+                      "httpGet": {
+                        "path": "/readiness",
+                        "port": 8081,
+                        "scheme": "HTTP"
+                      },
                       "initialDelaySeconds": 30,
                       "timeoutSeconds": 5
                     },
+                    "resources": {
+                      "limits": {
+                        "cpu": "100m",
+                        "memory": "200Mi"
+                      },
+                      "requests": {
+                        "cpu": "100m",
+                        "memory": "50Mi"
+                      }
+                    }
+                  },
+                  {
+                    "args": [
+                      "-machines=http://127.0.0.1:4001",
+                      "-addr=0.0.0.0:53",
+                      "-ns-rotate=false",
+                      "-domain=cluster.local."
+                    ],
+                    "image": "gcr.io/google_containers/skydns:2015-10-13-8c72f8c",
                     "name": "skydns",
                     "ports": [
                       {
@@ -399,19 +390,19 @@ write_files:
                       }
                     ],
                     "resources": {
-                      "requests": {
-                        "cpu": "100m", 
-                        "memory": "50Mi"
-                      }, 
                       "limits": {
                         "cpu": "100m",
                         "memory": "200Mi"
+                      },
+                      "requests": {
+                        "cpu": "100m",
+                        "memory": "50Mi"
                       }
                     }
                   },
                   {
                     "args": [
-                      "-cmd=nslookup kubernetes.default.svc.cluster.local localhost",
+                      "-cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1 >/dev/null",
                       "-port=8080"
                     ],
                     "image": "gcr.io/google_containers/exechealthz:1.0",
@@ -423,11 +414,11 @@ write_files:
                       }
                     ],
                     "resources": {
-                      "requests": {
-                        "cpu": "10m", 
-                        "memory": "20Mi"
-                      }, 
                       "limits": {
+                        "cpu": "10m",
+                        "memory": "20Mi"
+                      },
+                      "requests": {
                         "cpu": "10m",
                         "memory": "20Mi"
                       }
@@ -486,50 +477,45 @@ write_files:
           "apiVersion": "v1",
           "kind": "ReplicationController",
           "metadata": {
-            "name": "heapster-v10",
-            "namespace": "kube-system",
             "labels": {
               "k8s-app": "heapster",
-              "version": "v10",
               "kubernetes.io/cluster-service": "true"
-            }
+            },
+            "name": "heapster-v1.0.2",
+            "namespace": "kube-system"
           },
           "spec": {
             "replicas": 1,
             "selector": {
-              "k8s-app": "heapster",
-              "version": "v10"
+              "k8s-app": "heapster"
             },
             "template": {
               "metadata": {
                 "labels": {
                   "k8s-app": "heapster",
-                  "version": "v10",
                   "kubernetes.io/cluster-service": "true"
                 }
               },
               "spec": {
                 "containers": [
                   {
-                    "image": "gcr.io/google_containers/heapster:v0.18.2",
+                    "command": [
+                      "/heapster",
+                      "--source=kubernetes.summary_api:''",
+                      "--metric_resolution=60s"
+                    ],
+                    "image": "gcr.io/google_containers/heapster:v1.0.2",
                     "name": "heapster",
                     "resources": {
                       "limits": {
                         "cpu": "100m",
-                        "memory": "224Mi"
+                        "memory": "208Mi"
                       },
                       "requests": {
                         "cpu": "100m",
-                        "memory": "224Mi"
+                        "memory": "208Mi"
                       }
-                    },
-                    "command": [
-                      "/heapster",
-                      "--source=kubernetes:''",
-                      "--sink=influxdb:http://monitoring-influxdb:8086",
-                      "--stats_resolution=30s",
-                      "--sink_frequency=1m"
-                    ]
+                    }
                   }
                 ]
               }
@@ -559,110 +545,6 @@ write_files:
             ],
             "selector": {
               "k8s-app": "heapster"
-            }
-          }
-        }
-
-  - path: /srv/kubernetes/manifests/influxdb-rc.json
-    content: |
-        {
-          "apiVersion": "v1",
-          "kind": "ReplicationController",
-          "metadata": {
-            "name": "monitoring-influxdb-v2",
-            "namespace": "kube-system",
-            "labels": {
-              "k8s-app": "influxdb",
-              "version": "v2",
-              "kubernetes.io/cluster-service": "true"
-            }
-          },
-          "spec": {
-            "replicas": 1,
-            "selector": {
-              "k8s-app": "influxdb",
-              "version": "v2"
-            },
-            "template": {
-              "metadata": {
-                "labels": {
-                  "k8s-app": "influxdb",
-                  "version": "v2",
-                  "kubernetes.io/cluster-service": "true"
-                }
-              },
-              "spec": {
-                "containers": [
-                  {
-                    "image": "gcr.io/google_containers/heapster_influxdb:v0.4",
-                    "name": "influxdb",
-                    "resources": {
-                      "limits": {
-                        "cpu": "100m",
-                        "memory": "200Mi"
-                      },
-                      "requests": {
-                        "cpu": "100m",
-                        "memory": "200Mi"
-                      }
-                    },
-                    "ports": [
-                      {
-                        "containerPort": 8083,
-                        "hostPort": 8083
-                      },
-                      {
-                        "containerPort": 8086,
-                        "hostPort": 8086
-                      }
-                    ],
-                    "volumeMounts": [
-                      {
-                        "name": "influxdb-persistent-storage",
-                        "mountPath": "/data"
-                      }
-                    ]
-                  }
-                ],
-                "volumes": [
-                  {
-                    "name": "influxdb-persistent-storage",
-                    "emptyDir": {}
-                  }
-                ]
-              }
-            }
-          }
-        }
-
-  - path: /srv/kubernetes/manifests/influxdb-svc.json
-    content: |
-        {
-          "apiVersion": "v1",
-          "kind": "Service",
-          "metadata": {
-            "name": "monitoring-influxdb",
-            "namespace": "kube-system",
-            "labels": {
-              "kubernetes.io/cluster-service": "true",
-              "kubernetes.io/name": "InfluxDB"
-            }
-          },
-          "spec": {
-            "ports": [
-              {
-                "name": "http",
-                "port": 8083,
-                "targetPort": 8083
-              },
-              {
-                "name": "api",
-                "port": 8086,
-                "targetPort": 8086
-              }
-            ],
-            "selector": {
-              "k8s-app": "influxdb"
             }
           }
         }

--- a/multi-node/aws/pkg/config/templates/cloud-config-worker
+++ b/multi-node/aws/pkg/config/templates/cloud-config-worker
@@ -25,6 +25,7 @@ coreos:
         [Service]
         Environment=KUBELET_VERSION={{.K8sVer}}
         Environment=KUBELET_ACI={{.HyperkubeImageRepo}}
+        Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf --mount volume=dns,target=/etc/resolv.conf"
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
         --api-servers={{.SecureAPIServers}} \
         --register-node=true \

--- a/multi-node/aws/pkg/config/templates/cluster.yaml
+++ b/multi-node/aws/pkg/config/templates/cluster.yaml
@@ -59,7 +59,7 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # dnsServiceIP: 10.3.0.10
 
 # Version of hyperkube image to use. This is the tag for the hyperkube image repository.
-# kubernetesVersion: v1.1.8_coreos.0
+# kubernetesVersion: v1.2.0_coreos.1
 
 # Hyperkube image repository to use.
 # hyperkubeImageRepo: quay.io/coreos/hyperkube

--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -285,176 +285,167 @@ EOF
         cat << EOF > $TEMPLATE
 {
   "apiVersion": "v1",
-   "kind": "ReplicationController",
-   "metadata": {
-     "labels": {
-       "k8s-app": "kube-dns",
-       "kubernetes.io/cluster-service": "true",
-       "version": "v11"
-     },
-     "name": "kube-dns-v11",
-     "namespace": "kube-system"
-   },
-   "spec": {
-     "replicas": 1,
-     "selector": {
-       "k8s-app": "kube-dns",
-       "version": "v11"
-     },
-     "template": {
-       "metadata": {
-         "labels": {
-           "k8s-app": "kube-dns",
-           "kubernetes.io/cluster-service": "true",
-           "version": "v11"
-         }
-       },
-       "spec": {
-         "containers": [
-           {
-             "command": [
-               "/usr/local/bin/etcd",
-               "-data-dir",
-               "/var/etcd/data",
-               "-listen-client-urls",
-               "http://127.0.0.1:2379,http://127.0.0.1:4001",
-               "-advertise-client-urls",
-               "http://127.0.0.1:2379,http://127.0.0.1:4001",
-               "-initial-cluster-token",
-               "skydns-etcd"
-             ],
-             "image": "gcr.io/google_containers/etcd-amd64:2.2.1",
-             "name": "etcd",
-             "resources": {
-               "requests": {
-                 "cpu": "100m", 
-                 "memory": "50Mi"
-               }, 
-               "limits": {
-                 "cpu": "100m",
-                 "memory": "50Mi"
-               }
-             },
-             "volumeMounts": [
-               {
-                 "mountPath": "/var/etcd/data",
-                 "name": "etcd-storage"
-               }
-             ]
-           },
-           {
-             "args": [
-               "--domain=cluster.local"
-             ],
-             "image": "gcr.io/google_containers/kube2sky:1.14",
-             "name": "kube2sky",
-             "livenessProbe": {
-               "successThreshold": 1, 
-               "initialDelaySeconds": 60, 
-               "httpGet": {
-                 "path": "/healthz", 
-                 "scheme": "HTTP", 
-                 "port": 8080
-               }, 
-               "timeoutSeconds": 5, 
-               "failureThreshold": 5
-             }, 
-             "readinessProbe": {
-               "initialDelaySeconds": 30, 
-               "httpGet": {
-                 "path": "/readiness", 
-                 "scheme": "HTTP", 
-                 "port": 8081
-               }, 
-               "timeoutSeconds": 5
-             }, 
-             "resources": {
-               "requests": {
-                 "cpu": "100m", 
-                 "memory": "50Mi"
-               }, 
-               "limits": {
-                 "cpu": "100m",
-                 "memory": "200Mi"
-               }
-             }
-           },
-           {
-             "args": [
-               "-machines=http://localhost:4001",
-               "-addr=0.0.0.0:53",
-               "-ns-rotate=false", 
-               "-domain=cluster.local."
-             ],
-             "image": "gcr.io/google_containers/skydns:2015-10-13-8c72f8c",
-             "livenessProbe": {
-               "httpGet": {
-                 "path": "/healthz",
-                 "port": 8080,
-                 "scheme": "HTTP"
-               },
-               "initialDelaySeconds": 30,
-               "timeoutSeconds": 5
-             },
-             "name": "skydns",
-             "ports": [
-               {
-                 "containerPort": 53,
-                 "name": "dns",
-                 "protocol": "UDP"
-               },
-               {
-                 "containerPort": 53,
-                 "name": "dns-tcp",
-                 "protocol": "TCP"
-               }
-             ],
-             "resources": {
-               "requests": {
-                 "cpu": "100m", 
-                 "memory": "50Mi"
-               }, 
-               "limits": {
-                 "cpu": "100m",
-                 "memory": "200Mi"
-               }
-             }
-           },
-           {
-             "args": [
-               "-cmd=nslookup kubernetes.default.svc.cluster.local localhost",
-               "-port=8080"
-             ],
-             "image": "gcr.io/google_containers/exechealthz:1.0",
-             "name": "healthz",
-             "ports": [
-               {
-                 "containerPort": 8080,
-                 "protocol": "TCP"
-               }
-             ],
-             "resources": {
-               "requests": {
-                 "cpu": "10m", 
-                 "memory": "20Mi"
-               }, 
-               "limits": {
-                 "cpu": "10m",
-                 "memory": "20Mi"
-               }
-             }
-           }
-         ],
-         "dnsPolicy": "Default",
-         "volumes": [
-           {
-             "emptyDir": {},
-             "name": "etcd-storage"
-           }
-         ]
-       }
-     }
-   }
+  "kind": "ReplicationController",
+  "metadata": {
+    "labels": {
+      "k8s-app": "kube-dns",
+      "kubernetes.io/cluster-service": "true",
+      "version": "v11"
+    },
+    "name": "kube-dns-v11",
+    "namespace": "kube-system"
+  },
+  "spec": {
+    "replicas": 1,
+    "selector": {
+      "k8s-app": "kube-dns",
+      "version": "v11"
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "k8s-app": "kube-dns",
+          "kubernetes.io/cluster-service": "true",
+          "version": "v11"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "command": [
+              "/usr/local/bin/etcd",
+              "-data-dir",
+              "/var/etcd/data",
+              "-listen-client-urls",
+              "http://127.0.0.1:2379,http://127.0.0.1:4001",
+              "-advertise-client-urls",
+              "http://127.0.0.1:2379,http://127.0.0.1:4001",
+              "-initial-cluster-token",
+              "skydns-etcd"
+            ],
+            "image": "gcr.io/google_containers/etcd-amd64:2.2.1",
+            "name": "etcd",
+            "resources": {
+              "limits": {
+                "cpu": "100m",
+                "memory": "500Mi"
+              },
+              "requests": {
+                "cpu": "100m",
+                "memory": "50Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "mountPath": "/var/etcd/data",
+                "name": "etcd-storage"
+              }
+            ]
+          },
+          {
+            "args": [
+              "--domain=cluster.local"
+            ],
+            "image": "gcr.io/google_containers/kube2sky:1.14",
+            "livenessProbe": {
+              "failureThreshold": 5,
+              "httpGet": {
+                "path": "/healthz",
+                "port": 8080,
+                "scheme": "HTTP"
+              },
+              "initialDelaySeconds": 60,
+              "successThreshold": 1,
+              "timeoutSeconds": 5
+            },
+            "name": "kube2sky",
+            "readinessProbe": {
+              "httpGet": {
+                "path": "/readiness",
+                "port": 8081,
+                "scheme": "HTTP"
+              },
+              "initialDelaySeconds": 30,
+              "timeoutSeconds": 5
+            },
+            "resources": {
+              "limits": {
+                "cpu": "100m",
+                "memory": "200Mi"
+              },
+              "requests": {
+                "cpu": "100m",
+                "memory": "50Mi"
+              }
+            }
+          },
+          {
+            "args": [
+              "-machines=http://127.0.0.1:4001",
+              "-addr=0.0.0.0:53",
+              "-ns-rotate=false",
+              "-domain=cluster.local."
+            ],
+            "image": "gcr.io/google_containers/skydns:2015-10-13-8c72f8c",
+            "name": "skydns",
+            "ports": [
+              {
+                "containerPort": 53,
+                "name": "dns",
+                "protocol": "UDP"
+              },
+              {
+                "containerPort": 53,
+                "name": "dns-tcp",
+                "protocol": "TCP"
+              }
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "100m",
+                "memory": "200Mi"
+              },
+              "requests": {
+                "cpu": "100m",
+                "memory": "50Mi"
+              }
+            }
+          },
+          {
+            "args": [
+              "-cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1 >/dev/null",
+              "-port=8080"
+            ],
+            "image": "gcr.io/google_containers/exechealthz:1.0",
+            "name": "healthz",
+            "ports": [
+              {
+                "containerPort": 8080,
+                "protocol": "TCP"
+              }
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "10m",
+                "memory": "20Mi"
+              },
+              "requests": {
+                "cpu": "10m",
+                "memory": "20Mi"
+              }
+            }
+          }
+        ],
+        "dnsPolicy": "Default",
+        "volumes": [
+          {
+            "emptyDir": {},
+            "name": "etcd-storage"
+          }
+        ]
+      }
+    }
+  }
 }
 EOF
     }
@@ -499,8 +490,8 @@ EOF
     }
 
     # For one controller and one worker node, fix memory at
-    # 224Mi. Multiple node clusters should scale up their memory by
-    # about 12Mi per node
+    # 208Mi. Multiple node clusters should scale up their memory by
+    # about 4Mi per node
     local TEMPLATE=/srv/kubernetes/manifests/heapster-rc.json
     [ -f $TEMPLATE ] || {
         echo "TEMPLATE: $TEMPLATE"
@@ -510,127 +501,45 @@ EOF
   "apiVersion": "v1",
   "kind": "ReplicationController",
   "metadata": {
-    "name": "heapster-v10",
-    "namespace": "kube-system",
     "labels": {
       "k8s-app": "heapster",
-      "version": "v10",
       "kubernetes.io/cluster-service": "true"
-    }
+    },
+    "name": "heapster-v1.0.2",
+    "namespace": "kube-system"
   },
   "spec": {
     "replicas": 1,
     "selector": {
-      "k8s-app": "heapster",
-      "version": "v10"
+      "k8s-app": "heapster"
     },
     "template": {
       "metadata": {
         "labels": {
           "k8s-app": "heapster",
-          "version": "v10",
           "kubernetes.io/cluster-service": "true"
         }
       },
       "spec": {
         "containers": [
           {
-            "image": "gcr.io/google_containers/heapster:v0.18.2",
+            "command": [
+              "/heapster",
+              "--source=kubernetes.summary_api:''",
+              "--metric_resolution=60s"
+            ],
+            "image": "gcr.io/google_containers/heapster:v1.0.2",
             "name": "heapster",
             "resources": {
               "limits": {
                 "cpu": "100m",
-                "memory": "224Mi"
+                "memory": "208Mi"
               },
               "requests": {
                 "cpu": "100m",
-                "memory": "224Mi"
+                "memory": "208Mi"
               }
-            },
-            "command": [
-              "/heapster",
-              "--source=kubernetes:''",
-              "--sink=influxdb:http://monitoring-influxdb:8086",
-              "--stats_resolution=30s",
-              "--sink_frequency=1m"
-            ]
-          }
-        ]
-      }
-    }
-  }
-}
-EOF
-    }
-
-    local TEMPLATE=/srv/kubernetes/manifests/influxdb-rc.json
-    [ -f $TEMPLATE ] || {
-        echo "TEMPLATE: $TEMPLATE"
-        mkdir -p $(dirname $TEMPLATE)
-        cat << EOF > $TEMPLATE
-{
-  "apiVersion": "v1",
-  "kind": "ReplicationController",
-  "metadata": {
-    "name": "monitoring-influxdb-v2",
-    "namespace": "kube-system",
-    "labels": {
-      "k8s-app": "influxdb",
-      "version": "v2",
-      "kubernetes.io/cluster-service": "true"
-    }
-  },
-  "spec": {
-    "replicas": 1,
-    "selector": {
-      "k8s-app": "influxdb",
-      "version": "v2"
-    },
-    "template": {
-      "metadata": {
-        "labels": {
-          "k8s-app": "influxdb",
-          "version": "v2",
-          "kubernetes.io/cluster-service": "true"
-        }
-      },
-      "spec": {
-        "containers": [
-          {
-            "image": "gcr.io/google_containers/heapster_influxdb:v0.4",
-            "name": "influxdb",
-            "resources": {
-              "limits": {
-                "cpu": "100m",
-                "memory": "200Mi"
-              },
-              "requests": {
-                "cpu": "100m",
-                "memory": "200Mi"
-              }
-            },
-            "ports": [
-              {
-                "containerPort": 8083,
-                "hostPort": 8083
-              },
-              {
-                "containerPort": 8086,
-                "hostPort": 8086
-              }
-            ],
-            "volumeMounts": [
-              {
-                "name": "influxdb-persistent-storage",
-                "mountPath": "/data"
-              }
-            ]
-          }
-        ],
-        "volumes": [
-          {
-            "name": "influxdb-persistent-storage",
-            "emptyDir": {}
+            }
           }
         ]
       }
@@ -665,43 +574,6 @@ EOF
     ],
     "selector": {
       "k8s-app": "heapster"
-    }
-  }
-}
-EOF
-    }
-
-    local TEMPLATE=/srv/kubernetes/manifests/influxdb-svc.json
-    [ -f $TEMPLATE ] || {
-        echo "TEMPLATE: $TEMPLATE"
-        mkdir -p $(dirname $TEMPLATE)
-        cat << EOF > $TEMPLATE
-{
-  "apiVersion": "v1",
-  "kind": "Service",
-  "metadata": {
-    "name": "monitoring-influxdb",
-    "namespace": "kube-system",
-    "labels": {
-      "kubernetes.io/cluster-service": "true",
-      "kubernetes.io/name": "InfluxDB"
-    }
-  },
-  "spec": {
-    "ports": [
-      {
-        "name": "http",
-        "port": 8083,
-        "targetPort": 8083
-      },
-      {
-        "name": "api",
-        "port": 8086,
-        "targetPort": 8086
-      }
-    ],
-    "selector": {
-      "k8s-app": "influxdb"
     }
   }
 }
@@ -753,10 +625,9 @@ function start_addons {
     echo "K8S: DNS addon"
     curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
     curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
+    echo "K8S: Heapster addon"
     curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
-    curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/influxdb-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
     curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
-    curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/influxdb-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
 }
 
 init_config

--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -5,7 +5,7 @@ set -e
 export ETCD_ENDPOINTS=
 
 # Specify the version (vX.Y.Z) of Kubernetes assets to deploy
-export K8S_VER=v1.1.8_coreos.0
+export K8S_VER=v1.2.0_coreos.1
 
 # The CIDR network to use for pod IPs.
 # Each pod launched in the cluster will be assigned an IP out of this range.

--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -336,150 +336,177 @@ EOF
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
 {
-    "apiVersion": "v1",
-    "kind": "ReplicationController",
-    "metadata": {
-        "labels": {
-            "k8s-app": "kube-dns",
-            "kubernetes.io/cluster-service": "true",
-            "version": "v9"
-        },
-        "name": "kube-dns-v9",
-        "namespace": "kube-system"
-    },
-    "spec": {
-        "replicas": 1,
-        "selector": {
-            "k8s-app": "kube-dns",
-            "version": "v9"
-        },
-        "template": {
-            "metadata": {
-                "labels": {
-                    "k8s-app": "kube-dns",
-                    "kubernetes.io/cluster-service": "true",
-                    "version": "v9"
-                }
-            },
-            "spec": {
-                "containers": [
-                    {
-                        "command": [
-                            "/usr/local/bin/etcd",
-                            "-data-dir",
-                            "/var/etcd/data",
-                            "-listen-client-urls",
-                            "http://127.0.0.1:2379,http://127.0.0.1:4001",
-                            "-advertise-client-urls",
-                            "http://127.0.0.1:2379,http://127.0.0.1:4001",
-                            "-initial-cluster-token",
-                            "skydns-etcd"
-                        ],
-                        "image": "gcr.io/google_containers/etcd:2.0.9",
-                        "name": "etcd",
-                        "resources": {
-                            "limits": {
-                                "cpu": "100m",
-                                "memory": "50Mi"
-                            }
-                        },
-                        "volumeMounts": [
-                            {
-                                "mountPath": "/var/etcd/data",
-                                "name": "etcd-storage"
-                            }
-                        ]
-                    },
-                    {
-                        "args": [
-                            "-domain=cluster.local"
-                        ],
-                        "image": "gcr.io/google_containers/kube2sky:1.11",
-                        "name": "kube2sky",
-                        "resources": {
-                            "limits": {
-                                "cpu": "100m",
-                                "memory": "50Mi"
-                            }
-                        }
-                    },
-                    {
-                        "args": [
-                            "-machines=http://127.0.0.1:4001",
-                            "-addr=0.0.0.0:53",
-                            "-ns-rotate=false",
-                            "-domain=cluster.local."
-                        ],
-                        "image": "gcr.io/google_containers/skydns:2015-10-13-8c72f8c",
-                        "livenessProbe": {
-                            "httpGet": {
-                                "path": "/healthz",
-                                "port": 8080,
-                                "scheme": "HTTP"
-                            },
-                            "initialDelaySeconds": 30,
-                            "timeoutSeconds": 5
-                        },
-                        "name": "skydns",
-                        "ports": [
-                            {
-                                "containerPort": 53,
-                                "name": "dns",
-                                "protocol": "UDP"
-                            },
-                            {
-                                "containerPort": 53,
-                                "name": "dns-tcp",
-                                "protocol": "TCP"
-                            }
-                        ],
-                        "readinessProbe": {
-                            "httpGet": {
-                                "path": "/healthz",
-                                "port": 8080,
-                                "scheme": "HTTP"
-                            },
-                            "initialDelaySeconds": 1,
-                            "timeoutSeconds": 5
-                        },
-                        "resources": {
-                            "limits": {
-                                "cpu": "100m",
-                                "memory": "50Mi"
-                            }
-                        }
-                    },
-                    {
-                        "args": [
-                            "-cmd=nslookup kubernetes.default.svc.cluster.local localhost >/dev/null",
-                            "-port=8080"
-                        ],
-                        "image": "gcr.io/google_containers/exechealthz:1.0",
-                        "name": "healthz",
-                        "ports": [
-                            {
-                                "containerPort": 8080,
-                                "protocol": "TCP"
-                            }
-                        ],
-                        "resources": {
-                            "limits": {
-                                "cpu": "10m",
-                                "memory": "20Mi"
-                            }
-                        }
-                    }
-                ],
-                "dnsPolicy": "Default",
-                "volumes": [
-                    {
-                        "emptyDir": {},
-                        "name": "etcd-storage"
-                    }
-                ]
-            }
-        }
-    }
+  "apiVersion": "v1",
+   "kind": "ReplicationController",
+   "metadata": {
+     "labels": {
+       "k8s-app": "kube-dns",
+       "kubernetes.io/cluster-service": "true",
+       "version": "v11"
+     },
+     "name": "kube-dns-v11",
+     "namespace": "kube-system"
+   },
+   "spec": {
+     "replicas": 1,
+     "selector": {
+       "k8s-app": "kube-dns",
+       "version": "v11"
+     },
+     "template": {
+       "metadata": {
+         "labels": {
+           "k8s-app": "kube-dns",
+           "kubernetes.io/cluster-service": "true",
+           "version": "v11"
+         }
+       },
+       "spec": {
+         "containers": [
+           {
+             "command": [
+               "/usr/local/bin/etcd",
+               "-data-dir",
+               "/var/etcd/data",
+               "-listen-client-urls",
+               "http://127.0.0.1:2379,http://127.0.0.1:4001",
+               "-advertise-client-urls",
+               "http://127.0.0.1:2379,http://127.0.0.1:4001",
+               "-initial-cluster-token",
+               "skydns-etcd"
+             ],
+             "image": "gcr.io/google_containers/etcd-amd64:2.2.1",
+             "name": "etcd",
+             "resources": {
+               "requests": {
+                 "cpu": "100m", 
+                 "memory": "50Mi"
+               }, 
+               "limits": {
+                 "cpu": "100m",
+                 "memory": "50Mi"
+               }
+             },
+             "volumeMounts": [
+               {
+                 "mountPath": "/var/etcd/data",
+                 "name": "etcd-storage"
+               }
+             ]
+           },
+           {
+             "args": [
+               "--domain=cluster.local"
+             ],
+             "image": "gcr.io/google_containers/kube2sky:1.14",
+             "name": "kube2sky",
+             "livenessProbe": {
+               "successThreshold": 1, 
+               "initialDelaySeconds": 60, 
+               "httpGet": {
+                 "path": "/healthz", 
+                 "scheme": "HTTP", 
+                 "port": 8080
+               }, 
+               "timeoutSeconds": 5, 
+               "failureThreshold": 5
+             }, 
+             "readinessProbe": {
+               "initialDelaySeconds": 30, 
+               "httpGet": {
+                 "path": "/readiness", 
+                 "scheme": "HTTP", 
+                 "port": 8081
+               }, 
+               "timeoutSeconds": 5
+             }, 
+             "resources": {
+               "requests": {
+                 "cpu": "100m", 
+                 "memory": "50Mi"
+               }, 
+               "limits": {
+                 "cpu": "100m",
+                 "memory": "200Mi"
+               }
+             }
+           },
+           {
+             "args": [
+               "-machines=http://localhost:4001",
+               "-addr=0.0.0.0:53",
+               "-ns-rotate=false", 
+               "-domain=cluster.local."
+             ],
+             "image": "gcr.io/google_containers/skydns:2015-10-13-8c72f8c",
+             "livenessProbe": {
+               "httpGet": {
+                 "path": "/healthz",
+                 "port": 8080,
+                 "scheme": "HTTP"
+               },
+               "initialDelaySeconds": 30,
+               "timeoutSeconds": 5
+             },
+             "name": "skydns",
+             "ports": [
+               {
+                 "containerPort": 53,
+                 "name": "dns",
+                 "protocol": "UDP"
+               },
+               {
+                 "containerPort": 53,
+                 "name": "dns-tcp",
+                 "protocol": "TCP"
+               }
+             ],
+             "resources": {
+               "requests": {
+                 "cpu": "100m", 
+                 "memory": "50Mi"
+               }, 
+               "limits": {
+                 "cpu": "100m",
+                 "memory": "200Mi"
+               }
+             }
+           },
+           {
+             "args": [
+               "-cmd=nslookup kubernetes.default.svc.cluster.local localhost",
+               "-port=8080"
+             ],
+             "image": "gcr.io/google_containers/exechealthz:1.0",
+             "name": "healthz",
+             "ports": [
+               {
+                 "containerPort": 8080,
+                 "protocol": "TCP"
+               }
+             ],
+             "resources": {
+               "requests": {
+                 "cpu": "10m", 
+                 "memory": "20Mi"
+               }, 
+               "limits": {
+                 "cpu": "10m",
+                 "memory": "20Mi"
+               }
+             }
+           }
+         ],
+         "dnsPolicy": "Default",
+         "volumes": [
+           {
+             "emptyDir": {},
+             "name": "etcd-storage"
+           }
+         ]
+       }
+     }
+   }
 }
 EOF
     }

--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -86,7 +86,7 @@ ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
 Environment=KUBELET_VERSION=${K8S_VER}
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=http://127.0.0.1:8080 \
-  --register-node=false \
+  --register-schedulable=false \
   --allow-privileged=true \
   --config=/etc/kubernetes/manifests \
   --hostname-override=${ADVERTISE_IP} \

--- a/multi-node/generic/worker-install.sh
+++ b/multi-node/generic/worker-install.sh
@@ -10,7 +10,7 @@ export ETCD_ENDPOINTS=
 export CONTROLLER_ENDPOINT=
 
 # Specify the version (vX.Y.Z) of Kubernetes assets to deploy
-export K8S_VER=v1.1.8_coreos.0
+export K8S_VER=v1.2.0_coreos.1
 
 # The IP address of the cluster DNS service.
 # This must be the same DNS_SERVICE_IP used when configuring the controller nodes.

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -5,7 +5,7 @@ set -e
 export ETCD_ENDPOINTS="http://127.0.0.1:2379"
 
 # Specify the version (vX.Y.Z) of Kubernetes assets to deploy
-export K8S_VER=v1.1.8_coreos.0
+export K8S_VER=v1.2.0_coreos.1
 
 # The CIDR network to use for pod IPs.
 # Each pod launched in the cluster will be assigned an IP out of this range.

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -276,176 +276,167 @@ EOF
         cat << EOF > $TEMPLATE
 {
   "apiVersion": "v1",
-   "kind": "ReplicationController",
-   "metadata": {
-     "labels": {
-       "k8s-app": "kube-dns",
-       "kubernetes.io/cluster-service": "true",
-       "version": "v11"
-     },
-     "name": "kube-dns-v11",
-     "namespace": "kube-system"
-   },
-   "spec": {
-     "replicas": 1,
-     "selector": {
-       "k8s-app": "kube-dns",
-       "version": "v11"
-     },
-     "template": {
-       "metadata": {
-         "labels": {
-           "k8s-app": "kube-dns",
-           "kubernetes.io/cluster-service": "true",
-           "version": "v11"
-         }
-       },
-       "spec": {
-         "containers": [
-           {
-             "command": [
-               "/usr/local/bin/etcd",
-               "-data-dir",
-               "/var/etcd/data",
-               "-listen-client-urls",
-               "http://127.0.0.1:2379,http://127.0.0.1:4001",
-               "-advertise-client-urls",
-               "http://127.0.0.1:2379,http://127.0.0.1:4001",
-               "-initial-cluster-token",
-               "skydns-etcd"
-             ],
-             "image": "gcr.io/google_containers/etcd-amd64:2.2.1",
-             "name": "etcd",
-             "resources": {
-               "requests": {
-                 "cpu": "100m", 
-                 "memory": "50Mi"
-               }, 
-               "limits": {
-                 "cpu": "100m",
-                 "memory": "50Mi"
-               }
-             },
-             "volumeMounts": [
-               {
-                 "mountPath": "/var/etcd/data",
-                 "name": "etcd-storage"
-               }
-             ]
-           },
-           {
-             "args": [
-               "--domain=cluster.local"
-             ],
-             "image": "gcr.io/google_containers/kube2sky:1.14",
-             "name": "kube2sky",
-             "livenessProbe": {
-               "successThreshold": 1, 
-               "initialDelaySeconds": 60, 
-               "httpGet": {
-                 "path": "/healthz", 
-                 "scheme": "HTTP", 
-                 "port": 8080
-               }, 
-               "timeoutSeconds": 5, 
-               "failureThreshold": 5
-             }, 
-             "readinessProbe": {
-               "initialDelaySeconds": 30, 
-               "httpGet": {
-                 "path": "/readiness", 
-                 "scheme": "HTTP", 
-                 "port": 8081
-               }, 
-               "timeoutSeconds": 5
-             }, 
-             "resources": {
-               "requests": {
-                 "cpu": "100m", 
-                 "memory": "50Mi"
-               }, 
-               "limits": {
-                 "cpu": "100m",
-                 "memory": "200Mi"
-               }
-             }
-           },
-           {
-             "args": [
-               "-machines=http://localhost:4001",
-               "-addr=0.0.0.0:53",
-               "-ns-rotate=false", 
-               "-domain=cluster.local."
-             ],
-             "image": "gcr.io/google_containers/skydns:2015-10-13-8c72f8c",
-             "livenessProbe": {
-               "httpGet": {
-                 "path": "/healthz",
-                 "port": 8080,
-                 "scheme": "HTTP"
-               },
-               "initialDelaySeconds": 30,
-               "timeoutSeconds": 5
-             },
-             "name": "skydns",
-             "ports": [
-               {
-                 "containerPort": 53,
-                 "name": "dns",
-                 "protocol": "UDP"
-               },
-               {
-                 "containerPort": 53,
-                 "name": "dns-tcp",
-                 "protocol": "TCP"
-               }
-             ],
-             "resources": {
-               "requests": {
-                 "cpu": "100m", 
-                 "memory": "50Mi"
-               }, 
-               "limits": {
-                 "cpu": "100m",
-                 "memory": "200Mi"
-               }
-             }
-           },
-           {
-             "args": [
-               "-cmd=nslookup kubernetes.default.svc.cluster.local localhost",
-               "-port=8080"
-             ],
-             "image": "gcr.io/google_containers/exechealthz:1.0",
-             "name": "healthz",
-             "ports": [
-               {
-                 "containerPort": 8080,
-                 "protocol": "TCP"
-               }
-             ],
-             "resources": {
-               "requests": {
-                 "cpu": "10m", 
-                 "memory": "20Mi"
-               }, 
-               "limits": {
-                 "cpu": "10m",
-                 "memory": "20Mi"
-               }
-             }
-           }
-         ],
-         "dnsPolicy": "Default",
-         "volumes": [
-           {
-             "emptyDir": {},
-             "name": "etcd-storage"
-           }
-         ]
-       }
-     }
-   }
+  "kind": "ReplicationController",
+  "metadata": {
+    "labels": {
+      "k8s-app": "kube-dns",
+      "kubernetes.io/cluster-service": "true",
+      "version": "v11"
+    },
+    "name": "kube-dns-v11",
+    "namespace": "kube-system"
+  },
+  "spec": {
+    "replicas": 1,
+    "selector": {
+      "k8s-app": "kube-dns",
+      "version": "v11"
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "k8s-app": "kube-dns",
+          "kubernetes.io/cluster-service": "true",
+          "version": "v11"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "command": [
+              "/usr/local/bin/etcd",
+              "-data-dir",
+              "/var/etcd/data",
+              "-listen-client-urls",
+              "http://127.0.0.1:2379,http://127.0.0.1:4001",
+              "-advertise-client-urls",
+              "http://127.0.0.1:2379,http://127.0.0.1:4001",
+              "-initial-cluster-token",
+              "skydns-etcd"
+            ],
+            "image": "gcr.io/google_containers/etcd-amd64:2.2.1",
+            "name": "etcd",
+            "resources": {
+              "limits": {
+                "cpu": "100m",
+                "memory": "500Mi"
+              },
+              "requests": {
+                "cpu": "100m",
+                "memory": "50Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "mountPath": "/var/etcd/data",
+                "name": "etcd-storage"
+              }
+            ]
+          },
+          {
+            "args": [
+              "--domain=cluster.local"
+            ],
+            "image": "gcr.io/google_containers/kube2sky:1.14",
+            "livenessProbe": {
+              "failureThreshold": 5,
+              "httpGet": {
+                "path": "/healthz",
+                "port": 8080,
+                "scheme": "HTTP"
+              },
+              "initialDelaySeconds": 60,
+              "successThreshold": 1,
+              "timeoutSeconds": 5
+            },
+            "name": "kube2sky",
+            "readinessProbe": {
+              "httpGet": {
+                "path": "/readiness",
+                "port": 8081,
+                "scheme": "HTTP"
+              },
+              "initialDelaySeconds": 30,
+              "timeoutSeconds": 5
+            },
+            "resources": {
+              "limits": {
+                "cpu": "100m",
+                "memory": "200Mi"
+              },
+              "requests": {
+                "cpu": "100m",
+                "memory": "50Mi"
+              }
+            }
+          },
+          {
+            "args": [
+              "-machines=http://127.0.0.1:4001",
+              "-addr=0.0.0.0:53",
+              "-ns-rotate=false",
+              "-domain=cluster.local."
+            ],
+            "image": "gcr.io/google_containers/skydns:2015-10-13-8c72f8c",
+            "name": "skydns",
+            "ports": [
+              {
+                "containerPort": 53,
+                "name": "dns",
+                "protocol": "UDP"
+              },
+              {
+                "containerPort": 53,
+                "name": "dns-tcp",
+                "protocol": "TCP"
+              }
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "100m",
+                "memory": "200Mi"
+              },
+              "requests": {
+                "cpu": "100m",
+                "memory": "50Mi"
+              }
+            }
+          },
+          {
+            "args": [
+              "-cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1 >/dev/null",
+              "-port=8080"
+            ],
+            "image": "gcr.io/google_containers/exechealthz:1.0",
+            "name": "healthz",
+            "ports": [
+              {
+                "containerPort": 8080,
+                "protocol": "TCP"
+              }
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "10m",
+                "memory": "20Mi"
+              },
+              "requests": {
+                "cpu": "10m",
+                "memory": "20Mi"
+              }
+            }
+          }
+        ],
+        "dnsPolicy": "Default",
+        "volumes": [
+          {
+            "emptyDir": {},
+            "name": "etcd-storage"
+          }
+        ]
+      }
+    }
+  }
 }
 EOF
     }
@@ -489,8 +480,8 @@ EOF
 EOF
     }
 
-    # For single node, fix memory at 212Mi. Multiple node clusters
-    # should scale up their memory by about 12Mi per node
+    # For single node, fix memory at 204Mi. Multiple node clusters
+    # should scale up their memory by about 4Mi per node
     local TEMPLATE=/srv/kubernetes/manifests/heapster-rc.json
     [ -f $TEMPLATE ] || {
         echo "TEMPLATE: $TEMPLATE"
@@ -500,127 +491,45 @@ EOF
   "apiVersion": "v1",
   "kind": "ReplicationController",
   "metadata": {
-    "name": "heapster-v10",
-    "namespace": "kube-system",
     "labels": {
       "k8s-app": "heapster",
-      "version": "v10",
       "kubernetes.io/cluster-service": "true"
-    }
+    },
+    "name": "heapster-v1.0.2",
+    "namespace": "kube-system"
   },
   "spec": {
     "replicas": 1,
     "selector": {
-      "k8s-app": "heapster",
-      "version": "v10"
+      "k8s-app": "heapster"
     },
     "template": {
       "metadata": {
         "labels": {
           "k8s-app": "heapster",
-          "version": "v10",
           "kubernetes.io/cluster-service": "true"
         }
       },
       "spec": {
         "containers": [
           {
-            "image": "gcr.io/google_containers/heapster:v0.18.2",
+            "command": [
+              "/heapster",
+              "--source=kubernetes.summary_api:''",
+              "--metric_resolution=60s"
+            ],
+            "image": "gcr.io/google_containers/heapster:v1.0.2",
             "name": "heapster",
             "resources": {
               "limits": {
                 "cpu": "100m",
-                "memory": "212Mi"
+                "memory": "208Mi"
               },
               "requests": {
                 "cpu": "100m",
-                "memory": "212Mi"
+                "memory": "208Mi"
               }
-            },
-            "command": [
-              "/heapster",
-              "--source=kubernetes:''",
-              "--sink=influxdb:http://monitoring-influxdb:8086",
-              "--stats_resolution=30s",
-              "--sink_frequency=1m"
-            ]
-          }
-        ]
-      }
-    }
-  }
-}
-EOF
-    }
-
-    local TEMPLATE=/srv/kubernetes/manifests/influxdb-rc.json
-    [ -f $TEMPLATE ] || {
-        echo "TEMPLATE: $TEMPLATE"
-        mkdir -p $(dirname $TEMPLATE)
-        cat << EOF > $TEMPLATE
-{
-  "apiVersion": "v1",
-  "kind": "ReplicationController",
-  "metadata": {
-    "name": "monitoring-influxdb-v2",
-    "namespace": "kube-system",
-    "labels": {
-      "k8s-app": "influxdb",
-      "version": "v2",
-      "kubernetes.io/cluster-service": "true"
-    }
-  },
-  "spec": {
-    "replicas": 1,
-    "selector": {
-      "k8s-app": "influxdb",
-      "version": "v2"
-    },
-    "template": {
-      "metadata": {
-        "labels": {
-          "k8s-app": "influxdb",
-          "version": "v2",
-          "kubernetes.io/cluster-service": "true"
-        }
-      },
-      "spec": {
-        "containers": [
-          {
-            "image": "gcr.io/google_containers/heapster_influxdb:v0.4",
-            "name": "influxdb",
-            "resources": {
-              "limits": {
-                "cpu": "100m",
-                "memory": "200Mi"
-              },
-              "requests": {
-                "cpu": "100m",
-                "memory": "200Mi"
-              }
-            },
-            "ports": [
-              {
-                "containerPort": 8083,
-                "hostPort": 8083
-              },
-              {
-                "containerPort": 8086,
-                "hostPort": 8086
-              }
-            ],
-            "volumeMounts": [
-              {
-                "name": "influxdb-persistent-storage",
-                "mountPath": "/data"
-              }
-            ]
-          }
-        ],
-        "volumes": [
-          {
-            "name": "influxdb-persistent-storage",
-            "emptyDir": {}
+            }
           }
         ]
       }
@@ -655,43 +564,6 @@ EOF
     ],
     "selector": {
       "k8s-app": "heapster"
-    }
-  }
-}
-EOF
-    }
-
-    local TEMPLATE=/srv/kubernetes/manifests/influxdb-svc.json
-    [ -f $TEMPLATE ] || {
-        echo "TEMPLATE: $TEMPLATE"
-        mkdir -p $(dirname $TEMPLATE)
-        cat << EOF > $TEMPLATE
-{
-  "apiVersion": "v1",
-  "kind": "Service",
-  "metadata": {
-    "name": "monitoring-influxdb",
-    "namespace": "kube-system",
-    "labels": {
-      "kubernetes.io/cluster-service": "true",
-      "kubernetes.io/name": "InfluxDB"
-    }
-  },
-  "spec": {
-    "ports": [
-      {
-        "name": "http",
-        "port": 8083,
-        "targetPort": 8083
-      },
-      {
-        "name": "api",
-        "port": 8086,
-        "targetPort": 8086
-      }
-    ],
-    "selector": {
-      "k8s-app": "influxdb"
     }
   }
 }
@@ -742,10 +614,9 @@ function start_addons {
     echo "K8S: DNS addon"
     curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
     curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
+    echo "K8S: Heapster addon"
     curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
-    curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/influxdb-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
     curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
-    curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/influxdb-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
 }
 
 init_config

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -275,150 +275,177 @@ EOF
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
 {
-    "apiVersion": "v1",
-    "kind": "ReplicationController",
-    "metadata": {
-        "labels": {
-            "k8s-app": "kube-dns",
-            "kubernetes.io/cluster-service": "true",
-            "version": "v9"
-        },
-        "name": "kube-dns-v9",
-        "namespace": "kube-system"
-    },
-    "spec": {
-        "replicas": 1,
-        "selector": {
-            "k8s-app": "kube-dns",
-            "version": "v9"
-        },
-        "template": {
-            "metadata": {
-                "labels": {
-                    "k8s-app": "kube-dns",
-                    "kubernetes.io/cluster-service": "true",
-                    "version": "v9"
-                }
-            },
-            "spec": {
-                "containers": [
-                    {
-                        "command": [
-                            "/usr/local/bin/etcd",
-                            "-data-dir",
-                            "/var/etcd/data",
-                            "-listen-client-urls",
-                            "http://127.0.0.1:2379,http://127.0.0.1:4001",
-                            "-advertise-client-urls",
-                            "http://127.0.0.1:2379,http://127.0.0.1:4001",
-                            "-initial-cluster-token",
-                            "skydns-etcd"
-                        ],
-                        "image": "gcr.io/google_containers/etcd:2.0.9",
-                        "name": "etcd",
-                        "resources": {
-                            "limits": {
-                                "cpu": "100m",
-                                "memory": "50Mi"
-                            }
-                        },
-                        "volumeMounts": [
-                            {
-                                "mountPath": "/var/etcd/data",
-                                "name": "etcd-storage"
-                            }
-                        ]
-                    },
-                    {
-                        "args": [
-                            "-domain=cluster.local"
-                        ],
-                        "image": "gcr.io/google_containers/kube2sky:1.11",
-                        "name": "kube2sky",
-                        "resources": {
-                            "limits": {
-                                "cpu": "100m",
-                                "memory": "50Mi"
-                            }
-                        }
-                    },
-                    {
-                        "args": [
-                            "-machines=http://127.0.0.1:4001",
-                            "-addr=0.0.0.0:53",
-                            "-ns-rotate=false",
-                            "-domain=cluster.local."
-                        ],
-                        "image": "gcr.io/google_containers/skydns:2015-10-13-8c72f8c",
-                        "livenessProbe": {
-                            "httpGet": {
-                                "path": "/healthz",
-                                "port": 8080,
-                                "scheme": "HTTP"
-                            },
-                            "initialDelaySeconds": 30,
-                            "timeoutSeconds": 5
-                        },
-                        "name": "skydns",
-                        "ports": [
-                            {
-                                "containerPort": 53,
-                                "name": "dns",
-                                "protocol": "UDP"
-                            },
-                            {
-                                "containerPort": 53,
-                                "name": "dns-tcp",
-                                "protocol": "TCP"
-                            }
-                        ],
-                        "readinessProbe": {
-                            "httpGet": {
-                                "path": "/healthz",
-                                "port": 8080,
-                                "scheme": "HTTP"
-                            },
-                            "initialDelaySeconds": 1,
-                            "timeoutSeconds": 5
-                        },
-                        "resources": {
-                            "limits": {
-                                "cpu": "100m",
-                                "memory": "50Mi"
-                            }
-                        }
-                    },
-                    {
-                        "args": [
-                            "-cmd=nslookup kubernetes.default.svc.cluster.local localhost >/dev/null",
-                            "-port=8080"
-                        ],
-                        "image": "gcr.io/google_containers/exechealthz:1.0",
-                        "name": "healthz",
-                        "ports": [
-                            {
-                                "containerPort": 8080,
-                                "protocol": "TCP"
-                            }
-                        ],
-                        "resources": {
-                            "limits": {
-                                "cpu": "10m",
-                                "memory": "20Mi"
-                            }
-                        }
-                    }
-                ],
-                "dnsPolicy": "Default",
-                "volumes": [
-                    {
-                        "emptyDir": {},
-                        "name": "etcd-storage"
-                    }
-                ]
-            }
-        }
-    }
+  "apiVersion": "v1",
+   "kind": "ReplicationController",
+   "metadata": {
+     "labels": {
+       "k8s-app": "kube-dns",
+       "kubernetes.io/cluster-service": "true",
+       "version": "v11"
+     },
+     "name": "kube-dns-v11",
+     "namespace": "kube-system"
+   },
+   "spec": {
+     "replicas": 1,
+     "selector": {
+       "k8s-app": "kube-dns",
+       "version": "v11"
+     },
+     "template": {
+       "metadata": {
+         "labels": {
+           "k8s-app": "kube-dns",
+           "kubernetes.io/cluster-service": "true",
+           "version": "v11"
+         }
+       },
+       "spec": {
+         "containers": [
+           {
+             "command": [
+               "/usr/local/bin/etcd",
+               "-data-dir",
+               "/var/etcd/data",
+               "-listen-client-urls",
+               "http://127.0.0.1:2379,http://127.0.0.1:4001",
+               "-advertise-client-urls",
+               "http://127.0.0.1:2379,http://127.0.0.1:4001",
+               "-initial-cluster-token",
+               "skydns-etcd"
+             ],
+             "image": "gcr.io/google_containers/etcd-amd64:2.2.1",
+             "name": "etcd",
+             "resources": {
+               "requests": {
+                 "cpu": "100m", 
+                 "memory": "50Mi"
+               }, 
+               "limits": {
+                 "cpu": "100m",
+                 "memory": "50Mi"
+               }
+             },
+             "volumeMounts": [
+               {
+                 "mountPath": "/var/etcd/data",
+                 "name": "etcd-storage"
+               }
+             ]
+           },
+           {
+             "args": [
+               "--domain=cluster.local"
+             ],
+             "image": "gcr.io/google_containers/kube2sky:1.14",
+             "name": "kube2sky",
+             "livenessProbe": {
+               "successThreshold": 1, 
+               "initialDelaySeconds": 60, 
+               "httpGet": {
+                 "path": "/healthz", 
+                 "scheme": "HTTP", 
+                 "port": 8080
+               }, 
+               "timeoutSeconds": 5, 
+               "failureThreshold": 5
+             }, 
+             "readinessProbe": {
+               "initialDelaySeconds": 30, 
+               "httpGet": {
+                 "path": "/readiness", 
+                 "scheme": "HTTP", 
+                 "port": 8081
+               }, 
+               "timeoutSeconds": 5
+             }, 
+             "resources": {
+               "requests": {
+                 "cpu": "100m", 
+                 "memory": "50Mi"
+               }, 
+               "limits": {
+                 "cpu": "100m",
+                 "memory": "200Mi"
+               }
+             }
+           },
+           {
+             "args": [
+               "-machines=http://localhost:4001",
+               "-addr=0.0.0.0:53",
+               "-ns-rotate=false", 
+               "-domain=cluster.local."
+             ],
+             "image": "gcr.io/google_containers/skydns:2015-10-13-8c72f8c",
+             "livenessProbe": {
+               "httpGet": {
+                 "path": "/healthz",
+                 "port": 8080,
+                 "scheme": "HTTP"
+               },
+               "initialDelaySeconds": 30,
+               "timeoutSeconds": 5
+             },
+             "name": "skydns",
+             "ports": [
+               {
+                 "containerPort": 53,
+                 "name": "dns",
+                 "protocol": "UDP"
+               },
+               {
+                 "containerPort": 53,
+                 "name": "dns-tcp",
+                 "protocol": "TCP"
+               }
+             ],
+             "resources": {
+               "requests": {
+                 "cpu": "100m", 
+                 "memory": "50Mi"
+               }, 
+               "limits": {
+                 "cpu": "100m",
+                 "memory": "200Mi"
+               }
+             }
+           },
+           {
+             "args": [
+               "-cmd=nslookup kubernetes.default.svc.cluster.local localhost",
+               "-port=8080"
+             ],
+             "image": "gcr.io/google_containers/exechealthz:1.0",
+             "name": "healthz",
+             "ports": [
+               {
+                 "containerPort": 8080,
+                 "protocol": "TCP"
+               }
+             ],
+             "resources": {
+               "requests": {
+                 "cpu": "10m", 
+                 "memory": "20Mi"
+               }, 
+               "limits": {
+                 "cpu": "10m",
+                 "memory": "20Mi"
+               }
+             }
+           }
+         ],
+         "dnsPolicy": "Default",
+         "volumes": [
+           {
+             "emptyDir": {},
+             "name": "etcd-storage"
+           }
+         ]
+       }
+     }
+   }
 }
 EOF
     }


### PR DESCRIPTION
I changed some doc links, moved all references of the `v1.1.8_coreos.0` image to `v1.2.0_coreos.0`. Most importantly the kube-dns addon was updated to v11 which allows the v1.2.0 conformance tests to pass.

cc @aaronlevy 