### PR TITLE
kube-aws: increase heapster memory limit to 650Mi

### DIFF
--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -510,7 +510,7 @@ write_files:
                     "resources": {
                       "limits": {
                         "cpu": "100m",
-                        "memory": "208Mi"
+                        "memory": "650Mi"
                       },
                       "requests": {
                         "cpu": "100m",


### PR DESCRIPTION
fixes #358