### PR TITLE
kube-aws: cloudformation tags

### DIFF
--- a/multi-node/aws/pkg/cluster/cluster.go
+++ b/multi-node/aws/pkg/cluster/cluster.go
@@ -147,12 +147,20 @@ func (c *Cluster) Create(stackBody string) error {
 		return err
 	}
 
+	var tags []*cloudformation.Tag
+	for k, v := range c.StackTags {
+		key := k
+		value := v
+		tags = append(tags, &cloudformation.Tag{Key: &key, Value: &value})
+	}
+
 	cfSvc := cloudformation.New(c.session)
 	creq := &cloudformation.CreateStackInput{
 		StackName:    aws.String(c.ClusterName),
 		OnFailure:    aws.String("DO_NOTHING"),
 		Capabilities: []*string{aws.String(cloudformation.CapabilityCapabilityIam)},
 		TemplateBody: &stackBody,
+		Tags:         tags,
 	}
 
 	resp, err := cfSvc.CreateStack(creq)

--- a/multi-node/aws/pkg/config/config.go
+++ b/multi-node/aws/pkg/config/config.go
@@ -82,33 +82,33 @@ func ClusterFromBytes(data []byte) (*Cluster, error) {
 }
 
 type Cluster struct {
-	ClusterName              string `yaml:"clusterName"`
-	ExternalDNSName          string `yaml:"externalDNSName"`
-	KeyName                  string `yaml:"keyName"`
-	Region                   string `yaml:"region"`
-	AvailabilityZone         string `yaml:"availabilityZone"`
-	ReleaseChannel           string `yaml:"releaseChannel"`
-	ControllerInstanceType   string `yaml:"controllerInstanceType"`
-	ControllerRootVolumeSize int    `yaml:"controllerRootVolumeSize"`
-	WorkerCount              int    `yaml:"workerCount"`
-	WorkerInstanceType       string `yaml:"workerInstanceType"`
-	WorkerRootVolumeSize     int    `yaml:"workerRootVolumeSize"`
-	WorkerSpotPrice          string `yaml:"workerSpotPrice"`
-	VPCID                    string `yaml:"vpcId"`
-	RouteTableID             string `yaml:"routeTableId"`
-	VPCCIDR                  string `yaml:"vpcCIDR"`
-	InstanceCIDR             string `yaml:"instanceCIDR"`
-	ControllerIP             string `yaml:"controllerIP"`
-	PodCIDR                  string `yaml:"podCIDR"`
-	ServiceCIDR              string `yaml:"serviceCIDR"`
-	DNSServiceIP             string `yaml:"dnsServiceIP"`
-	K8sVer                   string `yaml:"kubernetesVersion"`
-	HyperkubeImageRepo       string `yaml:"hyperkubeImageRepo"`
-	KMSKeyARN                string `yaml:"kmsKeyArn"`
-
-	CreateRecordSet bool   `yaml:"createRecordSet"`
-	RecordSetTTL    int    `yaml:"recordSetTTL"`
-	HostedZone      string `yaml:"hostedZone"`
+	ClusterName              string            `yaml:"clusterName"`
+	ExternalDNSName          string            `yaml:"externalDNSName"`
+	KeyName                  string            `yaml:"keyName"`
+	Region                   string            `yaml:"region"`
+	AvailabilityZone         string            `yaml:"availabilityZone"`
+	ReleaseChannel           string            `yaml:"releaseChannel"`
+	ControllerInstanceType   string            `yaml:"controllerInstanceType"`
+	ControllerRootVolumeSize int               `yaml:"controllerRootVolumeSize"`
+	WorkerCount              int               `yaml:"workerCount"`
+	WorkerInstanceType       string            `yaml:"workerInstanceType"`
+	WorkerRootVolumeSize     int               `yaml:"workerRootVolumeSize"`
+	WorkerSpotPrice          string            `yaml:"workerSpotPrice"`
+	VPCID                    string            `yaml:"vpcId"`
+	RouteTableID             string            `yaml:"routeTableId"`
+	VPCCIDR                  string            `yaml:"vpcCIDR"`
+	InstanceCIDR             string            `yaml:"instanceCIDR"`
+	ControllerIP             string            `yaml:"controllerIP"`
+	PodCIDR                  string            `yaml:"podCIDR"`
+	ServiceCIDR              string            `yaml:"serviceCIDR"`
+	DNSServiceIP             string            `yaml:"dnsServiceIP"`
+	K8sVer                   string            `yaml:"kubernetesVersion"`
+	HyperkubeImageRepo       string            `yaml:"hyperkubeImageRepo"`
+	KMSKeyARN                string            `yaml:"kmsKeyArn"`
+	CreateRecordSet          bool              `yaml:"createRecordSet"`
+	RecordSetTTL             int               `yaml:"recordSetTTL"`
+	HostedZone               string            `yaml:"hostedZone"`
+	StackTags                map[string]string `yaml:"stackTags"`
 }
 
 const (

--- a/multi-node/aws/pkg/config/templates/cluster.yaml
+++ b/multi-node/aws/pkg/config/templates/cluster.yaml
@@ -1,7 +1,6 @@
 # Unique name of Kubernetes cluster. In order to deploy
 # more than one cluster into the same AWS account, this
 # name must not conflict with an existing cluster.
-
 clusterName: {{.ClusterName}}
 
 # DNS name routable to the Kubernetes controller nodes
@@ -81,3 +80,8 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 
 # Hyperkube image repository to use.
 # hyperkubeImageRepo: quay.io/coreos/hyperkube
+
+# AWS Tags for cloudformation stack resources 
+#stackTags:
+#  Name: "Kubernetes" 
+#  Environment: "Production"


### PR DESCRIPTION
Currently there is no way to specify tags to apply to the created cloudformation stack. Many companies use tags to audit their AWS environment and do cost analysis. This pull request adds the ability to specify cloudformation resource tags as a list of key-value pairs (string -> string) in the cluster.yaml file