### PR TITLE
kube-aws: don't append trailing dot to externalDNSName

### DIFF
--- a/multi-node/aws/pkg/cluster/cluster.go
+++ b/multi-node/aws/pkg/cluster/cluster.go
@@ -307,7 +307,7 @@ func (c *Cluster) validateDNSConfig(r53 r53Service) error {
 
 	if len(recordSetsResp.ResourceRecordSets) > 0 {
 		for _, recordSet := range recordSetsResp.ResourceRecordSets {
-			if *recordSet.Name == c.ExternalDNSName {
+			if *recordSet.Name == config.WithTrailingDot(c.ExternalDNSName) {
 				return fmt.Errorf(
 					"RecordSet for \"%s\" already exists in Hosted Zone \"%s.\"",
 					c.ExternalDNSName,

--- a/multi-node/aws/pkg/cluster/cluster_test.go
+++ b/multi-node/aws/pkg/cluster/cluster_test.go
@@ -218,7 +218,7 @@ type dummyR53Service struct {
 func (r53 dummyR53Service) ListHostedZonesByName(input *route53.ListHostedZonesByNameInput) (*route53.ListHostedZonesByNameOutput, error) {
 	output := &route53.ListHostedZonesByNameOutput{}
 	for _, zone := range r53.HostedZones {
-		if zone.DNS == *input.DNSName {
+		if zone.DNS == config.WithTrailingDot(*input.DNSName) {
 			output.HostedZones = append(output.HostedZones, &route53.HostedZone{
 				Name: aws.String(zone.DNS),
 				Id:   aws.String(zone.Id),

--- a/multi-node/aws/pkg/config/config.go
+++ b/multi-node/aws/pkg/config/config.go
@@ -70,12 +70,9 @@ func ClusterFromBytes(data []byte) (*Cluster, error) {
 		return nil, fmt.Errorf("failed to parse cluster: %v", err)
 	}
 
-	// HostedZone needs to end with a '.'
-	c.HostedZone = withTrailingDot(c.HostedZone)
-
-	// ExternalDNSName doesn't require '.' to be created,
-	// but adding it here makes validations easier
-	c.ExternalDNSName = withTrailingDot(c.ExternalDNSName)
+	// HostedZone needs to end with a '.', amazon will not append it for you.
+	// as it will with RecordSets
+	c.HostedZone = WithTrailingDot(c.HostedZone)
 
 	if err := c.valid(); err != nil {
 		return nil, fmt.Errorf("invalid cluster: %v", err)
@@ -511,7 +508,7 @@ func cidrOverlap(a, b *net.IPNet) bool {
 	return a.Contains(b.IP) || b.Contains(a.IP)
 }
 
-func withTrailingDot(s string) string {
+func WithTrailingDot(s string) string {
 	if s == "" {
 		return s
 	}
@@ -523,7 +520,7 @@ func withTrailingDot(s string) string {
 }
 
 func isSubdomain(sub, parent string) bool {
-	sub, parent = withTrailingDot(sub), withTrailingDot(parent)
+	sub, parent = WithTrailingDot(sub), WithTrailingDot(parent)
 	subParts, parentParts := strings.Split(sub, "."), strings.Split(parent, ".")
 
 	if len(parentParts) > len(subParts) {


### PR DESCRIPTION
We previously automatically appended trailing dots to externalDNSName
in the config struct, which was then reflected in kubeconfig.
This caused some problems with people using /etc/hosts, since they would
add the externalDNSName to their hosts file without the trailing dot,
and /etc/hosts lookups don't append one.

Now we only add trailing dots on the fly, whenever they're necessary to
interact with the AWS API, never anywhere persistent.