### PR TITLE
Add Kubernetes Network Policy

### DIFF
--- a/Documentation/deploy-workers.md
+++ b/Documentation/deploy-workers.md
@@ -30,9 +30,9 @@ $ sudo ln -s ${WORKER_FQDN}-worker-key.pem worker-key.pem
 ```
 
 
-### flannel Configuration
+### Networking Configuration
 
-*Note:* If the pod-network is being managed independently of flannel, this step can be skipped. See [kubernetes networking](kubernetes-networking.md) for more detail.
+*Note:* If the pod-network is being managed independently of flannel, then the flannel parts of this guide can be skipped. It's recommended that Calico is still used for providing network policy. See [kubernetes networking](kubernetes-networking.md) for more detail.
 
 Just like earlier, create `/etc/flannel/options.env` and modify these values:
 
@@ -59,7 +59,7 @@ ExecStartPre=/usr/bin/ln -sf /etc/flannel/options.env /run/flannel/options.env
 
 ### Docker Configuration
 
-*Note:* If the pod-network is being managed independently of flannel, this step can be skipped. See [kubernetes networking](kubernetes-networking.md) for more detail.
+*Note:* If the pod-network is being managed independently, this step can be skipped. See [kubernetes networking](kubernetes-networking.md) for more detail.
 
 Require that flanneld is running prior to Docker start.
 
@@ -80,7 +80,8 @@ Create `/etc/systemd/system/kubelet.service` and substitute the following variab
 * Replace `${MASTER_HOST}`
 * Replace `${ADVERTISE_IP}` with this node's publicly routable IP.
 * Replace `${DNS_SERVICE_IP}`
-* Replace `${K8S_VER}` This will map to: `quay.io/coreos/hyperkube:${K8S_VER}` release
+* Replace `${K8S_VER}` This will map to: `quay.io/coreos/hyperkube:${K8S_VER}` release. If using Calico a version that includes CNI binaries should be used. e.g. `v1.2.3_coreos.cni.1`
+* Replace `${NETWORK_PLUGIN}` with `cni` if using Calico. Otherwise just leave it blank.
 
 **/etc/systemd/system/kubelet.service**
 
@@ -91,6 +92,8 @@ ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
 Environment=KUBELET_VERSION=${K8S_VER}
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=https://${MASTER_HOST} \
+  --network-plugin-dir=/etc/kubernetes/cni/net.d \
+  --network-plugin=${NETWORK_PLUGIN} \
   --register-node=true \
   --allow-privileged=true \
   --config=/etc/kubernetes/manifests \
@@ -104,6 +107,38 @@ Restart=always
 RestartSec=10
 [Install]
 WantedBy=multi-user.target
+```
+
+### Set Up the CNI config
+
+The kubelet reads the CNI configuration on startup and uses that to determine which CNI plugin to call. Create the following file which tells the kubelet to call the flannel plugin but to then delegate control to the Calico plugin. Using the flannel plugin ensures that the Calico plugin is called with the IP range for the node that was selected by flannel.
+
+Note that this configuration is different to the one on the master nodes. It includes additional Kubernetes authentication information since the API server isn't available on localhost.
+
+* Replace `${ADVERTISE_IP}` with this node's publicly routable IP.
+* Replace `${ETCD_ENDPOINTS}`
+* Replace `${CONTROLER_IP}`
+
+**/etc/kubernetes/cni/net.d/10-calico.conf**
+
+```json
+{
+    "name": "calico",
+    "type": "flannel",
+    "delegate": {
+        "type": "calico",
+        "etcd_endpoints": "$ETCD_ENDPOINTS",
+        "log_level": "none",
+        "log_level_stderr": "info",
+        "hostname": "${ADVERTISE_IP}",
+        "policy": {
+            "type": "k8s",
+            "k8s_api_root": "https://${CONTROLER_IP}:443/api/v1/",
+            "k8s_client_key": "/etc/kubernetes/ssl/worker-key.pem",
+            "k8s_client_certificate": "/etc/kubernetes/ssl/worker.pem"
+        }
+    }
+}
 ```
 
 ### Set Up the kube-proxy Pod
