### PR TITLE
kube-aws: Print clearer message on `kube-aws destroy`

### DIFF
--- a/multi-node/aws/cmd/kube-aws/command_destroy.go
+++ b/multi-node/aws/cmd/kube-aws/command_destroy.go
@@ -38,6 +38,6 @@ func runCmdDestroy(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Failed destroying cluster: %v", err)
 	}
 
-	fmt.Println("Destroyed cluster")
+	fmt.Println("CloudFormation stack is being destroyed. This will take several minutes")
 	return nil
 }


### PR DESCRIPTION
Without this change, `kube-aws destroy` immediately returns with the message denoting that the cfn stack is already destroyed (which is not true as it takes several minutes until the stack get actually destroyed).

See https://github.com/coreos/coreos-kubernetes/issues/434#issuecomment-215514237 for discussion regarding phrasing and words.

Fixes #434

## Testing

I have tested this change with:

Rebuilding the `kube-aws` executable, rendering a template and creating the cfn stack from it:

```
$ ./build
$ bin/kube-aws render
Error: mkdir credentials: file exists
$ rm -Rf credentials/ userdata/
$ bin/kube-aws render
Success! Stack rendered to stack-template.json.

Next steps:
1. (Optional) Validate your changes to cluster.yaml with "kube-aws validate"
2. (Optional) Further customize the cluster by modifying stack-template.json or files in ./userdata.
3. Start the cluster with "kube-aws up".
$ bin/kube-aws up
Creating AWS resources. This should take around 5 minutes.
Success! Your AWS resources have been created:
Cluster Name:	kuoka-k8s
Controller IP:	52.68.250.134

The containers that power your cluster are now being dowloaded.

You should be able to access the Kubernetes API once the containers finish downloading.
```

Then actually running `bin/kube-aws destroy` on the stack to confirm the modified message:

```
$ bin/kube-aws destroy
CloudFormation stack is being destroyed. This will take several minutes
```
