### PR TITLE
kube-aws: Support Multi-AZ workers on AWS

### DIFF
--- a/multi-node/aws/pkg/config/templates/cluster.yaml
+++ b/multi-node/aws/pkg/config/templates/cluster.yaml
@@ -31,7 +31,7 @@ keyName: {{.KeyName}}
 # Region to provision Kubernetes cluster
 region: {{.Region}}
 
-# Availability Zone to provision Kubernetes cluster
+# Availability Zone to provision Kubernetes cluster when placing nodes in a single availability zone (not highly-available) Comment out for multi availability zone setting and use the below `subnets` section instead.
 availabilityZone: {{.AvailabilityZone}}
 
 # ARN of the KMS key used to encrypt TLS assets.
@@ -64,10 +64,17 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # CIDR for Kubernetes VPC. If vpcId is specified, must match the CIDR of existing vpc.
 # vpcCIDR: "10.0.0.0/16"
 
-# CIDR for Kubernetes subnet
+# CIDR for Kubernetes subnet when placing nodes in a single availability zone (not highly-available) Leave commented out for multi availability zone setting and use the below `subnets` section instead.
 # instanceCIDR: "10.0.0.0/24"
 
-# IP Address for controller in Kubernetes subnet
+# Kubernetes subnets with their CIDRs and availability zones. Differentiating availability zone for 2 or more subnets result in high-availability (failures of a single availability zone won't result in immediate downtimes)
+# subnets:
+#   - availabilityZone: us-west-1a
+#     instanceCIDR: "10.0.0.0/24"
+#   - availabilityZone: us-west-1b
+#     instanceCIDR: "10.0.1.0/24"
+
+# IP Address for the controller in Kubernetes subnet. When we have 2 or more subnets, the controller is placed in the first subnet and controllerIP must be included in the instanceCIDR of the first subnet. This convention will change once we have H/A controllers
 # controllerIP: 10.0.0.50
 
 # CIDR for all service IP addresses

--- a/multi-node/aws/pkg/config/templates/stack-template.json
+++ b/multi-node/aws/pkg/config/templates/stack-template.json
@@ -40,7 +40,10 @@
     "AutoScaleWorker": {
       "Properties": {
         "AvailabilityZones": [
-          "{{.AvailabilityZone}}"
+          {{range $index, $subnet := .Subnets}}
+          {{if gt $index 0}},{{end}}
+          "{{$subnet.AvailabilityZone}}"
+          {{end}}
         ],
         "DesiredCapacity": "{{.WorkerCount}}",
         "HealthCheckGracePeriod": 600,
@@ -63,9 +66,14 @@
           }
         ],
         "VPCZoneIdentifier": [
+          {{range $index, $subnet := .Subnets}}
+          {{with $subnetLogicalName := printf "Subnet%d" $index}}
+          {{if gt $index 0}},{{end}}
           {
-            "Ref": "Subnet"
+            "Ref": "{{$subnetLogicalName}}"
           }
+          {{end}}
+          {{end}}
         ]
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
@@ -226,7 +234,7 @@
     },
     "InstanceController": {
       "Properties": {
-        "AvailabilityZone": "{{.AvailabilityZone}}",
+        "AvailabilityZone": "{{(index .Subnets .ControllerSubnetIndex).AvailabilityZone}}",
         "BlockDeviceMappings": [
           {
             "DeviceName": "/dev/xvda",
@@ -253,7 +261,7 @@
             ],
             "PrivateIpAddress": "{{.ControllerIP}}",
             "SubnetId": {
-              "Ref": "Subnet"
+              "Ref": "Subnet{{.ControllerSubnetIndex}}"
             }
           }
         ],
@@ -502,22 +510,27 @@
         "ToPort": 10255
       },
       "Type": "AWS::EC2::SecurityGroupIngress"
-    },
-    "Subnet": {
+    }
+    {{range $index, $subnet := .Subnets}}
+    {{with $subnetLogicalName := printf "Subnet%d" $index}}
+    ,
+    "{{$subnetLogicalName}}": {
       "Properties": {
-        "AvailabilityZone": "{{.AvailabilityZone}}",
-        "CidrBlock": "{{.InstanceCIDR}}",
+        "AvailabilityZone": "{{$subnet.AvailabilityZone}}",
+        "CidrBlock": "{{$subnet.InstanceCIDR}}",
         "MapPublicIpOnLaunch": true,
         "Tags": [
           {
             "Key": "KubernetesCluster",
-            "Value": "{{.ClusterName}}"
+            "Value": "{{$.ClusterName}}"
           }
         ],
-        "VpcId": {{.VPCRef}}
+        "VpcId": {{$.VPCRef}}
       },
       "Type": "AWS::EC2::Subnet"
     }