@@ -182,6 +217,48 @@ contexts:
 current-context: kubelet-context
 ```
 
+### Set Up Calico Node Container
+
+The Calico node container runs on all hosts, including the master node. It performs two functions:
+* Connects containers to the flannel overlay network, which enables the "one IP per pod" concept.
+* Enforces network policy created through the Kubernetes policy API, ensuring pods talk to authorized resources only.
+
+This step can be skipped if not using Calico.
+
+Create `/etc/systemd/system/calico-node.service` and substitute the following variables:
+
+* Replace `${ADVERTISE_IP}` with this node's publicly routable IP.
+* Replace `${ETCD_ENDPOINTS}`
+
+**/etc/systemd/system/calico-node.service**
+
+```yaml
+[Unit]
+Description=Calico node for network policy
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+Slice=machine.slice
+Environment=CALICO_DISABLE_FILE_LOGGING=true
+Environment=HOSTNAME=${ADVERTISE_IP}
+Environment=IP=${ADVERTISE_IP}
+Environment=FELIX_FELIXHOSTNAME=${ADVERTISE_IP}
+Environment=CALICO_NETWORKING=false
+Environment=NO_DEFAULT_POOLS=true
+Environment=ETCD_ENDPOINTS=${ETCD_ENDPOINTS}
+ExecStart=/usr/bin/rkt run --inherit-env --stage1-from-dir=stage1-fly.aci \
+--volume=modules,kind=host,source=/lib/modules,readOnly=false \
+--mount=volume=modules,target=/lib/modules \
+--trust-keys-from-https quay.io/calico/node:v0.19.0
+KillMode=mixed
+Restart=always
+TimeoutStartSec=0
+
+[Install]
+WantedBy=multi-user.target
+```
+
 ## Start Services
 
 Now we can start the Worker services.
@@ -194,24 +271,29 @@ Tell systemd to rescan the units on disk:
 $ sudo systemctl daemon-reload
 ```
 
-### Start kubelet
+### Start kubelet, flannel and Calico Node
 
-Start the kubelet, which will start the proxy as well.
+Start the kubelet, which will start the proxy as well as the Calico node (if required).
 
 ```sh
+$ sudo systemctl start flanneld
 $ sudo systemctl start kubelet
+$ sudo systemctl start calico-node
 ```
 
-Ensure that the kubelet starts on each boot:
+Ensure that the services start on each boot:
 
 ```sh
+$ sudo systemctl enable flanneld
+Created symlink from /etc/systemd/system/multi-user.target.wants/flanneld.service to /etc/systemd/system/flanneld.service.
 $ sudo systemctl enable kubelet
 Created symlink from /etc/systemd/system/multi-user.target.wants/kubelet.service to /etc/systemd/system/kubelet.service.
+$ sudo systemctl enable calico-node
+Created symlink from /etc/systemd/system/multi-user.target.wants/calico-node.service to /etc/systemd/system/calico-node.service.
 ```
 
 To check the health of the kubelet systemd unit that we created, run `systemctl status kubelet.service`.
-
-If you run into issues with Docker and Flannel, check to see that the drop-in was applied correctly by running `systemctl cat docker.service` and ensuring that the drop-in appears at the bottom.
+To check the health of the calico-node systemd unit that we created, run `systemctl status calico-node.service`.
 
 <div class="co-m-docs-next-step">
   <p><strong>Is the kubelet running?</strong></p>

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -8,6 +8,7 @@ This guide will walk you through a deployment of a single-master/multi-worker Ku
 - deploy worker nodes
 - configure `kubectl` to work with our cluster
 - deploy the DNS add-on
+- deploy the network policy add-on
 
 Working through this guide may take you a few hours, but it will give you good understanding of the moving pieces of your cluster and set you up for success in the long run. Let's get started.
 

--- a/Documentation/kubernetes-on-aws.md
+++ b/Documentation/kubernetes-on-aws.md
@@ -158,6 +158,17 @@ You can now customize your cluster by editing asset files:
 
 You can also now check the `my-cluster` asset directory into version control if you desire. The contents of this directory are your reproducible cluster assets. Please take care not to commit the `my-cluster/credentials` directory, as it contains your TLS secrets. If you're using git, the `credentials` directory will already be ignored for you.
 
+#### Calico network policy (optional)
+
+The cluster can be configured to use Calico to provide network policy.
+
+Edit the `cluster.yaml` file:
+```yaml
+useCalico: true
+kubernetesVersion: v1.2.3_coreos.cni.1
+```
+The hyperkube image version needs to contain the CNI binaries (these are tagged with `_cni`)
+
 #### Route53 Host Record (optional)
 
 `kube-aws` can optionally create an A record for the controller IP in an existing hosted zone.

--- a/Documentation/kubernetes-on-baremetal.md
+++ b/Documentation/kubernetes-on-baremetal.md
@@ -24,11 +24,12 @@ Mixing multiple methods is possible. For example, doing an install to disk for t
 ### Kubernetes Pod Network
 
 The following guides assume the use of [flannel][coreos-flannel] as a software-defined overlay network to manage routing of the [pod network][pod-network].
-However, bare metal is a common platform where a self-managed network is used, due to the flexbility provided by physical networking gear.
+However, bare metal is a common platform where a self-managed network is used, due to the flexibility provided by physical networking gear. One common alternative is to use [Calico][calico-networking] networking, avoiding the use of an overlay and allowing interop with physical networking gear using BGP.
 
 See the [Kubernetes networking](kubernetes-networking.md) documentation for more information on self-managed networking options.
 
 [coreos-flannel]: https://coreos.com/flannel/docs/latest/flannel-config.html
+[calico-networking]: https://github.com/projectcalico/calico-containers
 [pod-network]: https://github.com/kubernetes/kubernetes/blob/release-1.2/docs/design/networking.md#pod-to-pod
 
 <div class="co-m-docs-next-step">

