### PR TITLE
Documentation: update docs for podmaster removal

### DIFF
--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -6,14 +6,9 @@ See the [CoreOS Documentation](https://coreos.com/os/docs/latest/) for guides on
 
 Manual configuration of the required master node services is explained below, but most of the configuration could also be done with cloud-config, aside from placing the TLS assets on disk. For security reasons, these secrets should not be stored in cloud-config.
 
-The instructions below configure the required master node services using two main directories:
+The instructions below configure the required master node components using manifests stored in `/etc/kubernetes/manifests`. The kubelet will watch this location for new or modified manifests and run them automatically.
 
-* `/etc/kubernetes/manifests` for services that the kubelet should run on every master node
-* `/srv/kubernetes/manifests` for services that should run only on a single master node at a time (determined by a leader election).  The podmaster on that node manages the startup of these services by copying their manifests from here to the `/etc/kubernetes/manifests` directory, and the kubelet picks them up from there.
-
-It is vital to understand the distinction between the two and ensure that the scheduler and controller manager manifests are not accidentally placed directly in the `/etc/kubernetes/manifests` directory.
-
-If you are deploying multiple master nodes in a high-availability cluster, these instructions can be repeated for each one you wish to launch.
+If you are deploying multiple master nodes in a high-availability cluster, these instructions can be repeated for each one you wish to launch. Each of the master components is safe to run on multiple master nodes due to stateless design or built-in leader-election. In the case of leader-election, the service ensures that important cluster management is handled by the leader, with the additional master nodes ready to take over at any time.
 
 ## Configure Service Components
 
@@ -218,79 +213,17 @@ spec:
     name: ssl-certs-host
 ```
 
-### Set up the kube-podmaster Pod
-
-The kube-podmaster is responsible for implementing leader-election for the kube-controller-manager and kube-scheduler. Because these services modify the cluster state, we only want to have one master node making modifications at a time.
-
-In a single-master deployment, the kube-podmaster will simply run the kube-scheduler and kube-controller-manager on the only master node. In a multi-master deployment, the kube-podmaster will be responsible for starting a new instance of the Kubernetes components in the case of a machine dying.
-
-When creating `/etc/kubernetes/manifests/kube-podmaster.yaml`:
-
-* Replace `${ETCD_ENDPOINTS}`
-* Replace `${ADVERTISE_IP}`
-
-**/etc/kubernetes/manifests/kube-podmaster.yaml**
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: kube-podmaster
-  namespace: kube-system
-spec:
-  hostNetwork: true
-  containers:
-  - name: scheduler-elector
-    image: gcr.io/google_containers/podmaster:1.1
-    command:
-    - /podmaster
-    - --etcd-servers=${ETCD_ENDPOINTS}
-    - --key=scheduler
-    - --whoami=${ADVERTISE_IP}
-    - --source-file=/src/manifests/kube-scheduler.yaml
-    - --dest-file=/dst/manifests/kube-scheduler.yaml
-    volumeMounts:
-    - mountPath: /src/manifests
-      name: manifest-src
-      readOnly: true
-    - mountPath: /dst/manifests
-      name: manifest-dst
-  - name: controller-manager-elector
-    image: gcr.io/google_containers/podmaster:1.1
-    command:
-    - /podmaster
-    - --etcd-servers=${ETCD_ENDPOINTS}
-    - --key=controller
-    - --whoami=${ADVERTISE_IP}
-    - --source-file=/src/manifests/kube-controller-manager.yaml
-    - --dest-file=/dst/manifests/kube-controller-manager.yaml
-    terminationMessagePath: /dev/termination-log
-    volumeMounts:
-    - mountPath: /src/manifests
-      name: manifest-src
-      readOnly: true
-    - mountPath: /dst/manifests
-      name: manifest-dst
-  volumes:
-  - hostPath:
-      path: /srv/kubernetes/manifests
-    name: manifest-src
-  - hostPath:
-      path: /etc/kubernetes/manifests
-    name: manifest-dst
-```
-
 ### Set Up the kube-controller-manager Pod
 
 The controller manager is responsible for reconciling any required actions based on changes to [Replication Controllers][rc-overview].
 
 For example, if you increased the replica count, the controller manager would generate a scale up event, which would cause a new Pod to get scheduled in the cluster. The controller manager communicates with the API to submit these events.
 
-Create `/srv/kubernetes/manifests/kube-controller-manager.yaml`. It will use the TLS certificate placed on disk earlier.
+Create `/etc/kubernetes/manifests/kube-controller-manager.yaml`. It will use the TLS certificate placed on disk earlier.
 
 [rc-overview]: https://coreos.com/kubernetes/docs/latest/replication-controller.html
 
-**/srv/kubernetes/manifests/kube-controller-manager.yaml**
+**/etc/kubernetes/manifests/kube-controller-manager.yaml**
 
 ```yaml
 apiVersion: v1
@@ -307,6 +240,7 @@ spec:
     - /hyperkube
     - controller-manager
     - --master=http://127.0.0.1:8080
+    - --leader-elect=true 
     - --service-account-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
     - --root-ca-file=/etc/kubernetes/ssl/ca.pem
     livenessProbe:
@@ -336,9 +270,9 @@ spec:
 
 The scheduler is the last major piece of our master node. It monitors the API for unscheduled pods, finds them a machine to run on, and communicates the decision back to the API.
 
-Create File `/srv/kubernetes/manifests/kube-scheduler.yaml`:
+Create File `/etc/kubernetes/manifests/kube-scheduler.yaml`:
 
-**/srv/kubernetes/manifests/kube-scheduler.yaml**
+**/etc/kubernetes/manifests/kube-scheduler.yaml**
 
 ```yaml
 apiVersion: v1
@@ -355,6 +289,7 @@ spec:
     - /hyperkube
     - scheduler
     - --master=http://127.0.0.1:8080
+    - --leader-elect=true
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/Documentation/kubernetes-upgrade.md
+++ b/Documentation/kubernetes-upgrade.md
@@ -28,37 +28,19 @@ Master nodes consist of the following Kubernetes components:
 * kube-apiserver
 * kube-controller-manager
 * kube-scheduler
-* kube-podmaster (high-availability)
 
 While upgrading the master components, user pods on worker nodes will continue to run normally.
 
-### Upgrading kube-apiserver and kube-proxy
+### Upgrading Master Node Components
 
-Both the kube-apiserver and kube-proxy are run as "static pods". This means the pod definition is a file on disk (default location: `/etc/kubernetes/manifests`). To update these components, you simply need to update the static manifest file. When the manifest changes on disk, the kubelet will pick up the changes and restart the local pod.
+The master node components (kube-controller-manager,kube-scheduler, kube-apiserver, and kube-proxy) are run as "static pods". This means the pod definition is a file on disk (default location: `/etc/kubernetes/manifests`). To update these components, you simply need to update the static manifest file. When the manifest changes on disk, the kubelet will pick up the changes and restart the local pod.
 
 For example, to upgrade the kube-apiserver version you could update the pod image tag in `/etc/kubernetes/manifests/kube-apiserver.yaml`:
 
 From: `image: quay.io/coreos/hyperkube:v1.0.6_coreos.0`
 To: `image: quay.io/coreos//hyperkube:v1.0.7_coreos.0`
 
-The kubelet would then restart the pod, and the new image version would be used.
-
-**NOTE:** If you are running a multi-master high-availabililty cluster, please see the next section on upgrading the remaining master node components. Otherwise you can upgrade the remaining static pods (controller-manager, scheduler) using the same process described above.
-
-### Upgrading Remaining Master Node Components (High-Availability)
-
-The kube-controller-manager, kube-scheduler, and kube-podmaster are all also deployed as static pods in `/etc/kubernetes/manifests`. However, in high-availability deployments, the kube-podmaster is responsible for making sure only a single copy of the controller-manager and scheduler are running cluster-wide.
-
-To accomplish this the kube-podmaster on each master node, if leader-elected, will copy the static manifest from `/srv/kubernetes/manifests` into `/etc/kubernetes/manifests` and the kubelet will pick up the manifest and run the pod. If the kube-podmaster loses its status as leader, it will remove the static pod from `/etc/kubernetes/manifests/` and the kubelet will shut down the pod.
-
-This configuration means upgrading of these components will take a little more coordination.
-
-To upgrade the kube-controller-manager and kube-scheduler:
-
-1. For each master node:
-   1. Make changes to the base manifests in `/srv/kubernetes/manifests`
-   1. Remove the existing manifests (if present) from `/etc/kubernetes/manifests`
-   1. The kube-podmaster will automatically fetch the new manifest from `/srv/kubernetes/manifests` and copy it to `/etc/kubernetes/manifests` and the new pod will be started.
+In high-availability deployments, the control-plane components (apiserver, scheduler, and controller-manager) are deployed to all master nodes. Upgrades of these components will require them being updated on each master node.
 
 **NOTE:** Because a particular master node may not be elected to run a particular component (e.g. kube-scheduler), updating the local manifest may not update the currently active instance of the Pod. You should update the manifests on all master nodes to ensure that no matter which is active, all will reflect the updated manifest.
 


### PR DESCRIPTION
cc @aaronlevy @robszumski @joshix 

Podmaster was removed in #355 because of the new `--leader-elect` flag. I updated the docs to reflect this.