+    {{end}}
+    {{end}}
     {{if not .VPCID}}
     ,
     "{{.VPCLogicalName}}": {
@@ -580,28 +593,37 @@
         "VpcId": {{.VPCRef}}
       },
       "Type": "AWS::EC2::VPCGatewayAttachment"
-    },
-    "SubnetRouteTableAssociation": {
+    }
+    {{range $index, $subnet := .Subnets}}
+    {{with $subnetLogicalName := printf "Subnet%d" $index}}
+    ,
+    "{{$subnetLogicalName}}RouteTableAssociation": {
       "Properties": {
         "RouteTableId": { "Ref" : "RouteTable"},
         "SubnetId": {
-          "Ref": "Subnet"
+          "Ref": "{{$subnetLogicalName}}"
         }
       },
       "Type": "AWS::EC2::SubnetRouteTableAssociation"
     }
+    {{end}}
+    {{end}}
     {{else}}
     {{if .RouteTableID}}
+    {{range $index, $subnet := .Subnets}}
+    {{with $subnetLogicalName := printf "Subnet%d" $index}}
     ,
-    "SubnetRouteTableAssociation": {
+    "{{$subnetLogicalName}}RouteTableAssociation": {
       "Properties": {
         "RouteTableId": "{{.RouteTableID}}",
         "SubnetId": {
-          "Ref": "Subnet"
+          "Ref": "{{$subnetLogicalName}}"
         }
       },
       "Type": "AWS::EC2::SubnetRouteTableAssociation"
     }
+    {{end}}
+    {{end}}
     {{end}}
     {{end}}
 

--- a/multi-node/aws/pkg/config/tls_config_test.go
+++ b/multi-node/aws/pkg/config/tls_config_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func genTLSAssets(t *testing.T) *RawTLSAssets {
-	cluster, err := ClusterFromBytes([]byte(minimalConfigYaml))
+	cluster, err := ClusterFromBytes([]byte(singleAzConfigYaml))
 	if err != nil {
 		t.Fatalf("failed generating config: %v", err)
 	}

--- a/multi-node/aws/pkg/config/user_data_config_test.go
+++ b/multi-node/aws/pkg/config/user_data_config_test.go
@@ -19,7 +19,7 @@ func (d *dummyEncryptService) Encrypt(input *kms.EncryptInput) (*kms.EncryptOutp
 }
 
 func TestCloudConfigTemplating(t *testing.T) {
-	cluster, err := ClusterFromBytes([]byte(minimalConfigYaml))
+	cluster, err := ClusterFromBytes([]byte(singleAzConfigYaml))
 	if err != nil {
 		t.Fatalf("Unable to load cluster config: %v", err)
 	}


### PR DESCRIPTION
One step forward to achieve high-availability throughout the cluster.
This change allows you to specify multiple subnets in cluster.yaml to make workers' ASG spread instances over those subnets. Differentiating each subnet's availability zone results in H/A of workers.
Beware that this change itself does nothing with H/A of masters.

Possibly relates to #147, #100

## How I have tested this

I have tested this running `./build && rm -rf cluster.yaml userdata/ credentials/ && bin/kube-aws init *several options* && bin/kube-aws render && bin/kube-aws up` with with/without the newly added `subnets` section in `cluster.yaml`.

For example, given a `cluster.yaml`:

```yaml
*snip*

subnets:
- instanceCIDR: "10.0.0.0/24"
  availabilityZone: ap-northeast-1a
- instanceCIDR: "10.0.1.0/24"
  availabilityZone: ap-northeast-1c
```

After modifying worker ASG's desired capacity to 2 result in 2 worker nodes:

```
$ kubectl --kubeconfig=kubeconfig get nodes
NAME                                            STATUS                     AGE
ip-10-0-0-125.ap-northeast-1.compute.internal   Ready                      10m
ip-10-0-0-50.ap-northeast-1.compute.internal    Ready,SchedulingDisabled   17m
ip-10-0-1-51.ap-northeast-1.compute.internal    Ready                      17m
```

spreading across availability zone(this time they are `ap-northeast-1a` and `ap-northeast-1c`)

![image](https://cloud.githubusercontent.com/assets/22009/14840679/650a7fa6-0c71-11e6-8faa-9122a023f9f4.png)