--- a/Documentation/kubernetes-on-vagrant.md
+++ b/Documentation/kubernetes-on-vagrant.md
@@ -60,6 +60,8 @@ The default cluster configuration is to start a virtual machine for each role &m
 #$etcd_vm_memory=512
 ```
 
+By default, Calico network policy is disabled. To enabled it, change the line `export USE_CALICO=false` to `export USE_CALICO=true` in both the `../generic/controller-install.sh` and the `../generic/worker-install.sh` files. You must also ensure that the `K8S_VER` variable in both of those files refers to an version of the hyperkube image that bundles the CNI binaries, e.g. `export K8S_VER=v1.2.3_coreos.cni.1`. This is not the default and must be manually changed when using Calico.
+
 Ensure the latest CoreOS vagrant image will be used by running `vagrant box update`.
 
 Then simply run `vagrant up` and wait for the command to succeed.

--- a/Documentation/kubernetes-upgrade.md
+++ b/Documentation/kubernetes-upgrade.md
@@ -20,6 +20,21 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=https://master [...]
 ```
 
+## Upgrading Calico
+
+The Calico agent runs on both master and worker nodes, and is is distributed as a container image. It runs under rkt using systemd.
+
+To update the image version, change the image tag in the service file (`/etc/systemd/system/calico-node.service`) to reference the new calico-node image.
+
+
+**/etc/systemd/system/calico-node.service**
+```
+ExecStart=/usr/bin/rkt run --inherit-env --stage1-from-dir=stage1-fly.aci \
+--volume=modules,kind=host,source=/lib/modules,readOnly=false \
+--mount=volume=modules,target=/lib/modules \
+--trust-keys-from-https quay.io/calico/node:v0.19.0
+```
+
 ## Upgrading Master Nodes
 
 Master nodes consist of the following Kubernetes components:
@@ -28,6 +43,7 @@ Master nodes consist of the following Kubernetes components:
 * kube-apiserver
 * kube-controller-manager
 * kube-scheduler
+* policy-agent
 
 While upgrading the master components, user pods on worker nodes will continue to run normally.
 
