### PR TITLE
Add flag to point Kubernetes volume_plugin_dir to a subdir mounted in…

### DIFF
--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -91,7 +91,8 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --config=/etc/kubernetes/manifests \
   --hostname-override=${ADVERTISE_IP} \
   --cluster_dns=${DNS_SERVICE_IP} \
-  --cluster_domain=cluster.local
+  --cluster_domain=cluster.local \
+  --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec
 Restart=always
 RestartSec=10
 

--- a/multi-node/generic/worker-install.sh
+++ b/multi-node/generic/worker-install.sh
@@ -60,7 +60,8 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --cluster_domain=cluster.local \
   --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
   --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
-  --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem
+  --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
+  --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec
 Restart=always
 RestartSec=10
 

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -84,7 +84,8 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --config=/etc/kubernetes/manifests \
   --hostname-override=${ADVERTISE_IP} \
   --cluster_dns=${DNS_SERVICE_IP} \
-  --cluster_domain=cluster.local
+  --cluster_domain=cluster.local \
+  --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec
 Restart=always
 RestartSec=10
 


### PR DESCRIPTION
…to kubelet_wrapper. 

Since `/usr/libexec/...` is read-only on CoreOS, the default for this flag is completely useless. Let's make it useful.