### PR TITLE
kube-aws: improve success messages

### DIFF
--- a/multi-node/aws/cmd/kube-aws/command_init.go
+++ b/multi-node/aws/cmd/kube-aws/command_init.go
@@ -70,6 +70,13 @@ func runCmdInit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Error exec-ing default config template: %v", err)
 	}
 
-	fmt.Printf("Edit %s to parameterize the cluster. Then use the \"kube-aws render\" command to render the stack template.\n", configPath)
+	successMsg :=
+		"Success! Created %s\n" +
+			"\n" +
+			"Next steps:\n" +
+			"1. (Optional) Edit %s to parameterize the cluster.\n" +
+			"2. Use the \"kube-aws render\" command to render the stack template.\n"
+
+	fmt.Printf(successMsg, configPath, configPath)
 	return nil
 }

--- a/multi-node/aws/cmd/kube-aws/command_init.go
+++ b/multi-node/aws/cmd/kube-aws/command_init.go
@@ -71,11 +71,12 @@ func runCmdInit(cmd *cobra.Command, args []string) error {
 	}
 
 	successMsg :=
-		"Success! Created %s\n" +
-			"\n" +
-			"Next steps:\n" +
-			"1. (Optional) Edit %s to parameterize the cluster.\n" +
-			"2. Use the \"kube-aws render\" command to render the stack template.\n"
+		`Success! Created %s
+
+Next steps:
+1. (Optional) Edit %s to parameterize the cluster.
+2. Use the "kube-aws render" command to render the stack template.
+`
 
 	fmt.Printf(successMsg, configPath, configPath)
 	return nil

--- a/multi-node/aws/cmd/kube-aws/command_render.go
+++ b/multi-node/aws/cmd/kube-aws/command_render.go
@@ -80,6 +80,13 @@ func runCmdRender(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	fmt.Printf("Edit %s and/or any of the cluster assets. Then use the \"kube-aws up\" command to create the stack.\n", configPath)
+	successMsg := "Success! Stack rendered to stack-template.json.\n" +
+		"\n" +
+		"Next steps:\n" +
+		"1. (Optional) Validate your changes to %s with \"kube-aws validate\".\n" +
+		"2. (Optional) Further customize the cluster by modifying stack-template.json or files in ./userdata.\n" +
+		"3. Start the cluster with \"kube-aws up\".\n"
+
+	fmt.Printf(successMsg, configPath)
 	return nil
 }

--- a/multi-node/aws/cmd/kube-aws/command_render.go
+++ b/multi-node/aws/cmd/kube-aws/command_render.go
@@ -80,12 +80,14 @@ func runCmdRender(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	successMsg := "Success! Stack rendered to stack-template.json.\n" +
-		"\n" +
-		"Next steps:\n" +
-		"1. (Optional) Validate your changes to %s with \"kube-aws validate\".\n" +
-		"2. (Optional) Further customize the cluster by modifying stack-template.json or files in ./userdata.\n" +
-		"3. Start the cluster with \"kube-aws up\".\n"
+	successMsg :=
+		`Success! Stack rendered to stack-template.json.
+
+Next steps:
+1. (Optional) Validate your changes to %s with "kube-aws validate"
+2. (Optional) Further customize the cluster by modifying stack-template.json or files in ./userdata.
+3. Start the cluster with "kube-aws up".
+`
 
 	fmt.Printf(successMsg, configPath)
 	return nil

--- a/multi-node/aws/cmd/kube-aws/command_up.go
+++ b/multi-node/aws/cmd/kube-aws/command_up.go
@@ -52,6 +52,7 @@ func runCmdUp(cmd *cobra.Command, args []string) error {
 		}
 		return nil
 	}
+
 	cluster := cluster.New(conf, upOpts.awsDebug)
 	if upOpts.update {
 		report, err := cluster.Update(string(data))
@@ -62,6 +63,7 @@ func runCmdUp(cmd *cobra.Command, args []string) error {
 			fmt.Printf("Update stack: %s\n", report)
 		}
 	} else {
+		fmt.Printf("Creating AWS resources. This make take several minutes.\n")
 		if err := cluster.Create(string(data)); err != nil {
 			return fmt.Errorf("Error creating cluster: %v", err)
 		}
@@ -72,7 +74,12 @@ func runCmdUp(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Failed fetching cluster info: %v", err)
 	}
 
-	fmt.Print(info.String())
+	successMsg := "Success! Your AWS resources have been created: \n" +
+		info.String() + "\n" +
+		"The containers that power your cluster are now being dowloaded.\n\n" +
+		"You should be able to access the Kubernetes API once the containers " +
+		"finish downloading.\n"
+	fmt.Print(successMsg)
 
 	return nil
 }

--- a/multi-node/aws/cmd/kube-aws/command_up.go
+++ b/multi-node/aws/cmd/kube-aws/command_up.go
@@ -74,12 +74,14 @@ func runCmdUp(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Failed fetching cluster info: %v", err)
 	}
 
-	successMsg := "Success! Your AWS resources have been created: \n" +
-		info.String() + "\n" +
-		"The containers that power your cluster are now being dowloaded.\n\n" +
-		"You should be able to access the Kubernetes API once the containers " +
-		"finish downloading.\n"
-	fmt.Print(successMsg)
+	successMsg :=
+		`Success! Your AWS resources have been created:
+%s
+The containers that power your cluster are now being dowloaded.
+
+You should be able to access the Kubernetes API once the containers finish downloading.
+`
+	fmt.Printf(successMsg, info.String())
 
 	return nil
 }


### PR DESCRIPTION
Before it wasn't entirely clear that the command had succeeded.  This
also clarifies if next steps are required or not, as well as makes them
easier to read.

Credit to robszumski for writing most of the messages.

fixes #353