@@ -46,7 +62,7 @@ In high-availability deployments, the control-plane components (apiserver, sched
 
 ### Upgrading Worker Nodes
 
-Worker nodes will consist of the following kubernetes components.
+Worker nodes consist of the following kubernetes components.
 
 * kube-proxy
 

--- a/multi-node/aws/README.md
+++ b/multi-node/aws/README.md
@@ -187,6 +187,8 @@ The various templates are located in the `pkg/config/templates/` folder of the s
 go generate ./pkg/config
 ```
 
+This command is run automatically as part of the `build` script.
+
 ### Useful Resources
 
 The following links can be useful for development:

--- a/multi-node/aws/pkg/config/config.go
+++ b/multi-node/aws/pkg/config/config.go
@@ -108,6 +108,7 @@ type Cluster struct {
 	RecordSetTTL             int               `yaml:"recordSetTTL"`
 	HostedZone               string            `yaml:"hostedZone"`
 	StackTags                map[string]string `yaml:"stackTags"`
+	UseCalico                bool              `yaml:"useCalico"`
 }
 
 const (
@@ -126,6 +127,9 @@ func (c Cluster) Config() (*Config, error) {
 	config.APIServers = fmt.Sprintf("http://%s:8080", c.ControllerIP)
 	config.SecureAPIServers = fmt.Sprintf("https://%s:443", c.ControllerIP)
 	config.APIServerEndpoint = fmt.Sprintf("https://%s", c.ExternalDNSName)
+	if config.UseCalico {
+		config.K8sNetworkPlugin = "cni"
+	}
 
 	var err error
 	if config.AMI, err = getAMI(config.Region, config.ReleaseChannel); err != nil {
@@ -329,6 +333,8 @@ type Config struct {
 
 	//Reference strings for dynamic resources
 	VPCRef string
+
+	K8sNetworkPlugin string
 }
 
 func (cfg Cluster) valid() error {

--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -42,6 +42,8 @@ coreos:
         Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf --mount volume=dns,target=/etc/resolv.conf"
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
         --api-servers=http://localhost:8080 \
+        --network-plugin-dir=/etc/kubernetes/cni/net.d \
+        --network-plugin={{.K8sNetworkPlugin}} \
         --register-schedulable=false \
         --allow-privileged=true \
         --config=/etc/kubernetes/manifests \
@@ -49,6 +51,35 @@ coreos:
         --cluster_domain=cluster.local
         Restart=always
         RestartSec=10
+
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: calico-node.service
+      command: start
+      enable: {{.UseCalico}}
+      content: |
+        [Unit]
+        Description=Calico per-host agent
+        Requires=network-online.target
+        After=network-online.target
+
+        [Service]
+        Slice=machine.slice
+        Environment=CALICO_DISABLE_FILE_LOGGING=true
+        Environment=HOSTNAME=$private_ipv4
+        Environment=IP=$private_ipv4
+        Environment=FELIX_FELIXHOSTNAME=$private_ipv4
+        Environment=CALICO_NETWORKING=false
+        Environment=NO_DEFAULT_POOLS=true
+        Environment=ETCD_ENDPOINTS={{ .ETCDEndpoints }}
+        ExecStart=/usr/bin/rkt run --inherit-env --stage1-from-dir=stage1-fly.aci \
+        --volume=modules,kind=host,source=/lib/modules,readOnly=false \
+        --mount=volume=modules,target=/lib/modules \
+        --trust-keys-from-https quay.io/calico/node:v0.19.0
+        KillMode=mixed
+        Restart=always
+        TimeoutStartSec=0
 
         [Install]
         WantedBy=multi-user.target
@@ -84,6 +115,21 @@ coreos:
         ExecStartPre=/usr/bin/curl http://127.0.0.1:8080/version
         ExecStart=/opt/bin/install-kube-system
 
+    - name: install-calico-system.service
+      command: start
+      enable: {{.UseCalico}}
+      content: |
+        [Unit]
+        Requires=kubelet.service docker.service
+        After=kubelet.service docker.service
+
+        [Service]
+        Type=simple
+        StartLimitInterval=0
+        Restart=on-failure
+        ExecStartPre=/usr/bin/curl http://127.0.0.1:8080/version
+        ExecStart=/opt/bin/install-calico-system
+
 write_files:
   - path: /opt/bin/install-kube-system
     permissions: 0700
@@ -106,6 +152,20 @@ write_files:
           "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services"
       done
 
+  - path: /opt/bin/install-calico-system
+    permissions: 0700
+    owner: root:root
+    content: |
+      #!/bin/bash -e
+      /usr/bin/curl -H "Content-Type: application/json" -XPOST -d @"/srv/kubernetes/manifests/calico-system.json" "http://127.0.0.1:8080/api/v1/namespaces"
+
+      /usr/bin/curl -H "Content-Type: application/json" -XPOST \
+      -d @"/srv/kubernetes/manifests/network-policy.json" \
+      "http://127.0.0.1:8080/apis/extensions/v1beta1/namespaces/default/thirdpartyresources"
+
+
+      /usr/bin/cp /srv/kubernetes/manifests/calico-policy-agent.yaml /etc/kubernetes/manifests
+
   - path: /opt/bin/decrypt-tls-assets
     owner: root:root
     permissions: 0700
@@ -117,7 +177,6 @@ write_files:
         docker run --rm -v /etc/kubernetes/ssl:/etc/kubernetes/ssl --rm quay.io/coreos/awscli aws --region {{.Region}} kms decrypt --ciphertext-blob fileb://$encKey --output text --query Plaintext | base64 --decode > $tmpPath
         mv  $tmpPath $encKey
       done
-
 
   - path: /etc/kubernetes/manifests/kube-proxy.yaml
     content: |
@@ -173,7 +232,7 @@ write_files:
           - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
           - --client-ca-file=/etc/kubernetes/ssl/ca.pem
           - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
-          - --runtime-config=extensions/v1beta1/deployments=true,extensions/v1beta1/daemonsets=true
+          - --runtime-config=extensions/v1beta1/deployments=true,extensions/v1beta1/daemonsets=true,extensions/v1beta1=true,extensions/v1beta1/thirdpartyresources=true
           - --cloud-provider=aws
           ports:
           - containerPort: 443
@@ -264,6 +323,35 @@ write_files:
             initialDelaySeconds: 15
             timeoutSeconds: 1
 
+  - path: /srv/kubernetes/manifests/calico-policy-agent.yaml
+    content: |
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: calico-policy-agent
+        namespace: calico-system
+      spec:
+        hostNetwork: true
+        containers:
+          # The Calico policy agent.
+          - name: k8s-policy-agent
+            image: calico/k8s-policy-agent:v0.1.4
+            env:
+              - name: ETCD_ENDPOINTS
+                value: "{{ .ETCDEndpoints }}"
+              - name: K8S_API
+                value: "http://127.0.0.1:8080"
+              - name: LEADER_ELECTION
+                value: "true"
+          # Leader election container used by the policy agent.
+          - name: leader-elector
+            image: quay.io/calico/leader-elector:v0.1.0
+            imagePullPolicy: IfNotPresent
+            args:
+              - "--election=calico-policy-election"
+              - "--election-namespace=calico-system"
+              - "--http=127.0.0.1:4040"
+
   - path: /srv/kubernetes/manifests/kube-system.json
     content: |
         {
@@ -272,6 +360,32 @@ write_files:
           "metadata": {
             "name": "kube-system"
           }
+        }
+
+  - path: /srv/kubernetes/manifests/calico-system.json
+    content: |
+        {
+          "apiVersion": "v1",
+          "kind": "Namespace",
+          "metadata": {
+            "name": "calico-system"
+          }
+        }
+
+  - path: /srv/kubernetes/manifests/network-policy.json
+    content: |
+        {
+          "kind": "ThirdPartyResource",
+          "apiVersion": "extensions/v1beta1",
+          "metadata": {
+            "name": "network-policy.net.alpha.kubernetes.io"
+          },
+          "description": "Specification for a network isolation policy",
+          "versions": [
+            {
+              "name": "v1alpha1"
+            }
+          ]
         }
 
   - path: /srv/kubernetes/manifests/kube-dns-rc.json
@@ -611,3 +725,21 @@ write_files:
   - path: /etc/kubernetes/ssl/apiserver-key.pem
     encoding: gzip+base64
     content: {{.TLSConfig.APIServerKey}}
+
+  - path: /etc/kubernetes/cni/net.d/10-calico.conf
+    content: |
+        {
+            "name": "calico",
+            "type": "flannel",
+            "delegate": {
+                "type": "calico",
+                "etcd_endpoints": "{{ .ETCDEndpoints }}",
+                "log_level": "none",
+                "log_level_stderr": "info",
+                "hostname": "$private_ipv4",
+                "policy": {
+                    "type": "k8s",
+                    "k8s_api_root": "http://127.0.0.1:8080/api/v1/"
+                }
+            }
+        }

--- a/multi-node/aws/pkg/config/templates/cloud-config-worker
+++ b/multi-node/aws/pkg/config/templates/cloud-config-worker
@@ -28,6 +28,8 @@ coreos:
         Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf --mount volume=dns,target=/etc/resolv.conf"
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
         --api-servers={{.SecureAPIServers}} \
+        --network-plugin-dir=/etc/kubernetes/cni/net.d \
+        --network-plugin={{.K8sNetworkPlugin}} \
         --register-node=true \
         --allow-privileged=true \
         --config=/etc/kubernetes/manifests \
@@ -39,6 +41,35 @@ coreos:
         --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem
         Restart=always
         RestartSec=10
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: calico-node.service
+      command: start
+      enable: {{.UseCalico}}
+      content: |
+        [Unit]
+        Description=Calico per-host agent
+        Requires=network-online.target
+        After=network-online.target
+
+        [Service]
+        Slice=machine.slice
+        Environment=CALICO_DISABLE_FILE_LOGGING=true
+        Environment=HOSTNAME=$private_ipv4
+        Environment=IP=$private_ipv4
+        Environment=FELIX_FELIXHOSTNAME=$private_ipv4
+        Environment=CALICO_NETWORKING=false
+        Environment=NO_DEFAULT_POOLS=true
+        Environment=ETCD_ENDPOINTS={{ .ETCDEndpoints }}
+        ExecStart=/usr/bin/rkt run --inherit-env --stage1-from-dir=stage1-fly.aci \
+        --volume=modules,kind=host,source=/lib/modules,readOnly=false \
+        --mount=volume=modules,target=/lib/modules \
+        --trust-keys-from-https quay.io/calico/node:v0.19.0
+        KillMode=mixed
+        Restart=always
+        TimeoutStartSec=0
+
         [Install]
         WantedBy=multi-user.target
 
@@ -143,4 +174,24 @@ write_files:
             user: kubelet
           name: kubelet-context
         current-context: kubelet-context
+
+  - path: /etc/kubernetes/cni/net.d/10-calico.conf
+    content: |
+        {
+            "name": "calico",
+            "type": "flannel",
+            "delegate": {
+                "type": "calico",
+                "etcd_endpoints": "{{ .ETCDEndpoints }}",
+                "log_level": "none",
+                "log_level_stderr": "info",
+                "hostname": "$private_ipv4",
+                "policy": {
+                    "type": "k8s",
+                    "k8s_api_root": "https://{{.ControllerIP}}:443/api/v1/",
+                    "k8s_client_key": "/etc/kubernetes/ssl/worker-key.pem",
+                    "k8s_client_certificate": "/etc/kubernetes/ssl/worker.pem"
+                }
+            }
+        }
 

--- a/multi-node/aws/pkg/config/templates/cluster.yaml
+++ b/multi-node/aws/pkg/config/templates/cluster.yaml
@@ -85,6 +85,10 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # Hyperkube image repository to use.
 # hyperkubeImageRepo: quay.io/coreos/hyperkube
 
+# Use Calico for network policy. When set to "true" the kubernetesVersion (above)
+# must also be updated to include a version tagged with CNI e.g. v1.2.3_coreos.cni.1
+# useCalico: false
+
 # AWS Tags for cloudformation stack resources 
 #stackTags:
 #  Name: "Kubernetes" 

--- a/multi-node/generic/worker-install.sh
+++ b/multi-node/generic/worker-install.sh
@@ -12,9 +12,16 @@ export CONTROLLER_ENDPOINT=
 # Specify the version (vX.Y.Z) of Kubernetes assets to deploy
 export K8S_VER=v1.2.3_coreos.0
 
+# Hyperkube image repository to use.
+export HYPERKUBE_IMAGE_REPO=quay.io/coreos/hyperkube
+
 # The IP address of the cluster DNS service.
 # This must be the same DNS_SERVICE_IP used when configuring the controller nodes.
 export DNS_SERVICE_IP=10.3.0.10
+
+# Whether to use Calico for Kubernetes network policy. When using Calico,
+# K8S_VER (above) must be changed to an image tagged with CNI (e.g. v1.2.3_coreos.cni.1).
+export USE_CALICO=false
 
 # The above settings can optionally be overridden using an environment file:
 ENV_FILE=/run/coreos-kubernetes/options.env
@@ -22,7 +29,7 @@ ENV_FILE=/run/coreos-kubernetes/options.env
 # -------------
 
 function init_config {
-    local REQUIRED=( 'ADVERTISE_IP' 'ETCD_ENDPOINTS' 'CONTROLLER_ENDPOINT' 'DNS_SERVICE_IP' 'K8S_VER' )
+    local REQUIRED=( 'ADVERTISE_IP' 'ETCD_ENDPOINTS' 'CONTROLLER_ENDPOINT' 'DNS_SERVICE_IP' 'K8S_VER' 'HYPERKUBE_IMAGE_REPO' 'USE_CALICO' )
 
     if [ -f $ENV_FILE ]; then
         export $(cat $ENV_FILE | xargs)
@@ -38,6 +45,12 @@ function init_config {
             exit 1
         fi
     done
+
+    if [ $USE_CALICO = "true" ]; then
+        export K8S_NETWORK_PLUGIN="cni"
+    else
+        export K8S_NETWORK_PLUGIN=""
+    fi
 }
 
 function init_templates {
@@ -47,11 +60,13 @@ function init_templates {
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
 [Service]
-ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
-
 Environment=KUBELET_VERSION=${K8S_VER}
+Environment=KUBELET_ACI=${HYPERKUBE_IMAGE_REPO}
+ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=${CONTROLLER_ENDPOINT} \
+  --network-plugin-dir=/etc/kubernetes/cni/net.d \
+  --network-plugin=${K8S_NETWORK_PLUGIN} \
   --register-node=true \
   --allow-privileged=true \
   --config=/etc/kubernetes/manifests \
@@ -63,6 +78,38 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem
 Restart=always
 RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    }
+
+    local TEMPLATE=/etc/systemd/system/calico-node.service
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+[Unit]
+Description=Calico per-host agent
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+Slice=machine.slice
+Environment=CALICO_DISABLE_FILE_LOGGING=true
+Environment=HOSTNAME=${ADVERTISE_IP}
+Environment=IP=${ADVERTISE_IP}
+Environment=FELIX_FELIXHOSTNAME=${ADVERTISE_IP}
+Environment=CALICO_NETWORKING=false
+Environment=NO_DEFAULT_POOLS=true
+Environment=ETCD_ENDPOINTS=${ETCD_ENDPOINTS}
+ExecStart=/usr/bin/rkt run --inherit-env --stage1-from-dir=stage1-fly.aci \
+--volume=modules,kind=host,source=/lib/modules,readOnly=false \
+--mount=volume=modules,target=/lib/modules \
+--trust-keys-from-https quay.io/calico/node:v0.19.0
+KillMode=mixed
+Restart=always
+TimeoutStartSec=0
 
 [Install]
 WantedBy=multi-user.target
@@ -108,7 +155,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-proxy
-    image: quay.io/coreos/hyperkube:$K8S_VER
+    image: ${HYPERKUBE_IMAGE_REPO}:$K8S_VER
     command:
     - /hyperkube
     - proxy
@@ -170,6 +217,31 @@ After=flanneld.service
 EOF
     }
 
+     local TEMPLATE=/etc/kubernetes/cni/net.d/10-calico.conf
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+{
+    "name": "calico",
+    "type": "flannel",
+    "delegate": {
+        "type": "calico",
+        "etcd_endpoints": "$ETCD_ENDPOINTS",
+        "log_level": "none",
+        "log_level_stderr": "info",
+        "hostname": "${ADVERTISE_IP}",
+        "policy": {
+            "type": "k8s",
+            "k8s_api_root": "${CONTROLLER_ENDPOINT}:443/api/v1/",
+            "k8s_client_key": "/etc/kubernetes/ssl/worker-key.pem",
+            "k8s_client_certificate": "/etc/kubernetes/ssl/worker.pem"
+        }
+    }
+}
+EOF
+    }
+
 }
 
 init_config
@@ -178,5 +250,10 @@ init_templates
 systemctl stop update-engine; systemctl mask update-engine
 
 systemctl daemon-reload
+systemctl enable flanneld; systemctl start flanneld
 systemctl enable kubelet; systemctl start kubelet
+if [ $USE_CALICO = "true" ]; then
+        systemctl enable calico-node; systemctl start calico-node
+fi
+
 

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -5,7 +5,10 @@ set -e
 export ETCD_ENDPOINTS="http://127.0.0.1:2379"
 
 # Specify the version (vX.Y.Z) of Kubernetes assets to deploy
-export K8S_VER=v1.2.3_coreos.0
+export K8S_VER=v1.2.3_coreos.cni.1
+
+# Hyperkube image repository to use.
+export HYPERKUBE_IMAGE_REPO=quay.io/coreos/hyperkube
 
 # The CIDR network to use for pod IPs.
 # Each pod launched in the cluster will be assigned an IP out of this range.
@@ -27,10 +30,14 @@ export K8S_SERVICE_IP=10.3.0.1
 # This same IP must be configured on all worker nodes to enable DNS service discovery.
 export DNS_SERVICE_IP=10.3.0.10
 
+# Whether to use Calico for Kubernetes network policy. When using Calico,
+# K8S_VER (above) must be changed to an image tagged with CNI (e.g. v1.2.3_coreos.cni.1).
+export USE_CALICO=true
+
 # -------------
 
 function init_config {
-    local REQUIRED=('ADVERTISE_IP' 'POD_NETWORK' 'ETCD_ENDPOINTS' 'SERVICE_IP_RANGE' 'K8S_SERVICE_IP' 'DNS_SERVICE_IP' 'K8S_VER' )
+    local REQUIRED=('ADVERTISE_IP' 'POD_NETWORK' 'ETCD_ENDPOINTS' 'SERVICE_IP_RANGE' 'K8S_SERVICE_IP' 'DNS_SERVICE_IP' 'K8S_VER' 'USE_CALICO')
 
     if [ -z $ADVERTISE_IP ]; then
         export ADVERTISE_IP=$(awk -F= '/COREOS_PUBLIC_IPV4/ {print $2}' /etc/environment)
@@ -42,6 +49,12 @@ function init_config {
             exit 1
         fi
     done
+
+    if [ $USE_CALICO = "true" ]; then
+        export K8S_NETWORK_PLUGIN="cni"
+    else
+        export K8S_NETWORK_PLUGIN=""
+    fi
 }
 
 function init_flannel {
@@ -77,8 +90,12 @@ function init_templates {
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
 
 Environment=KUBELET_VERSION=${K8S_VER}
+Environment=KUBELET_ACI=${HYPERKUBE_IMAGE_REPO}
+ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=http://127.0.0.1:8080 \
+  --network-plugin-dir=/etc/kubernetes/cni/net.d \
+  --network-plugin=${K8S_NETWORK_PLUGIN} \
   --register-node=true \
   --allow-privileged=true \
   --config=/etc/kubernetes/manifests \
@@ -87,6 +104,38 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --cluster_domain=cluster.local
 Restart=always
 RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    }
+
+    local TEMPLATE=/etc/systemd/system/calico-node.service
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+[Unit]
+Description=Calico per-host agent
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+Slice=machine.slice
+Environment=CALICO_DISABLE_FILE_LOGGING=true
+Environment=HOSTNAME=${ADVERTISE_IP}
+Environment=IP=${ADVERTISE_IP}
+Environment=FELIX_FELIXHOSTNAME=${ADVERTISE_IP}
+Environment=CALICO_NETWORKING=false
+Environment=NO_DEFAULT_POOLS=true
+Environment=ETCD_ENDPOINTS=${ETCD_ENDPOINTS}
+ExecStart=/usr/bin/rkt run --inherit-env --stage1-from-dir=stage1-fly.aci \
+--volume=modules,kind=host,source=/lib/modules,readOnly=false \
+--mount=volume=modules,target=/lib/modules \
+--trust-keys-from-https quay.io/calico/node:v0.19.0
+KillMode=mixed
+Restart=always
+TimeoutStartSec=0
 
 [Install]
 WantedBy=multi-user.target
@@ -107,7 +156,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-proxy
-    image: quay.io/coreos/hyperkube:$K8S_VER
+    image: ${HYPERKUBE_IMAGE_REPO}:$K8S_VER
     command:
     - /hyperkube
     - proxy
@@ -140,7 +189,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-apiserver
-    image: quay.io/coreos/hyperkube:$K8S_VER
+    image: ${HYPERKUBE_IMAGE_REPO}:$K8S_VER
     command:
     - /hyperkube
     - apiserver
@@ -155,7 +204,7 @@ spec:
     - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
     - --client-ca-file=/etc/kubernetes/ssl/ca.pem
     - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
-    - --runtime-config=extensions/v1beta1/deployments=true,extensions/v1beta1/daemonsets=true
+    - --runtime-config=extensions/v1beta1/deployments=true,extensions/v1beta1/daemonsets=true,extensions/v1beta1=true,extensions/v1beta1/thirdpartyresources=true
     ports:
     - containerPort: 443
       hostPort: 443
@@ -193,7 +242,7 @@ metadata:
 spec:
   containers:
   - name: kube-controller-manager
-    image: quay.io/coreos/hyperkube:$K8S_VER
+    image: ${HYPERKUBE_IMAGE_REPO}:$K8S_VER
     command:
     - /hyperkube
     - controller-manager
@@ -239,7 +288,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-scheduler
-    image: quay.io/coreos/hyperkube:$K8S_VER
+    image: ${HYPERKUBE_IMAGE_REPO}:$K8S_VER
     command:
     - /hyperkube
     - scheduler
@@ -254,6 +303,41 @@ spec:
 EOF
     }
 
+    local TEMPLATE=/srv/kubernetes/manifests/calico-policy-agent.yaml
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+apiVersion: v1
+kind: Pod
+metadata:
+  name: calico-policy-agent
+  namespace: calico-system
+spec:
+  hostNetwork: true
+  containers:
+    # The Calico policy agent.
+    - name: k8s-policy-agent
+      image: calico/k8s-policy-agent:v0.1.4
+      env:
+        - name: ETCD_ENDPOINTS
+          value: "${ETCD_ENDPOINTS}"
+        - name: K8S_API
+          value: "http://127.0.0.1:8080"
+        - name: LEADER_ELECTION
+          value: "true"
+    # Leader election container used by the policy agent.
+    - name: leader-elector
+      image: quay.io/calico/leader-elector:v0.1.0
+      imagePullPolicy: IfNotPresent
+      args:
+        - "--election=calico-policy-election"
+        - "--election-namespace=calico-system"
+        - "--http=127.0.0.1:4040"
+
+EOF
+    }
+
     local TEMPLATE=/srv/kubernetes/manifests/kube-system.json
     [ -f $TEMPLATE ] || {
         echo "TEMPLATE: $TEMPLATE"
@@ -265,6 +349,42 @@ EOF
   "metadata": {
     "name": "kube-system"
   }
+}
+EOF
+    }
+
+    local TEMPLATE=/srv/kubernetes/manifests/calico-system.json
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+{
+  "apiVersion": "v1",
+  "kind": "Namespace",
+  "metadata": {
+    "name": "calico-system"
+  }
+}
+EOF
+    }
+
+    local TEMPLATE=/srv/kubernetes/manifests/network-policy.json
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+{
+  "kind": "ThirdPartyResource",
+  "apiVersion": "extensions/v1beta1",
+  "metadata": {
+    "name": "network-policy.net.alpha.kubernetes.io"
+  },
+  "description": "Specification for a network isolation policy",
+  "versions": [
+    {
+      "name": "v1alpha1"
+    }
+  ]
 }
 EOF
     }
@@ -645,6 +765,30 @@ Requires=flanneld.service
 After=flanneld.service
 EOF
     }
+
+    local TEMPLATE=/etc/kubernetes/cni/net.d/10-calico.conf
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+{
+    "name": "calico",
+    "type": "flannel",
+    "delegate": {
+        "type": "calico",
+        "etcd_endpoints": "$ETCD_ENDPOINTS",
+        "log_level": "none",
+        "log_level_stderr": "info",
+        "hostname": "${ADVERTISE_IP}",
+        "policy": {
+            "type": "k8s",
+            "k8s_api_root": "http://127.0.0.1:8080/api/v1/"
+        }
+    }
+}
+EOF
+    }
+
 }
 
 function start_addons {
@@ -664,6 +808,19 @@ function start_addons {
     curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
 }
 
+function enable_calico_policy {
+    echo "Waiting for Kubernetes API..."
+    until curl --silent "http://127.0.0.1:8080/version"
+    do
+        sleep 5
+    done
+    echo
+    echo "K8S: Calico Policy"
+    curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/calico-system.json)" "http://127.0.0.1:8080/api/v1/namespaces/" > /dev/null
+    curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/network-policy.json)" "http://127.0.0.1:8080/apis/extensions/v1beta1/namespaces/default/thirdpartyresources" >/dev/null
+    cp /srv/kubernetes/manifests/calico-policy-agent.yaml /etc/kubernetes/manifests
+}
+
 init_config
 init_templates
 systemctl enable etcd2; systemctl start etcd2
@@ -673,6 +830,13 @@ init_flannel
 systemctl stop update-engine; systemctl mask update-engine
 
 systemctl daemon-reload
+systemctl enable flanneld; systemctl start flanneld
 systemctl enable kubelet; systemctl start kubelet
+
+if [ $USE_CALICO = "true" ]; then
+        systemctl enable calico-node; systemctl start calico-node
+        enable_calico_policy
+fi
+
 start_addons
 echo "DONE"


### PR DESCRIPTION
I've been working on a change for the last few weeks to add support for Network Policy to this repo. The policy is implemented by Calico. Some information on what network policy is can be found [here](https://github.com/projectcalico/calico-containers/blob/master/docs/cni/kubernetes/NetworkPolicy.md)  and [here](https://github.com/projectcalico/calico-containers/blob/master/docs/cni/kubernetes/stars-demo/README.md)

The progression of the network policy API in kubernetes is being tracked at https://github.com/kubernetes/kubernetes/issues/22469

I'm aware that the CNI plugins aren't being downloaded in the best way - I'm currently waiting for a CNI release which should be happening very soon. I'll update the PR and retest as soon as binaries become available.