### PR TITLE
kube-aws: Beta channel now supported by kube-aws

### DIFF
--- a/multi-node/aws/pkg/config/region_map.go
+++ b/multi-node/aws/pkg/config/region_map.go
@@ -21,6 +21,7 @@ var regions = []string{
 
 var supportedChannels = []string{
 	"alpha",
+	"beta",
 }
 
 func getAMI(region, channel string) (string, error) {


### PR DESCRIPTION
Beta channel moved to `>962.0.0` on March 23, currently `991.2.0`.