### PR TITLE
kube-aws: fix shellcheck warnings in build script

### DIFF
--- a/multi-node/aws/build
+++ b/multi-node/aws/build
@@ -1,7 +1,8 @@
-#!/bin/bash -e
+#!/bin/bash
+set -euo pipefail
 
-COMMIT=`git rev-parse HEAD`
-TAG=$(git describe --exact-match --abbrev=0 --tags ${COMMIT} 2> /dev/null || true)
+COMMIT=$(git rev-parse HEAD)
+TAG=$(git describe --exact-match --abbrev=0 --tags "${COMMIT}" 2> /dev/null || true)
 
 if [ -z "$TAG" ]; then
 	VERSION=$COMMIT
@@ -18,15 +19,15 @@ GOPATH_VENDOR="$(pwd)/_gopath-vendor"
 GOPATH_KUBE_AWS="$(pwd)/_gopath-kube-aws"
 KUBE_AWS_DIR="${GOPATH_KUBE_AWS}/src/github.com/coreos/coreos-kubernetes/multi-node/aws"
 
-rm -rf $GOPATH_VENDOR $GOPATH_KUBE_AWS
+rm -rf "$GOPATH_VENDOR" "$GOPATH_KUBE_AWS"
 
-mkdir -p $GOPATH_VENDOR
-mkdir -p $(dirname $KUBE_AWS_DIR)
+mkdir -p "$GOPATH_VENDOR"
+mkdir -p "$(dirname "$KUBE_AWS_DIR")"
 
-ln -s $(pwd)/vendor $GOPATH_VENDOR/src
-ln -s $(pwd) $KUBE_AWS_DIR
+ln -s "$(pwd)"/vendor "$GOPATH_VENDOR"/src
+ln -s "$(pwd)" "$KUBE_AWS_DIR"
 
 export GOPATH="${GOPATH_VENDOR}:${GOPATH_KUBE_AWS}"
-cd $KUBE_AWS_DIR
+cd "$KUBE_AWS_DIR"
 go generate ./pkg/config
 go build -ldflags "-X github.com/coreos/coreos-kubernetes/multi-node/aws/pkg/cluster.VERSION=${VERSION}" -a -tags netgo -installsuffix netgo -o bin/kube-aws ./cmd/kube-aws


### PR DESCRIPTION
https://github.com/koalaman/shellcheck

Quote variales to prevent word splitting/globbing.
Prefer $() to ``

Enable "strict mode": http://redsymbol.net/articles/unofficial-bash-strict-mode/