### PR TITLE
kube-aws: enable verbose credential chain errors

### DIFF
--- a/multi-node/aws/pkg/cluster/cluster.go
+++ b/multi-node/aws/pkg/cluster/cluster.go
@@ -36,8 +36,10 @@ func (c *ClusterInfo) String() string {
 }
 
 func New(cfg *config.Cluster, awsDebug bool) *Cluster {
-	awsConfig := aws.NewConfig()
-	awsConfig = awsConfig.WithRegion(cfg.Region)
+	awsConfig := aws.NewConfig().
+		WithRegion(cfg.Region).
+		WithCredentialsChainVerboseErrors(true)
+
 	if awsDebug {
 		awsConfig = awsConfig.WithLogLevel(aws.LogDebug)
 	}

--- a/multi-node/aws/pkg/config/config.go
+++ b/multi-node/aws/pkg/config/config.go
@@ -172,8 +172,10 @@ func (c Cluster) stackConfig(opts StackTemplateOptions, compressUserData bool) (
 		return nil, err
 	}
 
-	awsConfig := aws.NewConfig()
-	awsConfig = awsConfig.WithRegion(stackConfig.Config.Region)
+	awsConfig := aws.NewConfig().
+		WithRegion(stackConfig.Config.Region).
+		WithCredentialsChainVerboseErrors(true)
+
 	kmsSvc := kms.New(session.New(awsConfig))
 
 	compactAssets, err := assets.compact(stackConfig.Config, kmsSvc)


### PR DESCRIPTION
There have been a lot of issues with people confused by the opaque
errors the AWS SDK outputs without this option.

Also, not using this option is marked deprecated anyway.

fixes #368