### PR TITLE
kube-aws: multiple etcd endpoints

### DIFF
--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -4,7 +4,7 @@ coreos:
     reboot-strategy: "off"
   flannel:
     interface: $private_ipv4
-    etcd_endpoints: {{ .ETCDEndpoints }}
+    etcd_endpoints: {{ .EtcdEndpoints }}
   etcd2:
     name: controller
     advertise-client-urls: http://$private_ipv4:2379
@@ -31,7 +31,7 @@ coreos:
             [Service]
             ExecStartPre=/usr/bin/curl --silent -X PUT -d \
             "value={\"Network\" : \"{{.PodCIDR}}\", \"Backend\" : {\"Type\" : \"vxlan\"}}" \
-            http://localhost:2379/v2/keys/coreos.com/network/config?prevExist=false
+            {{ .EtcdEndpoint }}/v2/keys/coreos.com/network/config?prevExist=false
     - name: kubelet.service
       command: start
       enable: true
@@ -163,7 +163,7 @@ write_files:
           - /hyperkube
           - apiserver
           - --bind-address=0.0.0.0
-          - --etcd-servers=http://localhost:2379
+          - --etcd-servers={{ .EtcdEndpoints }}
           - --allow-privileged=true
           - --service-cluster-ip-range={{.ServiceCIDR}}
           - --secure-port=443

--- a/multi-node/aws/pkg/config/templates/cloud-config-worker
+++ b/multi-node/aws/pkg/config/templates/cloud-config-worker
@@ -4,7 +4,7 @@ coreos:
     reboot-strategy: "off"
   flannel:
     interface: $private_ipv4
-    etcd_endpoints: {{ .ETCDEndpoints }}
+    etcd_endpoints: {{ .EtcdEndpoints }}
   units:
     - name: docker.service
       drop-ins:

--- a/multi-node/aws/pkg/config/templates/cluster.yaml
+++ b/multi-node/aws/pkg/config/templates/cluster.yaml
@@ -66,6 +66,13 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # IP Address for controller in Kubernetes subnet
 # controllerIP: 10.0.0.50
 
+# Comma seperated list of Etcd endpoints. By default this needs to be set to "http://<controllerIP>:2379" 
+# if custom etcdEndpoints are specified then a security group id can also be specified which will expose
+# the etcd security group to the worker & controller instances.
+# etcdEndpoints: "http://10.0.0.50:2379"
+# etcdSecurityGroupId: ""
+
+
 # CIDR for all service IP addresses
 # serviceCIDR: "10.3.0.0/24"
 

--- a/multi-node/aws/pkg/config/templates/stack-template.json
+++ b/multi-node/aws/pkg/config/templates/stack-template.json
@@ -348,10 +348,39 @@
       },
       "Type": "AWS::EC2::SecurityGroup"
     },
-    "SecurityGroupControllerIngressFromWorkerToEtcd": {
+    {{if .CustomEtcdEndpoint}}
+    "SecurityGroupIngressFromWorkerToEtcd": {
       "Properties": {
         "FromPort": 2379,
-        "GroupId": {
+        "GroupId": 
+          "{{.EtcdSecurityGroupId}}",
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "ToPort": 2379
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    "SecurityGroupIngressFromControllerToEtcd": {
+      "Properties": {
+        "FromPort": 2379,
+        "GroupId": 
+          "{{.EtcdSecurityGroupId}}",
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupController"
+        },
+        "ToPort": 2379
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    {{else}}
+    "SecurityGroupIngressFromWorkerToEtcd": {
+      "Properties": {
+        "FromPort": 2379,
+        "GroupId": 
+        { 
           "Ref": "SecurityGroupController"
         },
         "IpProtocol": "tcp",
@@ -362,6 +391,7 @@
       },
       "Type": "AWS::EC2::SecurityGroupIngress"
     },
+    {{end}}
     "SecurityGroupWorker": {
       "Properties": {
         "GroupDescription": {


### PR DESCRIPTION
adding ability to specify multiple etcd endpoints.

Currently the kube-aws tool explicitly defines the etcd endpoint as localhost inline in the userdata. This pull request allows for multiple etcd endpoints to be specified in cluster.yaml as a comma delimited list. 