### PR TITLE
kube-aws: allow access to controller kubelet's read-only port

### DIFF
--- a/multi-node/aws/pkg/config/templates/stack-template.json
+++ b/multi-node/aws/pkg/config/templates/stack-template.json
@@ -475,11 +475,25 @@
       },
       "Type": "AWS::EC2::SecurityGroupIngress"
     },
-    "SecurityGroupWorkerIngressFromWorkerToKubeletReadOnly": {
+    "SecurityGroupWorkerIngressFromWorkerToWorkerKubeletReadOnly": {
       "Properties": {
         "FromPort": 10255,
         "GroupId": {
           "Ref": "SecurityGroupWorker"
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "ToPort": 10255
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    "SecurityGroupWorkerIngressFromWorkerToControllerKubeletReadOnly": {
+      "Properties": {
+        "FromPort": 10255,
+        "GroupId": {
+          "Ref": "SecurityGroupController"
         },
         "IpProtocol": "tcp",
         "SourceSecurityGroupId": {


### PR DESCRIPTION
Pods scheduled to worker instances can now access controller kubelet's read-only port on 10255. This is necessary now that controller kubelets are registered w/ the control plane.

Fixes #431

\cc @pbx0 @aaronlevy 