### PR TITLE
kube-aws: truncate configPath (cluster.yaml) on open

### DIFF
--- a/multi-node/aws/cmd/kube-aws/command_init.go
+++ b/multi-node/aws/cmd/kube-aws/command_init.go
@@ -61,7 +61,7 @@ func runCmdInit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Error parsing default config template: %v", err)
 	}
 
-	out, err := os.OpenFile(configPath, os.O_CREATE|os.O_WRONLY, 0600)
+	out, err := os.OpenFile(configPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("Error opening %s : %v", configPath, err)
 	}


### PR DESCRIPTION
If the cluster.yaml file exists and is longer than the new version being
written, the resulting cluster.yaml will contain portions of the previous
version.