### PR TITLE
kube-aws: set default recordSetTTL to 300

### DIFF
--- a/multi-node/aws/pkg/cluster/cluster.go
+++ b/multi-node/aws/pkg/cluster/cluster.go
@@ -284,14 +284,6 @@ func (c *Cluster) validateDNSConfig(r53 r53Service) error {
 		return nil
 	}
 
-	if c.RecordSetTTL < 1 {
-		return fmt.Errorf("TTL must be at least 1 second")
-	}
-
-	if c.HostedZone == "" {
-		return fmt.Errorf("hostName cannot be blank when createRecordSet is true")
-	}
-
 	zonesResp, err := r53.ListHostedZonesByName(&route53.ListHostedZonesByNameInput{
 		DNSName: aws.String(c.HostedZone),
 	})

--- a/multi-node/aws/pkg/cluster/cluster_test.go
+++ b/multi-node/aws/pkg/cluster/cluster_test.go
@@ -270,17 +270,6 @@ hostedZone: staging.core-os.net
 		t.Errorf("returned error for valid config: %v", err)
 	}
 
-	c.RecordSetTTL = 0
-	if err := c.validateDNSConfig(r53); err == nil {
-		t.Errorf("failed to reject invalid TTL")
-	}
-
-	c.RecordSetTTL = 300
-	c.HostedZone = ""
-	if err := c.validateDNSConfig(r53); err == nil {
-		t.Errorf("failed to reject empty HostName")
-	}
-
 	c.HostedZone = "non-existant-zone"
 	if err := c.validateDNSConfig(r53); err == nil {
 		t.Errorf("failed to catch non-existent hosted zone")

--- a/multi-node/aws/pkg/config/config.go
+++ b/multi-node/aws/pkg/config/config.go
@@ -45,6 +45,7 @@ func newDefaultCluster() *Cluster {
 		WorkerInstanceType:       "m3.medium",
 		WorkerRootVolumeSize:     30,
 		CreateRecordSet:          false,
+		RecordSetTTL:             300,
 	}
 }
 
@@ -329,6 +330,20 @@ type Config struct {
 func (cfg Cluster) valid() error {
 	if cfg.ExternalDNSName == "" {
 		return errors.New("externalDNSName must be set")
+	}
+	if cfg.CreateRecordSet {
+		if cfg.HostedZone == "" {
+			return errors.New("hostedZone cannot be blank when createRecordSet is true")
+		}
+		if cfg.RecordSetTTL < 1 {
+			return errors.New("TTL must be at least 1 second")
+		}
+	} else {
+		if cfg.RecordSetTTL != newDefaultCluster().RecordSetTTL {
+			return errors.New(
+				"recordSetTTL should not be modified when createRecordSet is false",
+			)
+		}
 	}
 	if cfg.KeyName == "" {
 		return errors.New("keyName must be set")

--- a/multi-node/aws/pkg/config/config_test.go
+++ b/multi-node/aws/pkg/config/config_test.go
@@ -34,6 +34,13 @@ vpcId: vpc-xxxxx
 routeTableId: rtb-xxxxxx
 `, `
 vpcId: vpc-xxxxx
+`, `
+createRecordSet: false
+hostedZone: ""
+`, `
+createRecordSet: true
+recordSetTTL: 400
+hostedZone: core-os.net
 `,
 }
 
@@ -84,6 +91,17 @@ serviceCIDR: 172.5.0.0/16
 dnsServiceIP: 172.6.100.101 #dnsServiceIP not in service CIDR
 `, `
 routeTableId: rtb-xxxxxx # routeTableId specified without vpcId
+`, `
+# invalid TTL
+recordSetTTL: 0
+`, `
+# hostedZone shouldn't be blank when createRecordSet is true
+createRecordSet: true
+hostedZone: ""
+`, `
+# recordSetTTL shouldn't be modified when createRecordSet is false
+createRecordSet: false
+recordSetTTL: 400
 `,
 }
 
@@ -144,7 +162,6 @@ dnsServiceIP: 10.6.142.100
 	}
 
 	for _, testConfig := range testConfigs {
-
 		configBody := minimalConfigYaml + testConfig.NetworkConfig
 		cluster, err := ClusterFromBytes([]byte(configBody))
 		if err != nil {
@@ -160,7 +177,9 @@ dnsServiceIP: 10.6.142.100
 
 		kubernetesServiceIP := incrementIP(serviceNet.IP)
 		if kubernetesServiceIP.String() != testConfig.KubernetesServiceIP {
-			t.Errorf("KubernetesServiceIP mismatch: got %s, expected %s", kubernetesServiceIP, testConfig.KubernetesServiceIP)
+			t.Errorf("KubernetesServiceIP mismatch: got %s, expected %s",
+				kubernetesServiceIP,
+				testConfig.KubernetesServiceIP)
 		}
 	}
 


### PR DESCRIPTION
Validate that recordSetTTL is positive, and that HostedZone is not
blank in config rather than cluster since they don't depend on any
external state.

fixes #400