### PR TITLE
kube-aws: prefix EC2 instance names with the cluster name

### DIFF
--- a/multi-node/aws/pkg/config/templates/stack-template.json
+++ b/multi-node/aws/pkg/config/templates/stack-template.json
@@ -59,7 +59,7 @@
           {
             "Key": "Name",
             "PropagateAtLaunch": "true",
-            "Value": "kube-aws-worker"
+            "Value": "{{.ClusterName}}-kube-aws-worker"
           }
         ],
         "VPCZoneIdentifier": [
@@ -264,7 +264,7 @@
           },
           {
             "Key": "Name",
-            "Value": "kube-aws-controller"
+            "Value": "{{.ClusterName}}-kube-aws-controller"
           }
         ],
         "UserData": "{{ .UserDataController }}"


### PR DESCRIPTION
Fixes #371

Tested with the following procedures:

```
$ cd multi-node/aws
$ ./build
$ bin/kube-aws --cluster-name kuoka-k8s *snip*
$ bin/kube-aws render
$ bin/kube-aws up --export
$ bin/kube-aws up
```

After the cfn stack created, seeing EC2 instance names prefixed with the cluster name:

![image](https://cloud.githubusercontent.com/assets/22009/14805260/36209b2a-0ba5-11e6-8671-aacc05c33a94.png)