### PR TITLE
kube-aws: add script to run tests

### DIFF
--- a/multi-node/aws/test
+++ b/multi-node/aws/test
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+go test $(go list ./... | grep -v '/vendor/')


### PR DESCRIPTION
easier than always using ctrl+r