### PR TITLE
kube-aws: fix missing cluster-name in status cmd

### DIFF
--- a/multi-node/aws/cmd/kube-aws/command_validate.go
+++ b/multi-node/aws/cmd/kube-aws/command_validate.go
@@ -25,7 +25,12 @@ var (
 
 func init() {
 	cmdRoot.AddCommand(cmdValidate)
-	cmdValidate.Flags().BoolVar(&validateOpts.awsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")
+	cmdValidate.Flags().BoolVar(
+		&validateOpts.awsDebug,
+		"aws-debug",
+		false,
+		"Log debug information from aws-sdk-go library",
+	)
 }
 
 func runCmdValidate(cmd *cobra.Command, args []string) error {

--- a/multi-node/aws/pkg/cluster/cluster.go
+++ b/multi-node/aws/pkg/cluster/cluster.go
@@ -232,6 +232,7 @@ func (c *Cluster) Info() (*ClusterInfo, error) {
 	}
 
 	var info ClusterInfo
+	info.Name = *c.clusterName
 	for _, r := range resources {
 		switch aws.StringValue(r.LogicalResourceId) {
 		case "EIPController":

--- a/multi-node/aws/pkg/cluster/cluster.go
+++ b/multi-node/aws/pkg/cluster/cluster.go
@@ -220,7 +220,8 @@ func (c *Cluster) Info() (*ClusterInfo, error) {
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get public IP of controller instance")
+		errmsg := "unable to get public IP of controller instance:\n" + err.Error()
+		return nil, fmt.Errorf(errmsg)
 	}
 
 	var info ClusterInfo


### PR DESCRIPTION
Info() never actually set the info.Name field to anything.

fixes #352