### PR TITLE
kube-aws: Improve stack creation failed error messaging

### DIFF
--- a/multi-node/aws/build
+++ b/multi-node/aws/build
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/bin/bash
+set -euo pipefail
 
 COMMIT=`git rev-parse HEAD`
 TAG=$(git describe --exact-match --abbrev=0 --tags ${COMMIT} 2> /dev/null || true)

--- a/multi-node/aws/pkg/cluster/cluster_test.go
+++ b/multi-node/aws/pkg/cluster/cluster_test.go
@@ -284,6 +284,47 @@ hostedZone: staging.core-os.net
 	}
 }
 
+type dummyCloudformationService struct {
+	ExpectedTags []*cloudformation.Tag
+	StackEvents  []*cloudformation.StackEvent
+	StackStatus  string
+}
+
+func (cfSvc *dummyCloudformationService) CreateStack(req *cloudformation.CreateStackInput) (*cloudformation.CreateStackOutput, error) {
+
+	if len(cfSvc.ExpectedTags) != len(req.Tags) {
+		return nil, fmt.Errorf(
+			"expected tag count does not match supplied tag count\nexpected=%v, supplied=%v",
+			cfSvc.ExpectedTags,
+			req.Tags,
+		)
+	}
+
+	matchCnt := 0
+	for _, eTag := range cfSvc.ExpectedTags {
+		for _, tag := range req.Tags {
+			if *tag.Key == *eTag.Key && *tag.Value == *eTag.Value {
+				matchCnt++
+				break
+			}
+		}
+	}
+
+	if matchCnt != len(cfSvc.ExpectedTags) {
+		return nil, fmt.Errorf(
+			"not all tags matched\nexpected=%v, observed=%v",
+			cfSvc.ExpectedTags,
+			req.Tags,
+		)
+	}
+
+	resp := &cloudformation.CreateStackOutput{
+		StackId: req.StackName,
+	}
+
+	return resp, nil
+}
+
 func TestStackTags(t *testing.T) {
 	testCases := []struct {
 		expectedTags []*cloudformation.Tag
@@ -320,7 +361,6 @@ stackTags:
 	}
 
 	for _, testCase := range testCases {
-
 		configBody := minimalConfigYaml + testCase.clusterYaml
 		clusterConfig, err := config.ClusterFromBytes([]byte(configBody))
 		if err != nil {
@@ -344,41 +384,48 @@ stackTags:
 	}
 }
 
-type dummyCloudformationService struct {
-	ExpectedTags []*cloudformation.Tag
-}
-
-func (cfSvc *dummyCloudformationService) CreateStack(req *cloudformation.CreateStackInput) (*cloudformation.CreateStackOutput, error) {
-
-	if len(cfSvc.ExpectedTags) != len(req.Tags) {
-		return nil, fmt.Errorf(
-			"expected tag count does not match supplied tag count\nexpected=%v, supplied=%v",
-			cfSvc.ExpectedTags,
-			req.Tags,
-		)
+func TestStackCreationErrorMessaging(t *testing.T) {
+	events := []*cloudformation.StackEvent{
+		&cloudformation.StackEvent{
+			// Failure with all fields set
+			ResourceStatus:       aws.String("CREATE_FAILED"),
+			ResourceType:         aws.String("Computer"),
+			LogicalResourceId:    aws.String("test_comp"),
+			ResourceStatusReason: aws.String("BAD HD"),
+		},
+		&cloudformation.StackEvent{
+			// Success, should not show up
+			ResourceStatus: aws.String("SUCCESS"),
+			ResourceType:   aws.String("Computer"),
+		},
+		&cloudformation.StackEvent{
+			// Failure due to cancellation should not show up
+			ResourceStatus:       aws.String("CREATE_FAILED"),
+			ResourceType:         aws.String("Computer"),
+			ResourceStatusReason: aws.String("Resource creation cancelled"),
+		},
+		&cloudformation.StackEvent{
+			// Failure with missing fields
+			ResourceStatus: aws.String("CREATE_FAILED"),
+			ResourceType:   aws.String("Computer"),
+		},
 	}
 
-	matchCnt := 0
-	for _, eTag := range cfSvc.ExpectedTags {
-		for _, tag := range req.Tags {
-			if *tag.Key == *eTag.Key && *tag.Value == *eTag.Value {
-				matchCnt++
-				break
-			}
+	expectedMsgs := []string{
+		"CREATE_FAILED Computer test_comp BAD HD",
+		"CREATE_FAILED Computer",
+	}
+
+	outputMsgs := stackEventErrMsgs(events)
+	if len(expectedMsgs) != len(outputMsgs) {
+		t.Errorf("Expected %d stack error messages, got %d\n",
+			len(expectedMsgs),
+			len(stackEventErrMsgs(events)))
+	}
+
+	for i := range expectedMsgs {
+		if expectedMsgs[i] != outputMsgs[i] {
+			t.Errorf("Expected `%s`, got `%s`\n", expectedMsgs[i], outputMsgs[i])
 		}
 	}
-
-	if matchCnt != len(cfSvc.ExpectedTags) {
-		return nil, fmt.Errorf(
-			"not all tags matched\nexpected=%v, observed=%v",
-			cfSvc.ExpectedTags,
-			req.Tags,
-		)
-	}
-
-	resp := &cloudformation.CreateStackOutput{
-		StackId: req.StackName,
-	}
-
-	return resp, nil
 }


### PR DESCRIPTION
Previously you were only told which resources cloudformation failed to
create.  We now print the event details associated with each failure.

sample output:

![2016-05-03-134713_959x209_scrot](https://cloud.githubusercontent.com/assets/696309/14999515/a0a2ac6a-113e-11e6-8089-74b8b81618e3.png)

fixes #430