### PR TITLE
kube-aws: add option to create a record for externalDNSName automatic…

### DIFF
--- a/multi-node/aws/pkg/config/templates/cluster.yaml
+++ b/multi-node/aws/pkg/config/templates/cluster.yaml
@@ -5,9 +5,21 @@
 clusterName: {{.ClusterName}}
 
 # DNS name routable to the Kubernetes controller nodes
-# from worker nodes and external clients. The deployer
-# is responsible for making this name routable
+# from worker nodes and external clients. Configure the options
+# below if you'd like kube-aws to create a Route53 record sets/hosted zones
+# for you.  Otherwise the deployer is responsible for making this name routable
 externalDNSName: {{.ExternalDNSName}}
+
+# Set to true if you want kube-aws to create a Route53 A Record for you.
+#createRecordSet: false
+
+# TTL in seconds for the Route53 RecordSet created if createRecordSet is set to true.
+#recordSetTTL: 300
+
+# The name of the hosted zone to add the externalDNSName to, 
+# E.g: "google.com".  This needs to already exist, kube-aws will not create
+# it for you.
+#hostedZone: ""
 
 # Name of the SSH keypair already loaded into the AWS
 # account being used to deploy this cluster.

--- a/multi-node/aws/pkg/config/templates/stack-template.json
+++ b/multi-node/aws/pkg/config/templates/stack-template.json
@@ -91,6 +91,18 @@
       },
       "Type": "AWS::EC2::EIP"
     },
+    {{ if .CreateRecordSet }}
+    "ExternalDNS": {
+      "Type": "AWS::Route53::RecordSet",
+      "Properties": {
+        "HostedZoneName": "{{.HostedZone}}",
+        "Name": "{{.ExternalDNSName}}",
+        "TTL": {{.RecordSetTTL}},
+        "ResourceRecords": [{ "Ref": "EIPController"}],
+        "Type": "A"
+      }
+    },
+    {{ end }}
     "IAMInstanceProfileController": {
       "Properties": {
         "Path": "/",
@@ -198,11 +210,11 @@
                   "Effect": "Allow",
                   "Resource": "*"
                 },
-		{
-		  "Action" : "kms:Decrypt",
-		  "Effect" : "Allow",
-		  "Resource" : "{{.KMSKeyARN}}"
-		}
+                {
+                  "Action" : "kms:Decrypt",
+                  "Effect" : "Allow",
+                  "Resource" : "{{.KMSKeyARN}}"
+                }
               ],
               "Version": "2012-10-17"
             },


### PR DESCRIPTION
…ally

Currently it's on the user to create a record, via Route53 or otherwise,
in order to make the controller IP accessible via externalDNSName.  This
commit adds an option to automatically create a Route53 record in a given
hosted zone.