### PR TITLE
Use kubectl instead of curl to load kube-system manifests

### DIFF
--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -81,7 +81,7 @@ coreos:
         Type=simple
         StartLimitInterval=0
         Restart=on-failure
-        ExecStartPre=/usr/bin/curl http://127.0.0.1:8080/version
+        ExecStartPre=/usr/bin/curl -f http://127.0.0.1:8080/version
         ExecStart=/opt/bin/install-kube-system
 
 write_files:
@@ -90,21 +90,17 @@ write_files:
     owner: root:root
     content: |
       #!/bin/bash -e
-      /usr/bin/curl -H "Content-Type: application/json" -XPOST -d @"/srv/kubernetes/manifests/kube-system.json" "http://127.0.0.1:8080/api/v1/namespaces"
+      docker run -v /etc/kubernetes:/etc/kubernetes \
+                 -v /srv/kubernetes:/srv/kubernetes \
+                 --net host \
+                 --rm lachlanevenson/k8s-kubectl \
+                 apply -f /srv/kubernetes/manifests/kube-system.json
 
-      /usr/bin/curl  -H "Content-Type: application/json" -XPOST \
-      -d @"/srv/kubernetes/manifests/kube-dns-rc.json" \
-      "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers"
-
-      /usr/bin/curl  -H "Content-Type: application/json" -XPOST \
-      -d @"/srv/kubernetes/manifests/heapster-dc.json" \
-      "http://127.0.0.1:8080/apis/extensions/v1beta1/namespaces/kube-system/deployments"
-
-      for manifest in {kube-dns,heapster}-svc.json;do
-          /usr/bin/curl  -H "Content-Type: application/json" -XPOST \
-          -d @"/srv/kubernetes/manifests/$manifest" \
-          "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services"
-      done
+      docker run -v /etc/kubernetes:/etc/kubernetes \
+                 -v /srv/kubernetes:/srv/kubernetes \
+                 --net host \
+                 --rm lachlanevenson/k8s-kubectl \
+                 apply -f /srv/kubernetes/manifests/
 
   - path: /opt/bin/decrypt-tls-assets
     owner: root:root


### PR DESCRIPTION
curl can silently fail, leaving the kube system only partially set up

ideally we would use the quay.io/coreos/hyperkube:v1.2.2_coreos.0 image and run /hyperkube kubectl, however this doesn't work due to

https://github.com/kubernetes/kubernetes/issues/24088

this PR uses a 3rd party image for kubectl, which means it shouldn't be merged. 

i am hoping someone can help me add kubectl to the hyperkube image directly, or suggest other alternatives
