### PR TITLE
kube-aws: fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ go:
   - 1.6
 install:
   - export GO15VENDOREXPERIMENT=1
-  - go get golang.org/x/tools/cmd/vet
 script:
   - cd $TRAVIS_BUILD_DIR/multi-node/aws
   - test -z "$(find . -path ./vendor -prune -type f -o -name '*.go' -exec gofmt -d {} + | tee /dev/stderr)"


### PR DESCRIPTION
remove `go get golang.org/x/tools/cmd/vet`