### PR TITLE
kube-aws: don't add trailing dot to empty dns names

### DIFF
--- a/multi-node/aws/pkg/cluster/cluster_test.go
+++ b/multi-node/aws/pkg/cluster/cluster_test.go
@@ -258,11 +258,11 @@ hostedZone: staging.core-os.net
 		HostedZones: []Zone{
 			Zone{
 				Id:  "staging_id",
-				DNS: "staging.core-os.net",
+				DNS: "staging.core-os.net.",
 			},
 		},
 		ResourceRecordSets: map[string]string{
-			"staging_id": "existing-record.staging.core-os.net",
+			"staging_id": "existing-record.staging.core-os.net.",
 		},
 	}
 

--- a/multi-node/aws/pkg/config/config.go
+++ b/multi-node/aws/pkg/config/config.go
@@ -59,6 +59,16 @@ func ClusterFromFile(filename string) (*Cluster, error) {
 		return nil, fmt.Errorf("file %s: %v", filename, err)
 	}
 
+	return c, nil
+}
+
+// ClusterFromBytes Necessary for unit tests, which store configs as hardcoded strings
+func ClusterFromBytes(data []byte) (*Cluster, error) {
+	c := newDefaultCluster()
+	if err := yaml.Unmarshal(data, c); err != nil {
+		return nil, fmt.Errorf("failed to parse cluster: %v", err)
+	}
+
 	// HostedZone needs to end with a '.'
 	c.HostedZone = withTrailingDot(c.HostedZone)
 
@@ -66,15 +76,6 @@ func ClusterFromFile(filename string) (*Cluster, error) {
 	// but adding it here makes validations easier
 	c.ExternalDNSName = withTrailingDot(c.ExternalDNSName)
 
-	return c, nil
-}
-
-//Necessary for unit tests, which store configs as hardcoded strings
-func ClusterFromBytes(data []byte) (*Cluster, error) {
-	c := newDefaultCluster()
-	if err := yaml.Unmarshal(data, c); err != nil {
-		return nil, fmt.Errorf("failed to parse cluster: %v", err)
-	}
 	if err := c.valid(); err != nil {
 		return nil, fmt.Errorf("invalid cluster: %v", err)
 	}
@@ -491,6 +492,9 @@ func cidrOverlap(a, b *net.IPNet) bool {
 }
 
 func withTrailingDot(s string) string {
+	if s == "" {
+		return s
+	}
 	lastRune, _ := utf8.DecodeLastRuneInString(s)
 	if lastRune != rune('.') {
 		return s + "."


### PR DESCRIPTION
If you add the trailing dot to an empty hostname, the validation
that hostname isn't blank is worthless.

Basically none of the trailing dot stuff was being tested because it was
being added in ClusterFromFile rather than ClusterFromBytes, which is only
used in the live code. Also, the r53 dummy service was returning the
HostedZone and ResourceRecordSet without the final ., which would be
there in the real return values.