### PR TITLE
vagrant: Increase default Virtualbox memory to 2GB

### DIFF
--- a/single-node/Vagrantfile
+++ b/single-node/Vagrantfile
@@ -10,6 +10,7 @@ Vagrant.require_version ">= 1.6.0"
 
 CLUSTER_IP="10.3.0.1"
 NODE_IP = "172.17.4.99"
+NODE_MEMORY_SIZE = 2048
 USER_DATA_PATH = File.expand_path("user-data")
 SSL_TARBALL_PATH = File.expand_path("ssl/controller.tar")
 
@@ -28,7 +29,7 @@ Vagrant.configure("2") do |config|
   ["vmware_fusion", "vmware_workstation"].each do |vmware|
     config.vm.provider vmware do |v, override|
       v.vmx['numvcpus'] = 1
-      v.vmx['memsize'] = 1024
+      v.vmx['memsize'] = NODE_MEMORY_SIZE
       v.gui = false
 
       override.vm.box_url = "http://alpha.release.core-os.net/amd64-usr/current/coreos_production_vagrant_vmware_fusion.json"
@@ -38,7 +39,7 @@ Vagrant.configure("2") do |config|
   config.vm.provider :virtualbox do |v|
     v.cpus = 1
     v.gui = false
-    v.memory = 1024
+    v.memory = NODE_MEMORY_SIZE
 
     # On VirtualBox, we don't have guest additions or a functional vboxsf
     # in CoreOS, so tell Vagrant that so it can be smarter.


### PR DESCRIPTION
Without this change, we would end up with a non-functional k8s cluster set up because of memory exhaustion.

Also made it configurable via a constant defined at top of Vagrantfile according to https://github.com/coreos/coreos-kubernetes/issues/311#issuecomment-199522832

Tested with Virtualbox running `vagrant destroy -f  && vagrant up` and after several minutes running `kubectl --kubeconfig kubeconfig get svc` to confirm it's really up.

Fixes #311

P.S. Just fixing around to decrease num of non-critial issues to make coreos-kubernetes looks really good as it actually is 😄
Thanks for sharing!
