### PR TITLE
kube-aws: Drain nodes before shutting them down

### DIFF
--- a/Documentation/kube-aws-cluster-updates.md
+++ b/Documentation/kube-aws-cluster-updates.md
@@ -1,0 +1,40 @@
+# kube-aws cluster updates
+
+## Types of cluster update
+There are two distinct categories of cluster update.
+
+* **Parameter-level update**: Only changes to `cluster.yaml` and/or TLS assets in `credentials/` folder are reflected. To enact this type of update. Modifications to CloudFormation or cloud-config userdata templates will not be reflected. In this case, you do not have to re-render:
+
+```sh
+kube-aws up --update
+```
+
+* **Full update**: Any change (besides changes made to the etcd cluster- more on that later) will be enacted, including structural changes to CloudFormation and cloudinit templates. This is the type of upgrade that must be run on installing a new version of kube-aws, or more generally when cloudinit or CloudFormation templates are modified:
+
+```sh
+kube-aws render
+git diff # view changes to rendered assets
+kube-aws up --update
+```
+
+## Certificate rotation
+
+The parameter-level update mechanism can be used to rotate in new TLS credentials:
+
+```sh
+kube-aws render --generate-credentials
+kube-aws up --update
+```
+
+## the etcd caveat
+
+There is no solution for hosting an etcd cluster in a way that is easily updateable in this fashion- so updates are automatically masked for the etcd instances. This means that, after the cluster is created, nothing about the etcd ec2 instances is allowed to be updated.
+
+Fortunately, CoreOS update engine will take care of keeping the members of the etcd cluster up-to-date, but you as the operator will not be able to modify them after creation via the update mechanism.
+
+In the (near) future, etcd will be hosted on Kubernetes and this problem will no longer be relevant. Rather than concocting overly complex bandaide, we've decided to "punt" on this issue of the time being.
+
+
+
+
+

--- a/Documentation/kubernetes-on-aws-render.md
+++ b/Documentation/kubernetes-on-aws-render.md
@@ -67,11 +67,23 @@ There will now be a `cluster.yaml` file in the asset directory. This is the main
 
 ### Render contents of the asset directory
 
-Next, generate a set of cluster assets in the current directory, based on the settings in your `cluster.yaml` file.
+* In the simplest case, you can have kube-aws generate both your TLS identities and certificate authority for you.
 
-```sh
-$ kube-aws render
-```
+  ```sh
+  $ kube-aws render --generate-credentials --generate-ca
+  ```
+
+  This is not recommended for production, but is fine for development or testing purposes.
+
+* It is recommended that you supply your own immediate certificate signing authority and let kube-aws take care of generating the cluster TLS credentials.
+
+  ```sh
+  $ kube-aws render --generate-credentials --ca-cert-path=/path/to/ca-cert.pem --ca-key-path=/path/to/ca-key.pem
+  ```
+
+  For more information on operating your own CA, check out this [awesome guide](https://jamielinux.com/docs/openssl-certificate-authority/).
+
+* In certain cases, such as users with advanced pre-existing PKI infrastructure, the operator may wish to pre-generate all cluster TLS assets. In this case, you can run `kube-aws render` and copy in your TLS assets into the `credentials/` folder before running `kube-aws up`.
 
 Here's what the directory structure looks like:
 
@@ -88,6 +100,10 @@ $ tree
 │   ├── ca.pem
 │   ├── worker-key.pem
 │   └── worker.pem
+│   ├── etcd-key.pem
+│   └── etcd.pem
+│   ├── etcd-client-key.pem
+│   └── etcd-client.pem
 ├── kubeconfig
 ├── stack-template.json
 └── userdata

--- a/multi-node/aws/README.md
+++ b/multi-node/aws/README.md
@@ -89,9 +89,31 @@ There will now be a cluster.yaml file in the asset directory.
 
 ## Render contents of the asset directory
 
-```sh
-$ kube-aws render
-```
+* In the simplest case, you can have kube-aws generate both your TLS identities and certificate authority for you.
+
+  ```sh
+  $ kube-aws render --generate-credentials --generate-ca
+  ```
+
+  This is not recommended for production.
+
+* It is recommended that, for production, you supply your own immediate certificate signing authority.
+
+  ```sh
+  $ kube-aws render --generate-credentials --ca-cert-path=/path/to/ca-cert.pem --ca-key-path=/path/to/ca-key.pem
+  ```
+
+  For more information on operating your own CA, check out this [awesome guide](https://jamielinux.com/docs/openssl-certificate-authority/).
+
+* In certain cases, such as users with advanced pre-existing PKI infrastructure, you may wish to pre-generate all cluster TLS assets. In this case, make sure the file tree below exists in your cluster assets directory before running `kube-aws up`.
+
+  ```sh
+  ls -R credentials/
+  credentials/:
+  admin-key.pem  apiserver-key.pem  ca.pem               etcd-client.pem  etcd.pem        worker.pem
+  admin.pem      apiserver.pem      etcd-client-key.pem  etcd-key.pem     worker-key.pem
+  ```
+
 
 This generates the default set of cluster assets in your asset directory. These assets are templates and credentials that are used to create, update and interact with your Kubernetes cluster.
 
@@ -161,6 +183,10 @@ It can take some time after `kube-aws up` completes before the cluster is availa
 ```sh
 $ kube-aws up --export
 ```
+
+## Update an existing kube-aws cluster
+
+Read the [cluster update](../../Documentation/kube-aws-cluster-updates.md) documentation.
 
 ## Development
 

--- a/multi-node/aws/cmd/kube-aws/command_render.go
+++ b/multi-node/aws/cmd/kube-aws/command_render.go
@@ -7,7 +7,13 @@ import (
 	"os"
 	"text/template"
 
+	"crypto/rsa"
+	"crypto/x509"
+
+	"path"
+
 	"github.com/coreos/coreos-kubernetes/multi-node/aws/pkg/config"
+	"github.com/coreos/coreos-kubernetes/multi-node/aws/pkg/tlsutil"
 	"github.com/spf13/cobra"
 )
 
@@ -19,10 +25,20 @@ var (
 		RunE:         runCmdRender,
 		SilenceUsage: true,
 	}
+	renderOpts = struct {
+		generateCredentials bool
+		generateCA          bool
+		caKeyPath           string
+		caCertPath          string
+	}{}
 )
 
 func init() {
 	cmdRoot.AddCommand(cmdRender)
+	cmdRender.Flags().BoolVar(&renderOpts.generateCredentials, "generate-credentials", false, "generate new cluster TLS assets")
+	cmdRender.Flags().BoolVar(&renderOpts.generateCA, "generate-ca", false, "if generating credentials, generate root CA key and cert. NOT RECOMMENDED FOR PRODUCTION USE- use '-ca-key-path' and '-ca-cert-path' options to provide your own certificate authority assets")
+	cmdRender.Flags().StringVar(&renderOpts.caKeyPath, "ca-key-path", "./credentials/ca-key.pem", "path to pem-encoded CA RSA key")
+	cmdRender.Flags().StringVar(&renderOpts.caCertPath, "ca-cert-path", "./credentials/ca.pem", "path to pem-encoded CA x509 certificate")
 }
 
 func runCmdRender(cmd *cobra.Command, args []string) error {
@@ -32,16 +48,45 @@ func runCmdRender(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Failed to read cluster config: %v", err)
 	}
 
-	// Generate default TLS assets.
-	assets, err := cluster.NewTLSAssets()
-	if err != nil {
-		return fmt.Errorf("Error generating default assets: %v", err)
-	}
-	if err := os.Mkdir("credentials", 0700); err != nil {
-		return err
-	}
-	if err := assets.WriteToDir("./credentials"); err != nil {
-		return fmt.Errorf("Error create assets: %v", err)
+	if renderOpts.generateCredentials {
+		fmt.Printf("Generating TLS credentials...\n")
+		var caKey *rsa.PrivateKey
+		var caCert *x509.Certificate
+		if renderOpts.generateCA {
+			var err error
+			caKey, caCert, err = config.NewTLSCA()
+			if err != nil {
+				return fmt.Errorf("failed generating cluster CA: %v", err)
+			}
+			fmt.Printf("-> Generating new TLS CA\n")
+		} else {
+			fmt.Printf("-> Parsing existing TLS CA\n")
+			if caKeyBytes, err := ioutil.ReadFile(renderOpts.caKeyPath); err != nil {
+				return fmt.Errorf("failed reading ca key file %s : %v", renderOpts.caKeyPath, err)
+			} else {
+				if caKey, err = tlsutil.DecodePrivateKeyPEM(caKeyBytes); err != nil {
+					return fmt.Errorf("failed parsing ca key: %v", err)
+				}
+			}
+			if caCertBytes, err := ioutil.ReadFile(renderOpts.caCertPath); err != nil {
+				return fmt.Errorf("failed reading ca cert file %s : %v", renderOpts.caCertPath, err)
+			} else {
+				if caCert, err = tlsutil.DecodeCertificatePEM(caCertBytes); err != nil {
+					return fmt.Errorf("failed parsing ca cert: %v", err)
+				}
+			}
+		}
+		fmt.Printf("-> Generating new TLS assets\n")
+		assets, err := cluster.NewTLSAssets(caKey, caCert)
+		if err != nil {
+			return fmt.Errorf("Error generating default assets: %v", err)
+		}
+		if err := os.MkdirAll("credentials", 0700); err != nil {
+			return err
+		}
+		if err := assets.WriteToDir("./credentials", renderOpts.generateCA); err != nil {
+			return fmt.Errorf("Error create assets: %v", err)
+		}
 	}
 
 	// Create a Config and attempt to render a kubeconfig for it.
@@ -59,10 +104,6 @@ func runCmdRender(cmd *cobra.Command, args []string) error {
 	}
 
 	// Write all assets to disk.
-	userdataDir := "userdata"
-	if err := os.Mkdir(userdataDir, 0755); err != nil {
-		return err
-	}
 	files := []struct {
 		name string
 		data []byte
@@ -76,6 +117,10 @@ func runCmdRender(cmd *cobra.Command, args []string) error {
 		{"kubeconfig", kubeconfig.Bytes(), 0600},
 	}
 	for _, file := range files {
+		if err := os.MkdirAll(path.Dir(file.name), 0755); err != nil {
+			return err
+		}
+
 		if err := ioutil.WriteFile(file.name, file.data, file.mode); err != nil {
 			return err
 		}

--- a/multi-node/aws/cmd/kube-aws/command_render.go
+++ b/multi-node/aws/cmd/kube-aws/command_render.go
@@ -71,6 +71,7 @@ func runCmdRender(cmd *cobra.Command, args []string) error {
 		{"credentials/.gitignore", []byte("*"), 0644},
 		{"userdata/cloud-config-controller", config.CloudConfigController, 0644},
 		{"userdata/cloud-config-worker", config.CloudConfigWorker, 0644},
+		{"userdata/cloud-config-etcd", config.CloudConfigEtcd, 0644},
 		{"stack-template.json", config.StackTemplateTemplate, 0644},
 		{"kubeconfig", kubeconfig.Bytes(), 0600},
 	}

--- a/multi-node/aws/cmd/kube-aws/command_up.go
+++ b/multi-node/aws/cmd/kube-aws/command_up.go
@@ -26,7 +26,7 @@ var (
 func init() {
 	cmdRoot.AddCommand(cmdUp)
 	cmdUp.Flags().BoolVar(&upOpts.export, "export", false, "Don't create cluster, instead export cloudformation stack file")
-	//	cmdUp.Flags().BoolVar(&upOpts.update, "update", false, "update existing cluster with new cloudformation stack")
+	cmdUp.Flags().BoolVar(&upOpts.update, "update", false, "update existing cluster with new cloudformation stack")
 	cmdUp.Flags().BoolVar(&upOpts.awsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")
 }
 

--- a/multi-node/aws/cmd/kube-aws/main.go
+++ b/multi-node/aws/cmd/kube-aws/main.go
@@ -21,6 +21,7 @@ var stackTemplateOptions = config.StackTemplateOptions{
 	TLSAssetsDir:          "credentials",
 	ControllerTmplFile:    "userdata/cloud-config-controller",
 	WorkerTmplFile:        "userdata/cloud-config-worker",
+	EtcdTmplFile:          "userdata/cloud-config-etcd",
 	StackTemplateTmplFile: "stack-template.json",
 }
 

--- a/multi-node/aws/pkg/cluster/cluster.go
+++ b/multi-node/aws/pkg/cluster/cluster.go
@@ -24,8 +24,8 @@ import (
 var VERSION = "UNKNOWN"
 
 type Info struct {
-	Name         string
-	ControllerIP string
+	Name              string
+	ControllerELBInfo string
 }
 
 func (c *Info) String() string {
@@ -34,7 +34,7 @@ func (c *Info) String() string {
 	w.Init(buf, 0, 8, 0, '\t', 0)
 
 	fmt.Fprintf(w, "Cluster Name:\t%s\n", c.Name)
-	fmt.Fprintf(w, "Controller IP:\t%s\n", c.ControllerIP)
+	fmt.Fprintf(w, "Controller ELB Info:\t%s\n", c.ControllerELBInfo)
 
 	w.Flush()
 	return buf.String()
@@ -343,7 +343,7 @@ func (c *Cluster) Info() (*Info, error) {
 	cfSvc := cloudformation.New(c.session)
 	resp, err := cfSvc.DescribeStackResource(
 		&cloudformation.DescribeStackResourceInput{
-			LogicalResourceId: aws.String("EIPController"),
+			LogicalResourceId: aws.String("ElbAPIServer"),
 			StackName:         aws.String(c.ClusterName),
 		},
 	)
@@ -353,7 +353,7 @@ func (c *Cluster) Info() (*Info, error) {
 	}
 
 	var info Info
-	info.ControllerIP = *resp.StackResourceDetail.PhysicalResourceId
+	info.ControllerELBInfo = resp.StackResourceDetail.String()
 	info.Name = c.ClusterName
 	return &info, nil
 }

--- a/multi-node/aws/pkg/cluster/cluster.go
+++ b/multi-node/aws/pkg/cluster/cluster.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/route53"
 
 	"github.com/coreos/coreos-kubernetes/multi-node/aws/pkg/config"
@@ -24,8 +25,8 @@ import (
 var VERSION = "UNKNOWN"
 
 type Info struct {
-	Name              string
-	ControllerELBInfo string
+	Name           string
+	ControllerHost string
 }
 
 func (c *Info) String() string {
@@ -34,7 +35,7 @@ func (c *Info) String() string {
 	w.Init(buf, 0, 8, 0, '\t', 0)
 
 	fmt.Fprintf(w, "Cluster Name:\t%s\n", c.Name)
-	fmt.Fprintf(w, "Controller ELB Info:\t%s\n", c.ControllerELBInfo)
+	fmt.Fprintf(w, "Controller DNS Name:\t%s\n", c.ControllerHost)
 
 	w.Flush()
 	return buf.String()
@@ -340,21 +341,45 @@ func (c *Cluster) Update(stackBody string) (string, error) {
 }
 
 func (c *Cluster) Info() (*Info, error) {
-	cfSvc := cloudformation.New(c.session)
-	resp, err := cfSvc.DescribeStackResource(
-		&cloudformation.DescribeStackResourceInput{
-			LogicalResourceId: aws.String("ElbAPIServer"),
-			StackName:         aws.String(c.ClusterName),
-		},
-	)
-	if err != nil {
-		errmsg := "unable to get public IP of controller instance:\n" + err.Error()
-		return nil, fmt.Errorf(errmsg)
+	var elbName string
+	{
+		cfSvc := cloudformation.New(c.session)
+		resp, err := cfSvc.DescribeStackResource(
+			&cloudformation.DescribeStackResourceInput{
+				LogicalResourceId: aws.String("ElbAPIServer"),
+				StackName:         aws.String(c.ClusterName),
+			},
+		)
+		if err != nil {
+			errmsg := "unable to get public IP of controller instance:\n" + err.Error()
+			return nil, fmt.Errorf(errmsg)
+		}
+		elbName = *resp.StackResourceDetail.PhysicalResourceId
 	}
 
+	elbSvc := elb.New(c.session)
+
 	var info Info
-	info.ControllerELBInfo = resp.StackResourceDetail.String()
-	info.Name = c.ClusterName
+	{
+		resp, err := elbSvc.DescribeLoadBalancers(&elb.DescribeLoadBalancersInput{
+			LoadBalancerNames: []*string{
+				aws.String(elbName),
+			},
+			PageSize: aws.Int64(2),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("error describing load balancer %s: %v", elbName, err)
+		}
+		if len(resp.LoadBalancerDescriptions) == 0 {
+			return nil, fmt.Errorf("could not find a load balancer with name %s", elbName)
+		}
+		if len(resp.LoadBalancerDescriptions) > 1 {
+			return nil, fmt.Errorf("found multiple load balancers with name %s: %v", elbName, resp)
+		}
+
+		info.Name = c.ClusterName
+		info.ControllerHost = *resp.LoadBalancerDescriptions[0].DNSName
+	}
 	return &info, nil
 }
 

--- a/multi-node/aws/pkg/config/config.go
+++ b/multi-node/aws/pkg/config/config.go
@@ -28,6 +28,12 @@ const (
 )
 
 func newDefaultCluster() *Cluster {
+	experimental := Experimental{
+		NodeDrainer{
+			Enabled: false,
+		},
+	}
+
 	return &Cluster{
 		ClusterName:              "kubernetes",
 		ReleaseChannel:           "stable",
@@ -54,6 +60,7 @@ func newDefaultCluster() *Cluster {
 		CreateRecordSet:          false,
 		RecordSetTTL:             300,
 		Subnets:                  []*Subnet{},
+		Experimental:             experimental,
 	}
 }
 
@@ -146,12 +153,21 @@ type Cluster struct {
 	StackTags                map[string]string `yaml:"stackTags,omitempty"`
 	UseCalico                bool              `yaml:"useCalico,omitempty"`
 	Subnets                  []*Subnet         `yaml:"subnets,omitempty"`
+	Experimental             Experimental      `yaml:"experimental"`
 }
 
 type Subnet struct {
 	AvailabilityZone  string `yaml:"availabilityZone,omitempty"`
 	InstanceCIDR      string `yaml:"instanceCIDR,omitempty"`
 	lastAllocatedAddr *net.IP
+}
+
+type Experimental struct {
+	NodeDrainer NodeDrainer `yaml:"nodeDrainer"`
+}
+
+type NodeDrainer struct {
+	Enabled bool `yaml:"enabled"`
 }
 
 const (

--- a/multi-node/aws/pkg/config/config.go
+++ b/multi-node/aws/pkg/config/config.go
@@ -47,9 +47,13 @@ func newDefaultCluster() *Cluster {
 		WorkerRootVolumeType:     "gp2",
 		WorkerRootVolumeIOPS:     0,
 		WorkerRootVolumeSize:     30,
+		EtcdCount:                1,
+		EtcdInstanceType:         "m3.medium",
+		EtcdRootVolumeSize:       30,
+		EtcdDataVolumeSize:       30,
 		CreateRecordSet:          false,
 		RecordSetTTL:             300,
-		Subnets:                  []Subnet{},
+		Subnets:                  []*Subnet{},
 	}
 }
 
@@ -91,7 +95,7 @@ func ClusterFromBytes(data []byte) (*Cluster, error) {
 
 	// For backward-compatibility
 	if len(c.Subnets) == 0 {
-		c.Subnets = []Subnet{
+		c.Subnets = []*Subnet{
 			{
 				AvailabilityZone: c.AvailabilityZone,
 				InstanceCIDR:     c.InstanceCIDR,
@@ -119,6 +123,11 @@ type Cluster struct {
 	WorkerRootVolumeIOPS     int               `yaml:"workerRootVolumeIOPS,omitempty"`
 	WorkerRootVolumeSize     int               `yaml:"workerRootVolumeSize,omitempty"`
 	WorkerSpotPrice          string            `yaml:"workerSpotPrice,omitempty"`
+	EtcdCount                int               `yaml:"etcdCount"`
+	EtcdInstanceType         string            `yaml:"etcdInstanceType,omitempty"`
+	EtcdRootVolumeSize       int               `yaml:"etcdRootVolumeSize,omitempty"`
+	EtcdDataVolumeSize       int               `yaml:"etcdDataVolumeSize,omitempty"`
+	EtcdDataVolumeEphemeral  bool              `yaml:"etcdDataVolumEphemeral,omitempty"`
 	VPCID                    string            `yaml:"vpcId,omitempty"`
 	RouteTableID             string            `yaml:"routeTableId,omitempty"`
 	VPCCIDR                  string            `yaml:"vpcCIDR,omitempty"`
@@ -136,12 +145,13 @@ type Cluster struct {
 	HostedZoneID             string            `yaml:"hostedZoneId,omitempty"`
 	StackTags                map[string]string `yaml:"stackTags,omitempty"`
 	UseCalico                bool              `yaml:"useCalico,omitempty"`
-	Subnets                  []Subnet          `yaml:"subnets,omitempty"`
+	Subnets                  []*Subnet         `yaml:"subnets,omitempty"`
 }
 
 type Subnet struct {
-	AvailabilityZone string `yaml:"availabilityZone,omitempty"`
-	InstanceCIDR     string `yaml:"instanceCIDR,omitempty"`
+	AvailabilityZone  string `yaml:"availabilityZone,omitempty"`
+	InstanceCIDR      string `yaml:"instanceCIDR,omitempty"`
+	lastAllocatedAddr *net.IP
 }
 
 const (
@@ -156,7 +166,7 @@ var supportedReleaseChannels = map[string]bool{
 
 func (c Cluster) Config() (*Config, error) {
 	config := Config{Cluster: c}
-	config.ETCDEndpoints = fmt.Sprintf("http://%s:2379", c.ControllerIP)
+
 	config.APIServers = fmt.Sprintf("http://%s:8080", c.ControllerIP)
 	config.SecureAPIServers = fmt.Sprintf("https://%s:443", c.ControllerIP)
 	config.APIServerEndpoint = fmt.Sprintf("https://%s", c.ExternalDNSName)
@@ -181,6 +191,68 @@ func (c Cluster) Config() (*Config, error) {
 		config.VPCRef = fmt.Sprintf("%q", config.VPCID)
 	}
 
+	config.EtcdInstances = make([]etcdInstance, config.EtcdCount)
+	var etcdEndpoints, etcdInitialCluster bytes.Buffer
+	for etcdIndex := 0; etcdIndex < config.EtcdCount; etcdIndex++ {
+
+		//Round-robbin etcd instances across all available subnets
+		subnetIndex := etcdIndex % len(config.Subnets)
+		subnet := config.Subnets[subnetIndex]
+
+		_, subnetCIDR, err := net.ParseCIDR(subnet.InstanceCIDR)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing subnet instance cidr %s: %v", subnet.InstanceCIDR, err)
+		}
+		if subnet.lastAllocatedAddr == nil {
+			subnet.lastAllocatedAddr = &subnetCIDR.IP
+		}
+
+		nextAddr := incrementIP(*subnet.lastAllocatedAddr)
+		subnet.lastAllocatedAddr = &nextAddr
+		instance := etcdInstance{
+			IPAddress:   *subnet.lastAllocatedAddr,
+			SubnetIndex: subnetIndex,
+		}
+
+		//TODO: validate we're not overflowing the address space
+		//This is complicated, must also factor in DHCP addresses
+		//for ASG components
+
+		config.EtcdInstances[etcdIndex] = instance
+
+		//TODO: ipv6 support
+		if len(instance.IPAddress) != 4 {
+			return nil, fmt.Errorf("Non ipv4 address for etcd node: %v", instance.IPAddress)
+		}
+
+		//http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html#concepts-private-addresses
+
+		var dnsSuffix string
+		if config.Region == "us-east-1" {
+			// a special DNS suffix for the original AWS region!
+			dnsSuffix = "ec2.internal"
+		} else {
+			dnsSuffix = fmt.Sprintf("%s.compute.internal", config.Region)
+		}
+
+		hostname := fmt.Sprintf("ip-%d-%d-%d-%d.%s",
+			instance.IPAddress[0],
+			instance.IPAddress[1],
+			instance.IPAddress[2],
+			instance.IPAddress[3],
+			dnsSuffix,
+		)
+
+		fmt.Fprintf(&etcdEndpoints, "https://%s:2379", hostname)
+		fmt.Fprintf(&etcdInitialCluster, "%s=https://%s:2380", hostname, hostname)
+		if etcdIndex < config.EtcdCount-1 {
+			fmt.Fprintf(&etcdEndpoints, ",")
+			fmt.Fprintf(&etcdInitialCluster, ",")
+		}
+	}
+	config.EtcdEndpoints = etcdEndpoints.String()
+	config.EtcdInitialCluster = etcdInitialCluster.String()
+
 	return &config, nil
 }
 
@@ -188,6 +260,7 @@ type StackTemplateOptions struct {
 	TLSAssetsDir          string
 	ControllerTmplFile    string
 	WorkerTmplFile        string
+	EtcdTmplFile          string
 	StackTemplateTmplFile string
 }
 
@@ -195,6 +268,7 @@ type stackConfig struct {
 	*Config
 	UserDataWorker        string
 	UserDataController    string
+	UserDataEtcd          string
 	ControllerSubnetIndex int
 }
 
@@ -245,6 +319,7 @@ func (c Cluster) stackConfig(opts StackTemplateOptions, compressUserData bool) (
 	if controllerIPAddr == nil {
 		return nil, fmt.Errorf("invalid controllerIP: %s", stackConfig.ControllerIP)
 	}
+
 	controllerSubnetFound := false
 	for i, subnet := range stackConfig.Subnets {
 		_, instanceCIDR, err := net.ParseCIDR(subnet.InstanceCIDR)
@@ -265,6 +340,9 @@ func (c Cluster) stackConfig(opts StackTemplateOptions, compressUserData bool) (
 	}
 	if stackConfig.UserDataController, err = execute(opts.ControllerTmplFile, stackConfig.Config, compressUserData); err != nil {
 		return nil, fmt.Errorf("failed to render controller cloud config: %v", err)
+	}
+	if stackConfig.UserDataEtcd, err = execute(opts.EtcdTmplFile, stackConfig.Config, compressUserData); err != nil {
+		return nil, fmt.Errorf("failed to render etcd cloud config: %v", err)
 	}
 
 	return &stackConfig, nil
@@ -289,6 +367,10 @@ func (c Cluster) ValidateUserData(opts StackTemplateOptions) error {
 		{
 			Content: stackConfig.UserDataController,
 			Name:    "UserDataController",
+		},
+		{
+			Content: stackConfig.UserDataEtcd,
+			Name:    "UserDataEtcd",
 		},
 	} {
 		report, err := validate.Validate([]byte(userData.Content))
@@ -369,10 +451,18 @@ func getContextString(buf []byte, offset, lineCount int) string {
 	return string(buf[leftLimit:rightLimit])
 }
 
+type etcdInstance struct {
+	IPAddress   net.IP
+	SubnetIndex int
+}
+
 type Config struct {
 	Cluster
 
-	ETCDEndpoints     string
+	EtcdEndpoints      string
+	EtcdInitialCluster string
+	EtcdInstances      []etcdInstance
+
 	APIServers        string
 	SecureAPIServers  string
 	APIServerEndpoint string

--- a/multi-node/aws/pkg/config/config.go
+++ b/multi-node/aws/pkg/config/config.go
@@ -32,12 +32,12 @@ func newDefaultCluster() *Cluster {
 		ClusterName:              "kubernetes",
 		ReleaseChannel:           "stable",
 		VPCCIDR:                  "10.0.0.0/16",
-		ControllerIP:             "10.0.0.50",
 		PodCIDR:                  "10.2.0.0/16",
 		ServiceCIDR:              "10.3.0.0/24",
 		DNSServiceIP:             "10.3.0.10",
 		K8sVer:                   "v1.3.4_coreos.0",
 		HyperkubeImageRepo:       "quay.io/coreos/hyperkube",
+		ControllerCount:          1,
 		ControllerInstanceType:   "m3.medium",
 		ControllerRootVolumeType: "gp2",
 		ControllerRootVolumeIOPS: 0,
@@ -113,6 +113,7 @@ type Cluster struct {
 	Region                   string            `yaml:"region,omitempty"`
 	AvailabilityZone         string            `yaml:"availabilityZone,omitempty"`
 	ReleaseChannel           string            `yaml:"releaseChannel,omitempty"`
+	ControllerCount          int               `yaml:"controllerCount,omitempty"`
 	ControllerInstanceType   string            `yaml:"controllerInstanceType,omitempty"`
 	ControllerRootVolumeType string            `yaml:"controllerRootVolumeType,omitempty"`
 	ControllerRootVolumeIOPS int               `yaml:"controllerRootVolumeIOPS,omitempty"`
@@ -132,7 +133,6 @@ type Cluster struct {
 	RouteTableID             string            `yaml:"routeTableId,omitempty"`
 	VPCCIDR                  string            `yaml:"vpcCIDR,omitempty"`
 	InstanceCIDR             string            `yaml:"instanceCIDR,omitempty"`
-	ControllerIP             string            `yaml:"controllerIP,omitempty"`
 	PodCIDR                  string            `yaml:"podCIDR,omitempty"`
 	ServiceCIDR              string            `yaml:"serviceCIDR,omitempty"`
 	DNSServiceIP             string            `yaml:"dnsServiceIP,omitempty"`
@@ -167,8 +167,6 @@ var supportedReleaseChannels = map[string]bool{
 func (c Cluster) Config() (*Config, error) {
 	config := Config{Cluster: c}
 
-	config.APIServers = fmt.Sprintf("http://%s:8080", c.ControllerIP)
-	config.SecureAPIServers = fmt.Sprintf("https://%s:443", c.ControllerIP)
 	config.APIServerEndpoint = fmt.Sprintf("https://%s", c.ExternalDNSName)
 	if config.UseCalico {
 		config.K8sNetworkPlugin = "cni"
@@ -324,26 +322,6 @@ func (c Cluster) stackConfig(opts StackTemplateOptions, compressUserData bool) (
 
 	stackConfig.Config.TLSConfig = compactAssets
 
-	controllerIPAddr := net.ParseIP(stackConfig.ControllerIP)
-	if controllerIPAddr == nil {
-		return nil, fmt.Errorf("invalid controllerIP: %s", stackConfig.ControllerIP)
-	}
-
-	controllerSubnetFound := false
-	for i, subnet := range stackConfig.Subnets {
-		_, instanceCIDR, err := net.ParseCIDR(subnet.InstanceCIDR)
-		if err != nil {
-			return nil, fmt.Errorf("invalid instanceCIDR: %v", err)
-		}
-		if instanceCIDR.Contains(controllerIPAddr) {
-			stackConfig.ControllerSubnetIndex = i
-			controllerSubnetFound = true
-		}
-	}
-	if !controllerSubnetFound {
-		return nil, fmt.Errorf("Fail-fast occurred possibly because of a bug: ControllerSubnetIndex couldn't be determined for subnets (%v) and controllerIP (%v)", stackConfig.Subnets, stackConfig.ControllerIP)
-	}
-
 	if stackConfig.UserDataWorker, err = execute(opts.WorkerTmplFile, stackConfig.Config, compressUserData); err != nil {
 		return nil, fmt.Errorf("failed to render worker cloud config: %v", err)
 	}
@@ -472,8 +450,6 @@ type Config struct {
 	EtcdInitialCluster string
 	EtcdInstances      []etcdInstance
 
-	APIServers        string
-	SecureAPIServers  string
 	APIServerEndpoint string
 	AMI               string
 
@@ -543,11 +519,6 @@ func (c Cluster) valid() error {
 		return fmt.Errorf("invalid vpcCIDR: %v", err)
 	}
 
-	controllerIPAddr := net.ParseIP(c.ControllerIP)
-	if controllerIPAddr == nil {
-		return fmt.Errorf("invalid controllerIP: %s", c.ControllerIP)
-	}
-
 	if len(c.Subnets) == 0 {
 		if c.AvailabilityZone == "" {
 			return fmt.Errorf("availabilityZone must be set")
@@ -560,12 +531,6 @@ func (c Cluster) valid() error {
 			return fmt.Errorf("vpcCIDR (%s) does not contain instanceCIDR (%s)",
 				c.VPCCIDR,
 				c.InstanceCIDR,
-			)
-		}
-		if !instanceCIDR.Contains(controllerIPAddr) {
-			return fmt.Errorf("instanceCIDR (%s) does not contain controllerIP (%s)",
-				c.InstanceCIDR,
-				c.ControllerIP,
 			)
 		}
 	} else {
@@ -595,22 +560,9 @@ func (c Cluster) valid() error {
 			}
 		}
 
-		controllerInstanceCidrExists := false
-		for _, a := range instanceCIDRs {
-			if a.Contains(controllerIPAddr) {
-				controllerInstanceCidrExists = true
-			}
-		}
-		if !controllerInstanceCidrExists {
-			return fmt.Errorf("No instanceCIDRs in Subnets (%v) contain controllerIP (%s)",
-				instanceCIDRs,
-				c.ControllerIP,
-			)
-		}
-
 		for i, a := range instanceCIDRs {
 			for j, b := range instanceCIDRs[i+1:] {
-				if i > 0 && cidrOverlap(a, b) {
+				if cidrOverlap(a, b) {
 					return fmt.Errorf("CIDR of subnet %d (%s) overlaps with CIDR of subnet %d (%s)", i, a, j, b)
 				}
 			}

--- a/multi-node/aws/pkg/config/config.go
+++ b/multi-node/aws/pkg/config/config.go
@@ -167,6 +167,12 @@ var supportedReleaseChannels = map[string]bool{
 func (c Cluster) Config() (*Config, error) {
 	config := Config{Cluster: c}
 
+	config.MinWorkerCount = config.WorkerCount - 1
+	config.MaxWorkerCount = config.WorkerCount + 1
+
+	config.MinControllerCount = config.ControllerCount - 1
+	config.MaxControllerCount = config.ControllerCount + 1
+
 	config.APIServerEndpoint = fmt.Sprintf("https://%s", c.ExternalDNSName)
 	if config.UseCalico {
 		config.K8sNetworkPlugin = "cni"
@@ -445,6 +451,12 @@ type etcdInstance struct {
 
 type Config struct {
 	Cluster
+
+	MinWorkerCount int
+	MaxWorkerCount int
+
+	MinControllerCount int
+	MaxControllerCount int
 
 	EtcdEndpoints      string
 	EtcdInitialCluster string

--- a/multi-node/aws/pkg/config/config_test.go
+++ b/multi-node/aws/pkg/config/config_test.go
@@ -307,7 +307,7 @@ func TestMultipleSubnets(t *testing.T) {
 
 	validConfigs := []struct {
 		conf    string
-		subnets []Subnet
+		subnets []*Subnet
 	}{
 		{
 			conf: `
@@ -320,7 +320,7 @@ subnets:
   - availabilityZone: ap-northeast-1c
     instanceCIDR: 10.4.4.0/24
 `,
-			subnets: []Subnet{
+			subnets: []*Subnet{
 				{
 					InstanceCIDR:     "10.4.3.0/24",
 					AvailabilityZone: "ap-northeast-1a",
@@ -339,7 +339,7 @@ controllerIP: 10.4.3.50
 availabilityZone: ap-northeast-1a
 instanceCIDR: 10.4.3.0/24
 `,
-			subnets: []Subnet{
+			subnets: []*Subnet{
 				{
 					AvailabilityZone: "ap-northeast-1a",
 					InstanceCIDR:     "10.4.3.0/24",
@@ -355,7 +355,7 @@ availabilityZone: ap-northeast-1a
 instanceCIDR: 10.4.3.0/24
 subnets: []
 `,
-			subnets: []Subnet{
+			subnets: []*Subnet{
 				{
 					AvailabilityZone: "ap-northeast-1a",
 					InstanceCIDR:     "10.4.3.0/24",
@@ -368,7 +368,7 @@ subnets: []
 availabilityZone: "ap-northeast-1a"
 subnets: []
 `,
-			subnets: []Subnet{
+			subnets: []*Subnet{
 				{
 					AvailabilityZone: "ap-northeast-1a",
 					InstanceCIDR:     "10.0.0.0/24",
@@ -380,7 +380,7 @@ subnets: []
 # Missing subnets field fall-backs to the single subnet with the default az/cidr.
 availabilityZone: "ap-northeast-1a"
 `,
-			subnets: []Subnet{
+			subnets: []*Subnet{
 				{
 					AvailabilityZone: "ap-northeast-1a",
 					InstanceCIDR:     "10.0.0.0/24",

--- a/multi-node/aws/pkg/config/config_test.go
+++ b/multi-node/aws/pkg/config/config_test.go
@@ -456,7 +456,7 @@ subnets:
 		confBody := minimalConfigYaml + conf
 		_, err := ClusterFromBytes([]byte(confBody))
 		if err == nil {
-			t.Errorf("expected error parsing invalid config: %s", confBody)
+			t.Errorf("expected error parsing invalid config:\n%s", confBody)
 		}
 	}
 

--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -2,20 +2,15 @@
 coreos:
   update:
     reboot-strategy: "off"
+
   flannel:
     interface: $private_ipv4
-    etcd_endpoints: {{ .ETCDEndpoints }}
-  etcd2:
-    name: controller
-    advertise-client-urls: http://$private_ipv4:2379
-    initial-advertise-peer-urls: http://$private_ipv4:2380
-    listen-client-urls: http://0.0.0.0:2379
-    listen-peer-urls: http://0.0.0.0:2380
-    initial-cluster: controller=http://$private_ipv4:2380
-  units:
-    - name: etcd2.service
-      command: start
+    etcd_endpoints: {{ .EtcdEndpoints }}
+    etcd_cafile: /etc/kubernetes/ssl/ca.pem
+    etcd_certfile: /etc/kubernetes/ssl/etcd-client.pem
+    etcd_keyfile: /etc/kubernetes/ssl/etcd-client-key.pem
 
+  units:
     - name: docker.service
       drop-ins:
         - name: 40-flannel.conf
@@ -28,10 +23,17 @@ coreos:
       drop-ins:
         - name: 10-etcd.conf
           content: |
+            [Unit]
+            Requires=decrypt-tls-assets.service
+            After=decrypt-tls-assets.service
             [Service]
-            ExecStartPre=/usr/bin/curl --silent -X PUT -d \
-            "value={\"Network\" : \"{{.PodCIDR}}\", \"Backend\" : {\"Type\" : \"vxlan\"}}" \
-            http://localhost:2379/v2/keys/coreos.com/network/config?prevExist=false
+            Environment="ETCD_SSL_DIR=/etc/kubernetes/ssl"
+            ExecStartPre=/usr/bin/etcdctl \
+            --ca-file=/etc/kubernetes/ssl/ca.pem \
+            --cert-file=/etc/kubernetes/ssl/etcd-client.pem \
+            --key-file=/etc/kubernetes/ssl/etcd-client-key.pem \
+            --endpoints="{{.EtcdEndpoints}}" \
+            set /coreos.com/network/config '{"Network" : "{{.PodCIDR}}", "Backend" : {"Type" : "vxlan"}}'
     - name: kubelet.service
       command: start
       enable: true
@@ -73,7 +75,7 @@ coreos:
         Environment=FELIX_FELIXHOSTNAME=$private_ipv4
         Environment=CALICO_NETWORKING=false
         Environment=NO_DEFAULT_POOLS=true
-        Environment=ETCD_ENDPOINTS={{ .ETCDEndpoints }}
+        Environment=ETCD_ENDPOINTS={{ .EtcdEndpoints }}
         ExecStart=/usr/bin/rkt run --inherit-env --stage1-from-dir=stage1-fly.aci \
         --volume=modules,kind=host,source=/lib/modules,readOnly=false \
         --mount=volume=modules,target=/lib/modules \
@@ -91,17 +93,18 @@ coreos:
       content: |
         [Unit]
         Description=decrypt kubelet tls assets using amazon kms
-        Before=kubelet.service
-        After=docker.service
-        Requires=docker.service
+        Before=kubelet.service flanneld.service
+        After=early-docker.service
+        Requires=early-docker.service
 
         [Service]
         Type=oneshot
         RemainAfterExit=yes
+        Environment="DOCKER_HOST=unix:///var/run/early-docker.sock"
         ExecStart=/opt/bin/decrypt-tls-assets
 
         [Install]
-        RequiredBy=kubelet.service
+        RequiredBy=kubelet.service flanneld.service
 
     - name: install-kube-system.service
       command: start
@@ -176,7 +179,7 @@ write_files:
 
       for encKey in $(find /etc/kubernetes/ssl/*.pem.enc);do
         tmpPath="/tmp/$(basename $encKey).tmp"
-        docker run --rm -v /etc/kubernetes/ssl:/etc/kubernetes/ssl --rm quay.io/coreos/awscli aws --region {{.Region}} kms decrypt --ciphertext-blob fileb://$encKey --output text --query Plaintext | base64 --decode > $tmpPath
+        docker run --net host --rm -v /etc/kubernetes/ssl:/etc/kubernetes/ssl quay.io/coreos/awscli aws --region {{.Region}} kms decrypt --ciphertext-blob fileb://$encKey --output text --query Plaintext | base64 --decode > $tmpPath
         mv  $tmpPath /etc/kubernetes/ssl/$(basename $encKey .enc)
       done
 
@@ -223,7 +226,10 @@ write_files:
           - /hyperkube
           - apiserver
           - --bind-address=0.0.0.0
-          - --etcd-servers=http://localhost:2379
+          - --etcd-servers={{.EtcdEndpoints}}
+          - --etcd-cafile=/etc/kubernetes/ssl/ca.pem
+          - --etcd-certfile=/etc/kubernetes/ssl/etcd-client.pem
+          - --etcd-keyfile=/etc/kubernetes/ssl/etcd-client-key.pem
           - --allow-privileged=true
           - --service-cluster-ip-range={{.ServiceCIDR}}
           - --secure-port=443
@@ -353,7 +359,7 @@ write_files:
             image: calico/kube-policy-controller:v0.2.0
             env:
               - name: ETCD_ENDPOINTS
-                value: "{{ .ETCDEndpoints }}"
+                value: "{{ .EtcdEndpoints }}"
               - name: K8S_API
                 value: "http://127.0.0.1:8080"
               - name: LEADER_ELECTION
@@ -772,6 +778,15 @@ write_files:
     encoding: gzip+base64
     content: {{.TLSConfig.APIServerKey}}
 
+  - path: /etc/kubernetes/ssl/etcd-client.pem.enc
+    encoding: gzip+base64
+    content: {{.TLSConfig.EtcdClientCert}}
+
+  - path: /etc/kubernetes/ssl/etcd-client-key.pem.enc
+    encoding: gzip+base64
+    content: {{.TLSConfig.EtcdClientKey}}
+
+
 {{ if .UseCalico }}
   - path: /etc/kubernetes/cni/net.d/10-calico.conf
     content: |
@@ -780,7 +795,7 @@ write_files:
             "type": "flannel",
             "delegate": {
                 "type": "calico",
-                "etcd_endpoints": "{{ .ETCDEndpoints }}",
+                "etcd_endpoints": "{{ .EtcdEndpoints }}",
                 "log_level": "none",
                 "log_level_stderr": "info",
                 "hostname": "$private_ipv4",

--- a/multi-node/aws/pkg/config/templates/cloud-config-etcd
+++ b/multi-node/aws/pkg/config/templates/cloud-config-etcd
@@ -70,8 +70,8 @@ coreos:
       enable: true
       content: |
         [Unit]
-        Description=decrypt kubelet tls assets using amazon kms
-        Before=kubelet.service
+        Description=decrypt etcd2 tls assets using amazon kms
+        Before=etcd2.service
         After=early-docker.service
         Requires=early-docker.service
 
@@ -82,7 +82,7 @@ coreos:
         ExecStart=/opt/bin/decrypt-tls-assets
 
         [Install]
-        RequiredBy=kubelet.service
+        RequiredBy=etcd2.service
 
 
 write_files:

--- a/multi-node/aws/pkg/config/templates/cloud-config-etcd
+++ b/multi-node/aws/pkg/config/templates/cloud-config-etcd
@@ -1,0 +1,122 @@
+#cloud-config
+coreos:
+  update:
+    reboot-strategy: etcd-lock
+  units:
+    - name: etcd2.service
+      drop-ins:
+        - name: 20-etcd2-aws-cluster.conf
+          content: |
+            [Unit]
+            Requires=decrypt-tls-assets.service
+            After=decrypt-tls-assets.service
+
+            [Service]
+            Environment=ETCD_NAME=%H
+
+            Environment=ETCD_PEER_TRUSTED_CA_FILE=/etc/etcd2/ssl/ca.pem
+            Environment=ETCD_PEER_CERT_FILE=/etc/etcd2/ssl/etcd.pem
+            Environment=ETCD_PEER_KEY_FILE=/etc/etcd2/ssl/etcd-key.pem
+
+            Environment=ETCD_CLIENT_CERT_AUTH=true
+            Environment=ETCD_TRUSTED_CA_FILE=/etc/etcd2/ssl/ca.pem
+            Environment=ETCD_CERT_FILE=/etc/etcd2/ssl/etcd.pem
+            Environment=ETCD_KEY_FILE=/etc/etcd2/ssl/etcd-key.pem
+
+            Environment=ETCD_INITIAL_CLUSTER_STATE=new
+            Environment=ETCD_INITIAL_CLUSTER={{.EtcdInitialCluster}}
+            Environment=ETCD_DATA_DIR=/var/lib/etcd2
+            Environment=ETCD_LISTEN_CLIENT_URLS=https://%H:2379
+            Environment=ETCD_ADVERTISE_CLIENT_URLS=https://%H:2379
+            Environment=ETCD_LISTEN_PEER_URLS=https://%H:2380
+            Environment=ETCD_INITIAL_ADVERTISE_PEER_URLS=https://%H:2380
+            PermissionsStartOnly=true
+            ExecStartPre=/usr/bin/chown -R etcd:etcd /var/lib/etcd2
+      enable: true
+      command: start
+
+    - name: var-lib-etcd2.mount
+      enable: true
+      content: |
+        [Unit]
+        Before=etcd2.service
+
+        [Mount]
+        What=/dev/xvdf
+        Where=/var/lib/etcd2
+        Type=ext4
+
+        [Install]
+        RequiredBy=etcd2.service
+
+    - name: format-etcd2-volume.service
+      enable: true
+      content: |
+        [Unit]
+        Description=Formats etcd2 ebs volume
+        After=dev-xvdf.device
+        Requires=dev-xvdf.device
+        Before=var-lib-etcd2.mount
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStart=/opt/bin/ext4-format-volume-once /dev/xvdf
+
+        [Install]
+        RequiredBy=var-lib-etcd2.mount
+
+    - name: decrypt-tls-assets.service
+      enable: true
+      content: |
+        [Unit]
+        Description=decrypt kubelet tls assets using amazon kms
+        Before=kubelet.service
+        After=early-docker.service
+        Requires=early-docker.service
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        Environment="DOCKER_HOST=unix:///var/run/early-docker.sock"
+        ExecStart=/opt/bin/decrypt-tls-assets
+
+        [Install]
+        RequiredBy=kubelet.service
+
+
+write_files:
+  - path: /opt/bin/ext4-format-volume-once
+    permissions: 0700
+    owner: root:root
+    content: |
+      #!/bin/bash -e
+      if [[ "$(wipefs -n -p $1 | grep ext4)" == "" ]];then
+        mkfs.ext4 $1
+      else
+        echo "volume $1 is already formatted"
+      fi
+
+  - path: /opt/bin/decrypt-tls-assets
+    owner: root:root
+    permissions: 0700
+    content: |
+      #!/bin/bash -e
+
+      for encKey in $(find /etc/etcd2/ssl/*.pem.enc);do
+        tmpPath="/tmp/$(basename $encKey).tmp"
+        docker run --net host --rm -v /etc/etcd2/ssl:/etc/etcd2/ssl --rm quay.io/coreos/awscli aws --region {{.Region}} kms decrypt --ciphertext-blob fileb://$encKey --output text --query Plaintext | base64 --decode > $tmpPath
+        mv  $tmpPath /etc/etcd2/ssl/$(basename $encKey .enc)
+      done
+
+  - path: /etc/etcd2/ssl/ca.pem.enc
+    encoding: gzip+base64
+    content: {{.TLSConfig.CACert}}
+
+  - path: /etc/etcd2/ssl/etcd-key.pem.enc
+    encoding: gzip+base64
+    content: {{.TLSConfig.EtcdKey}}
+
+  - path: /etc/etcd2/ssl/etcd.pem.enc
+    encoding: gzip+base64
+    content: {{.TLSConfig.EtcdCert}}

--- a/multi-node/aws/pkg/config/templates/cloud-config-worker
+++ b/multi-node/aws/pkg/config/templates/cloud-config-worker
@@ -36,7 +36,7 @@ coreos:
         Environment=KUBELET_ACI={{.HyperkubeImageRepo}}
         Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf --mount volume=dns,target=/etc/resolv.conf"
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
-        --api-servers={{.SecureAPIServers}} \
+        --api-servers={{.APIServerEndpoint}} \
         --network-plugin-dir=/etc/kubernetes/cni/net.d \
         --network-plugin={{.K8sNetworkPlugin}} \
         --register-node=true \
@@ -150,7 +150,7 @@ write_files:
             command:
             - /hyperkube
             - proxy
-            - --master=https://{{.ControllerIP}}:443
+            - --master={{.APIServerEndpoint}}
             - --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml
             securityContext:
               privileged: true
@@ -208,7 +208,7 @@ write_files:
                 "hostname": "$private_ipv4",
                 "policy": {
                     "type": "k8s",
-                    "k8s_api_root": "https://{{.ControllerIP}}:443/api/v1/",
+                    "k8s_api_root": "{{.APIServerEndpoint}}/api/v1/",
                     "k8s_client_key": "/etc/kubernetes/ssl/worker-key.pem",
                     "k8s_client_certificate": "/etc/kubernetes/ssl/worker.pem"
                 }

--- a/multi-node/aws/pkg/config/templates/cloud-config-worker
+++ b/multi-node/aws/pkg/config/templates/cloud-config-worker
@@ -116,7 +116,7 @@ coreos:
         ExecStart=/bin/true
         ExecStop=/bin/sh -c '/usr/bin/docker run --rm -v /etc/kubernetes:/etc/kubernetes {{.HyperkubeImageRepo}}:{{.K8sVer}} \
           /hyperkube kubectl \
-          --server=https://{{.ControllerIP}}:443 \
+          --server=https://{{.ExternalDNSName}}:443 \
           --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
           drain $$(hostname) \
           --ignore-daemonsets \

--- a/multi-node/aws/pkg/config/templates/cloud-config-worker
+++ b/multi-node/aws/pkg/config/templates/cloud-config-worker
@@ -102,6 +102,29 @@ coreos:
         RequiredBy=kubelet.service flanneld.service
 
 
+    {{ if .Experimental.NodeDrainer.Enabled }}
+    - name: kube-node-drainer.service
+      enable: true
+      content: |
+        [Unit]
+        Description=drain this k8s node to make running pods time to gracefully shut down before stopping kubelet
+        After=kubelet.service
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        ExecStart=/bin/true
+        ExecStop=/bin/sh -c '/usr/bin/docker run --rm -v /etc/kubernetes:/etc/kubernetes {{.HyperkubeImageRepo}}:{{.K8sVer}} \
+          /hyperkube kubectl \
+          --server=https://{{.ControllerIP}}:443 \
+          --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
+          drain $$(hostname) \
+          --force'
+
+        [Install]
+        RequiredBy=kubelet.service
+    {{ end }}
+
 write_files:
   - path: /etc/kubernetes/ssl/etcd-client.pem.enc
     encoding: gzip+base64

--- a/multi-node/aws/pkg/config/templates/cloud-config-worker
+++ b/multi-node/aws/pkg/config/templates/cloud-config-worker
@@ -119,6 +119,7 @@ coreos:
           --server=https://{{.ControllerIP}}:443 \
           --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
           drain $$(hostname) \
+          --ignore-daemonsets \
           --force'
 
         [Install]

--- a/multi-node/aws/pkg/config/templates/cloud-config-worker
+++ b/multi-node/aws/pkg/config/templates/cloud-config-worker
@@ -4,7 +4,10 @@ coreos:
     reboot-strategy: "off"
   flannel:
     interface: $private_ipv4
-    etcd_endpoints: {{ .ETCDEndpoints }}
+    etcd_endpoints: {{ .EtcdEndpoints }}
+    etcd_cafile: /etc/kubernetes/ssl/ca.pem
+    etcd_certfile: /etc/kubernetes/ssl/etcd-client.pem
+    etcd_keyfile: /etc/kubernetes/ssl/etcd-client-key.pem
   units:
     - name: docker.service
       drop-ins:
@@ -13,6 +16,16 @@ coreos:
             [Unit]
             Requires=flanneld.service
             After=flanneld.service
+
+    - name: flanneld.service
+      drop-ins:
+        - name: 10-etcd.conf
+          content: |
+            [Unit]
+            Requires=decrypt-tls-assets.service
+            After=decrypt-tls-assets.service
+            [Service]
+            Environment="ETCD_SSL_DIR=/etc/kubernetes/ssl"
 
     - name: kubelet.service
       enable: true
@@ -57,7 +70,7 @@ coreos:
         Environment=FELIX_FELIXHOSTNAME=$private_ipv4
         Environment=CALICO_NETWORKING=false
         Environment=NO_DEFAULT_POOLS=true
-        Environment=ETCD_ENDPOINTS={{ .ETCDEndpoints }}
+        Environment=ETCD_ENDPOINTS={{ .EtcdEndpoints }}
         ExecStart=/usr/bin/rkt run --inherit-env --stage1-from-dir=stage1-fly.aci \
         --volume=modules,kind=host,source=/lib/modules,readOnly=false \
         --mount=volume=modules,target=/lib/modules \
@@ -75,19 +88,29 @@ coreos:
       content: |
         [Unit]
         Description=decrypt kubelet tls assets using amazon kms
-        Before=kubelet.service
-        After=docker.service
-        Requires=docker.service
+        Before=kubelet.service flanneld.service
+        After=early-docker.service
+        Requires=early-docker.service
 
         [Service]
         Type=oneshot
         RemainAfterExit=yes
+        Environment="DOCKER_HOST=unix:///var/run/early-docker.sock"
         ExecStart=/opt/bin/decrypt-tls-assets
 
         [Install]
-        RequiredBy=kubelet.service
+        RequiredBy=kubelet.service flanneld.service
+
 
 write_files:
+  - path: /etc/kubernetes/ssl/etcd-client.pem.enc
+    encoding: gzip+base64
+    content: {{.TLSConfig.EtcdClientCert}}
+
+  - path: /etc/kubernetes/ssl/etcd-client-key.pem.enc
+    encoding: gzip+base64
+    content: {{.TLSConfig.EtcdClientKey}}
+
   - path: /etc/kubernetes/ssl/worker.pem.enc
     encoding: gzip+base64
     content: {{.TLSConfig.WorkerCert}}
@@ -108,7 +131,7 @@ write_files:
 
       for encKey in $(find /etc/kubernetes/ssl/*.pem.enc);do
         tmpPath="/tmp/$(basename $encKey).tmp"
-        docker run --rm -v /etc/kubernetes/ssl:/etc/kubernetes/ssl --rm quay.io/coreos/awscli aws --region {{.Region}} kms decrypt --ciphertext-blob fileb://$encKey --output text --query Plaintext | base64 --decode > $tmpPath
+        docker run --net host --rm -v /etc/kubernetes/ssl:/etc/kubernetes/ssl quay.io/coreos/awscli aws --region {{.Region}} kms decrypt --ciphertext-blob fileb://$encKey --output text --query Plaintext | base64 --decode > $tmpPath
         mv  $tmpPath /etc/kubernetes/ssl/$(basename $encKey .enc)
       done
 
@@ -179,7 +202,7 @@ write_files:
             "type": "flannel",
             "delegate": {
                 "type": "calico",
-                "etcd_endpoints": "{{ .ETCDEndpoints }}",
+                "etcd_endpoints": "{{ .EtcdEndpoints }}",
                 "log_level": "none",
                 "log_level_stderr": "info",
                 "hostname": "$private_ipv4",

--- a/multi-node/aws/pkg/config/templates/cluster.yaml
+++ b/multi-node/aws/pkg/config/templates/cluster.yaml
@@ -134,7 +134,12 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # Use Calico for network policy.
 # useCalico: false
 
-# AWS Tags for cloudformation stack resources
+# Experimental features will change in backward-incompatible ways
+# experimental:
+#   nodeDrainer:
+#     enabled: true
+
+# AWS Tags for cloudformation stack resources 
 #stackTags:
 #  Name: "Kubernetes"
 #  Environment: "Production"

--- a/multi-node/aws/pkg/config/templates/cluster.yaml
+++ b/multi-node/aws/pkg/config/templates/cluster.yaml
@@ -113,9 +113,6 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #   - availabilityZone: us-west-1b
 #     instanceCIDR: "10.0.1.0/24"
 
-# IP Address for the controller in Kubernetes subnet. When we have 2 or more subnets, the controller is placed in the first subnet and controllerIP must be included in the instanceCIDR of the first subnet. This convention will change once we have H/A controllers
-# controllerIP: 10.0.0.50
-
 # CIDR for all service IP addresses
 # serviceCIDR: "10.3.0.0/24"
 

--- a/multi-node/aws/pkg/config/templates/cluster.yaml
+++ b/multi-node/aws/pkg/config/templates/cluster.yaml
@@ -73,6 +73,9 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # workerSpotPrice: "0.05"
 
 ## Etcd Cluster config
+## WARNING: Any changes to etcd parameters after the cluster is first created will not be applied
+## during a cluster upgrade, due to concerns over data loss.
+## This situation is being rectified with work towards automated management of etcd clusters
 
 # Number of etcd nodes
 # (Set to an odd number >= 3 for HA control plane)

--- a/multi-node/aws/pkg/config/templates/cluster.yaml
+++ b/multi-node/aws/pkg/config/templates/cluster.yaml
@@ -72,7 +72,27 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # Price (Dollars) to bid for spot instances. Omit for on-demand instances.
 # workerSpotPrice: "0.05"
 
+## Etcd Cluster config
+
+# Number of etcd nodes
+# (Set to an odd number >= 3 for HA control plane)
+# etcdCount: 1
+
 # Instance type for etcd node
+# etcdInstanceType: m3.medium
+
+# Root volume disk size (GiB) for etcd node
+# etcdRootVolumeSize: 30
+
+# Use ephemeral instance storage for etcd data volume instead of EBS?
+# (Recommended set to true for high-throughput control planes)
+# etcdDataVolumeEphemeral: false
+
+# Data EBS volume disk size (GiB) for etcd node
+# if etcdDataVolumeEphemeral=true, this value is ignored. The size of ephemeral volumes is not configurable.
+# etcdDataVolumeSize: 30
+
+## Networking config
 
 # ID of existing VPC to create subnet in. Leave blank to create a new VPC
 # vpcId:

--- a/multi-node/aws/pkg/config/templates/cluster.yaml
+++ b/multi-node/aws/pkg/config/templates/cluster.yaml
@@ -72,6 +72,8 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # Price (Dollars) to bid for spot instances. Omit for on-demand instances.
 # workerSpotPrice: "0.05"
 
+# Instance type for etcd node
+
 # ID of existing VPC to create subnet in. Leave blank to create a new VPC
 # vpcId:
 

--- a/multi-node/aws/pkg/config/templates/stack-template.json
+++ b/multi-node/aws/pkg/config/templates/stack-template.json
@@ -1,6 +1,13 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Description": "kube-aws Kubernetes cluster {{.ClusterName}}",
+  "Mappings" : {
+    "EtcdInstanceParams" : {
+      "UserData" : {
+	"cloudconfig" : "{{.UserDataEtcd}}"
+      }
+    }
+  },
   "Resources": {
     "AlarmControllerRecover": {
       "Properties": {
@@ -137,6 +144,17 @@
       },
       "Type": "AWS::IAM::InstanceProfile"
     },
+    "IAMInstanceProfileEtcd": {
+      "Properties": {
+        "Path": "/",
+        "Roles": [
+          {
+            "Ref": "IAMRoleEtcd"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::InstanceProfile"
+    },
     "IAMRoleController": {
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -249,6 +267,43 @@
       },
       "Type": "AWS::IAM::Role"
     },
+    "IAMRoleEtcd": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "ec2.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action" : "kms:Decrypt",
+                  "Effect" : "Allow",
+                  "Resource" : "{{.KMSKeyARN}}"
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "PolicyName": "root"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
     "InstanceController": {
       "Properties": {
         "AvailabilityZone": "{{(index .Subnets .ControllerSubnetIndex).AvailabilityZone}}",
@@ -300,6 +355,64 @@
       },
       "Type": "AWS::EC2::Instance"
     },
+    {{range $etcdIndex, $etcdInstance := .EtcdInstances}}
+    "InstanceEtcd{{$etcdIndex}}": {
+      "Properties": {
+        "BlockDeviceMappings": [
+          {
+            "DeviceName": "/dev/xvda",
+            "Ebs": {
+              "VolumeSize": "{{$.EtcdRootVolumeSize}}"
+            }
+          },
+	  {
+            "DeviceName": "/dev/xvdf",
+	    {{if $.EtcdDataVolumeEphemeral}}
+	    "VirtualName" : "ephemeral0"
+	    {{else}}
+            "Ebs": {
+              "VolumeSize": "{{$.EtcdDataVolumeSize}}"
+            }
+	    {{end}}
+          }
+        ],
+        "IamInstanceProfile": {
+          "Ref": "IAMInstanceProfileEtcd"
+        },
+        "ImageId": "{{$.AMI}}",
+        "InstanceType": "{{$.EtcdInstanceType}}",
+        "KeyName": "{{$.KeyName}}",
+        "NetworkInterfaces": [
+          {
+            "AssociatePublicIpAddress": true,
+            "DeleteOnTermination": true,
+            "DeviceIndex": "0",
+            "GroupSet": [
+              {
+                "Ref": "SecurityGroupEtcd"
+              }
+            ],
+            "PrivateIpAddress": "{{$etcdInstance.IPAddress}}",
+            "SubnetId": {
+              "Ref": "Subnet{{$etcdInstance.SubnetIndex}}"
+            }
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "{{$.ClusterName}}"
+          },
+          {
+            "Key": "Name",
+            "Value": "{{$.ClusterName}}-kube-aws-etcd-{{$etcdIndex}}"
+          }
+        ],
+        "UserData": { "Fn::FindInMap" : [ "EtcdInstanceParams", "UserData", "cloudconfig"] }
+      },
+      "Type": "AWS::EC2::Instance"
+    },
+    {{end}}
     "LaunchConfigurationWorker": {
       "Properties": {
         "BlockDeviceMappings": [
@@ -506,6 +619,34 @@
       },
       "Type": "AWS::EC2::SecurityGroupIngress"
     },
+    "SecurityGroupEtcdIngressFromControllerToEtcd": {
+      "Properties": {
+        "FromPort": 2379,
+        "GroupId": {
+          "Ref": "SecurityGroupEtcd"
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupController"
+        },
+        "ToPort": 2379
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    "SecurityGroupEtcdIngressFromWorkerToEtcd": {
+      "Properties": {
+        "FromPort": 2379,
+        "GroupId": {
+          "Ref": "SecurityGroupEtcd"
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "ToPort": 2379
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
     "SecurityGroupWorkerIngressFromWorkerToFlannel": {
       "Properties": {
         "FromPort": 8472,
@@ -547,6 +688,63 @@
         "ToPort": 10255
       },
       "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    "SecurityGroupEtcd": {
+      "Properties": {
+        "GroupDescription": {
+          "Ref": "AWS::StackName"
+        },
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 0,
+            "IpProtocol": "tcp",
+            "ToPort": 65535
+          },
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 0,
+            "IpProtocol": "udp",
+            "ToPort": 65535
+          }
+        ],
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 3,
+            "IpProtocol": "icmp",
+            "ToPort": -1
+          },
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 22,
+            "IpProtocol": "tcp",
+            "ToPort": 22
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "{{.ClusterName}}"
+          }
+        ],
+        "VpcId": {{.VPCRef}}
+      },
+      "Type": "AWS::EC2::SecurityGroup"
+    },
+    "SecurityGroupEtcdPeerIngress": {
+      "Properties": {
+        "FromPort": 2380,
+        "GroupId": {
+          "Ref": "SecurityGroupEtcd"
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupEtcd"
+        },
+        "ToPort": 2380
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
     }
     {{range $index, $subnet := .Subnets}}
     {{with $subnetLogicalName := printf "Subnet%d" $index}}
@@ -568,8 +766,8 @@
     }
     {{end}}
     {{end}}
-    {{if not .VPCID}}
     ,
+    {{if not .VPCID}}
     "{{.VPCLogicalName}}": {
       "Properties": {
         "CidrBlock": "{{.VPCCIDR}}",
@@ -649,7 +847,6 @@
     {{if .RouteTableID}}
     {{range $index, $subnet := .Subnets}}
     {{with $subnetLogicalName := printf "Subnet%d" $index}}
-    ,
     "{{$subnetLogicalName}}RouteTableAssociation": {
       "Properties": {
         "RouteTableId": "{{$.RouteTableID}}",

--- a/multi-node/aws/pkg/config/templates/stack-template.json
+++ b/multi-node/aws/pkg/config/templates/stack-template.json
@@ -23,8 +23,8 @@
         "LaunchConfigurationName": {
           "Ref": "LaunchConfigurationWorker"
         },
-        "MaxSize": "{{.WorkerCount}}",
-        "MinSize": "{{.WorkerCount}}",
+        "MaxSize": "{{.MaxWorkerCount}}",
+        "MinSize": "{{.MinWorkerCount}}",
         "Tags": [
           {
             "Key": "KubernetesCluster",
@@ -60,7 +60,8 @@
           "MaxBatchSize" : "1",
           "PauseTime" : "PT2M"
         }
-      }
+      },
+      "DependsOn" : ["AutoScaleController"]
     },
     "AutoScaleController": {
       "Type": "AWS::AutoScaling::AutoScalingGroup",
@@ -77,8 +78,8 @@
         "LaunchConfigurationName": {
           "Ref": "LaunchConfigurationController"
         },
-        "MaxSize": "{{.ControllerCount}}",
-        "MinSize": "{{.ControllerCount}}",
+        "MaxSize": "{{.MaxControllerCount}}",
+        "MinSize": "{{.MinControllerCount}}",
         "Tags": [
           {
             "Key": "KubernetesCluster",

--- a/multi-node/aws/pkg/config/templates/stack-template.json
+++ b/multi-node/aws/pkg/config/templates/stack-template.json
@@ -9,41 +9,6 @@
     }
   },
   "Resources": {
-    "AlarmControllerRecover": {
-      "Properties": {
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:automate:",
-                {
-                  "Ref": "AWS::Region"
-                },
-                ":ec2:recover"
-              ]
-            ]
-          }
-        ],
-        "AlarmDescription": "Trigger a recovery when system check fails for 5 consecutive minutes.",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "Dimensions": [
-          {
-            "Name": "InstanceId",
-            "Value": {
-              "Ref": "InstanceController"
-            }
-          }
-        ],
-        "EvaluationPeriods": "5",
-        "MetricName": "StatusCheckFailed_System",
-        "Namespace": "AWS/EC2",
-        "Period": "60",
-        "Statistic": "Minimum",
-        "Threshold": "0"
-      },
-      "Type": "AWS::CloudWatch::Alarm"
-    },
     "AutoScaleWorker": {
       "Properties": {
         "AvailabilityZones": [
@@ -97,14 +62,56 @@
         }
       }
     },
-    "EIPController": {
+    "AutoScaleController": {
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
       "Properties": {
-        "Domain": "vpc",
-        "InstanceId": {
-          "Ref": "InstanceController"
-        }
+        "AvailabilityZones": [
+          {{range $index, $subnet := .Subnets}}
+          {{if gt $index 0}},{{end}}
+          "{{$subnet.AvailabilityZone}}"
+          {{end}}
+        ],
+        "DesiredCapacity": "{{.ControllerCount}}",
+        "HealthCheckGracePeriod": 600,
+        "HealthCheckType": "EC2",
+        "LaunchConfigurationName": {
+          "Ref": "LaunchConfigurationController"
+        },
+        "MaxSize": "{{.ControllerCount}}",
+        "MinSize": "{{.ControllerCount}}",
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "PropagateAtLaunch": "true",
+            "Value": "{{.ClusterName}}"
+          },
+          {
+            "Key": "Name",
+            "PropagateAtLaunch": "true",
+            "Value": "{{.ClusterName}}-kube-aws-controller"
+          }
+        ],
+        "VPCZoneIdentifier": [
+          {{range $index, $subnet := .Subnets}}
+          {{with $subnetLogicalName := printf "Subnet%d" $index}}
+          {{if gt $index 0}},{{end}}
+          {
+            "Ref": "{{$subnetLogicalName}}"
+          }
+          {{end}}
+          {{end}}
+        ],
+	"LoadBalancerNames" : [
+	  { "Ref" : "ElbAPIServer" }
+	]
       },
-      "Type": "AWS::EC2::EIP"
+      "UpdatePolicy" : {
+        "AutoScalingRollingUpdate" : {
+          "MinInstancesInService" : "{{.ControllerCount}}",
+          "MaxBatchSize" : "1",
+          "PauseTime" : "PT2M"
+        }
+      }
     },
     {{ if .CreateRecordSet }}
     "ExternalDNS": {
@@ -117,8 +124,8 @@
 	{{ end }}
         "Name": "{{.ExternalDNSName}}",
         "TTL": {{.RecordSetTTL}},
-        "ResourceRecords": [{ "Ref": "EIPController"}],
-        "Type": "A"
+        "ResourceRecords": [{ "Fn::GetAtt": ["ElbAPIServer", "DNSName"]}],
+        "Type": "CNAME"
       }
     },
     {{ end }}
@@ -304,57 +311,6 @@
       },
       "Type": "AWS::IAM::Role"
     },
-    "InstanceController": {
-      "Properties": {
-        "AvailabilityZone": "{{(index .Subnets .ControllerSubnetIndex).AvailabilityZone}}",
-        "BlockDeviceMappings": [
-          {
-            "DeviceName": "/dev/xvda",
-            "Ebs": {
-              "VolumeSize": "{{.ControllerRootVolumeSize}}",
-              {{if gt .ControllerRootVolumeIOPS 0}}
-              "Iops": "{{.ControllerRootVolumeIOPS}}",
-              {{end}}
-              "VolumeType": "{{.ControllerRootVolumeType}}"
-            }
-          }
-        ],
-        "IamInstanceProfile": {
-          "Ref": "IAMInstanceProfileController"
-        },
-        "ImageId": "{{.AMI}}",
-        "InstanceType": "{{.ControllerInstanceType}}",
-        "KeyName": "{{.KeyName}}",
-        "NetworkInterfaces": [
-          {
-            "AssociatePublicIpAddress": false,
-            "DeleteOnTermination": true,
-            "DeviceIndex": "0",
-            "GroupSet": [
-              {
-                "Ref": "SecurityGroupController"
-              }
-            ],
-            "PrivateIpAddress": "{{.ControllerIP}}",
-            "SubnetId": {
-              "Ref": "Subnet{{.ControllerSubnetIndex}}"
-            }
-          }
-        ],
-        "Tags": [
-          {
-            "Key": "KubernetesCluster",
-            "Value": "{{.ClusterName}}"
-          },
-          {
-            "Key": "Name",
-            "Value": "{{.ClusterName}}-kube-aws-controller"
-          }
-        ],
-        "UserData": "{{ .UserDataController }}"
-      },
-      "Type": "AWS::EC2::Instance"
-    },
     {{range $etcdIndex, $etcdInstance := .EtcdInstances}}
     "InstanceEtcd{{$etcdIndex}}": {
       "Properties": {
@@ -445,6 +401,84 @@
       },
       "Type": "AWS::AutoScaling::LaunchConfiguration"
     },
+    "LaunchConfigurationController": {
+      "Properties": {
+        "BlockDeviceMappings": [
+          {
+            "DeviceName": "/dev/xvda",
+            "Ebs": {
+              "VolumeSize": "{{.ControllerRootVolumeSize}}"
+            }
+          }
+        ],
+        "IamInstanceProfile": {
+          "Ref": "IAMInstanceProfileController"
+        },
+        "ImageId": "{{.AMI}}",
+        "InstanceType": "{{.ControllerInstanceType}}",
+        "KeyName": "{{.KeyName}}",
+        "SecurityGroups": [
+          {
+            "Ref": "SecurityGroupController"
+          }
+        ],
+        "UserData": "{{ .UserDataController }}"
+      },
+      "Type": "AWS::AutoScaling::LaunchConfiguration"
+    },
+    "ElbAPIServer" : {
+      "Type" : "AWS::ElasticLoadBalancing::LoadBalancer",
+      "Properties" : {
+	"CrossZone" : true,
+	"HealthCheck" : {
+	  "HealthyThreshold" : "3",
+	  "Interval" : "10",
+	  "Target" : "TCP:443",
+	  "Timeout" : "8",
+	  "UnhealthyThreshold" : "3"
+	},
+	"Subnets" : [
+          {{range $index, $subnet := .Subnets}}
+          {{if gt $index 0}},{{end}}
+          { "Ref" : "Subnet{{$index}}" }
+          {{end}}
+	],
+	"Listeners" : [
+	  {
+	    "InstancePort" : "443",
+	    "InstanceProtocol" : "TCP",
+	    "LoadBalancerPort" : "443",
+	    "Protocol" : "TCP"
+	  }
+	],
+	"SecurityGroups" : [
+	  { "Ref" : "SecurityGroupElbAPIServer" }
+	]
+      }
+    },
+    "SecurityGroupElbAPIServer" : {
+      "Properties": {
+        "GroupDescription": {
+          "Ref": "AWS::StackName"
+        },
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "{{.ClusterName}}"
+          }
+        ],
+        "VpcId": {{.VPCRef}}
+      },
+      "Type": "AWS::EC2::SecurityGroup"
+    },
     "SecurityGroupController": {
       "Properties": {
         "GroupDescription": {
@@ -484,7 +518,13 @@
             "ToPort": 22
           },
           {
-            "CidrIp": "0.0.0.0/0",
+            "SourceSecurityGroupId" : { "Ref" : "SecurityGroupElbAPIServer" },
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443
+          },
+	  {
+            "SourceSecurityGroupId" : { "Ref" : "SecurityGroupWorker" },
             "FromPort": 443,
             "IpProtocol": "tcp",
             "ToPort": 443

--- a/multi-node/aws/pkg/config/templates_gen.go
+++ b/multi-node/aws/pkg/config/templates_gen.go
@@ -35,6 +35,7 @@ var files = []struct {
 }{
 	{"cloud-config-controller", "CloudConfigController"},
 	{"cloud-config-worker", "CloudConfigWorker"},
+	{"cloud-config-etcd", "CloudConfigEtcd"},
 	{"cluster.yaml", "DefaultClusterConfig"},
 	{"kubeconfig.tmpl", "KubeConfigTemplate"},
 	{"stack-template.json", "StackTemplateTemplate"},

--- a/multi-node/aws/pkg/config/tls_config.go
+++ b/multi-node/aws/pkg/config/tls_config.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"crypto/rsa"
+	"crypto/x509"
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
@@ -47,16 +48,11 @@ type CompactTLSAssets struct {
 	EtcdKey        string
 }
 
-func (c *Cluster) NewTLSAssets() (*RawTLSAssets, error) {
-	// Generate keys for the various components.
-	keys := make([]*rsa.PrivateKey, 6)
-	var err error
-	for i := range keys {
-		if keys[i], err = tlsutil.NewPrivateKey(); err != nil {
-			return nil, err
-		}
+func NewTLSCA() (*rsa.PrivateKey, *x509.Certificate, error) {
+	caKey, err := tlsutil.NewPrivateKey()
+	if err != nil {
+		return nil, nil, err
 	}
-	caKey, apiServerKey, workerKey, adminKey, etcdKey, etcdClientKey := keys[0], keys[1], keys[2], keys[3], keys[4], keys[5]
 
 	caConfig := tlsutil.CACertConfig{
 		CommonName:   "kube-ca",
@@ -64,8 +60,22 @@ func (c *Cluster) NewTLSAssets() (*RawTLSAssets, error) {
 	}
 	caCert, err := tlsutil.NewSelfSignedCACertificate(caConfig, caKey)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+
+	return caKey, caCert, nil
+}
+
+func (c *Cluster) NewTLSAssets(caKey *rsa.PrivateKey, caCert *x509.Certificate) (*RawTLSAssets, error) {
+	// Generate keys for the various components.
+	keys := make([]*rsa.PrivateKey, 5)
+	var err error
+	for i := range keys {
+		if keys[i], err = tlsutil.NewPrivateKey(); err != nil {
+			return nil, err
+		}
+	}
+	apiServerKey, workerKey, adminKey, etcdKey, etcdClientKey := keys[0], keys[1], keys[2], keys[3], keys[4]
 
 	//Compute kubernetesServiceIP from serviceCIDR
 	_, serviceNet, err := net.ParseCIDR(c.ServiceCIDR)
@@ -98,6 +108,9 @@ func (c *Cluster) NewTLSAssets() (*RawTLSAssets, error) {
 			fmt.Sprintf("*.%s.compute.internal", c.Region),
 			"*.ec2.internal",
 		},
+		//etcd https client/peer interfaces are not exposed externally
+		//will live the full year with the CA
+		Duration: tlsutil.Duration365d,
 	}
 
 	etcdCert, err := tlsutil.NewSignedServerCertificate(etcdConfig, etcdKey, caCert, caKey)
@@ -156,7 +169,7 @@ func ReadTLSAssets(dirname string) (*RawTLSAssets, error) {
 		name      string
 		cert, key *[]byte
 	}{
-		{"ca", &r.CACert, &r.CAKey},
+		{"ca", &r.CACert, nil},
 		{"apiserver", &r.APIServerCert, &r.APIServerKey},
 		{"worker", &r.WorkerCert, &r.WorkerKey},
 		{"admin", &r.AdminCert, &r.AdminKey},
@@ -172,16 +185,19 @@ func ReadTLSAssets(dirname string) (*RawTLSAssets, error) {
 			return nil, err
 		}
 		*file.cert = certData
-		keyData, err := ioutil.ReadFile(keyPath)
-		if err != nil {
-			return nil, err
+
+		if file.key != nil {
+			keyData, err := ioutil.ReadFile(keyPath)
+			if err != nil {
+				return nil, err
+			}
+			*file.key = keyData
 		}
-		*file.key = keyData
 	}
 	return r, nil
 }
 
-func (r *RawTLSAssets) WriteToDir(dirname string) error {
+func (r *RawTLSAssets) WriteToDir(dirname string, includeCAKey bool) error {
 	assets := []struct {
 		name      string
 		cert, key []byte
@@ -196,11 +212,15 @@ func (r *RawTLSAssets) WriteToDir(dirname string) error {
 	for _, asset := range assets {
 		certPath := filepath.Join(dirname, asset.name+".pem")
 		keyPath := filepath.Join(dirname, asset.name+"-key.pem")
+
 		if err := ioutil.WriteFile(certPath, asset.cert, 0600); err != nil {
 			return err
 		}
-		if err := ioutil.WriteFile(keyPath, asset.key, 0600); err != nil {
-			return err
+
+		if asset.name != "ca" || includeCAKey {
+			if err := ioutil.WriteFile(keyPath, asset.key, 0600); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -248,7 +268,6 @@ func (r *RawTLSAssets) compact(cfg *Config, kmsSvc encryptService) (*CompactTLSA
 	}
 	compactAssets := CompactTLSAssets{
 		CACert:         compact(r.CACert),
-		CAKey:          compact(r.CAKey),
 		APIServerCert:  compact(r.APIServerCert),
 		APIServerKey:   compact(r.APIServerKey),
 		WorkerCert:     compact(r.WorkerCert),

--- a/multi-node/aws/pkg/config/tls_config.go
+++ b/multi-node/aws/pkg/config/tls_config.go
@@ -17,38 +17,46 @@ import (
 
 // PEM encoded TLS assets.
 type RawTLSAssets struct {
-	CACert        []byte
-	CAKey         []byte
-	APIServerCert []byte
-	APIServerKey  []byte
-	WorkerCert    []byte
-	WorkerKey     []byte
-	AdminCert     []byte
-	AdminKey      []byte
+	CACert         []byte
+	CAKey          []byte
+	APIServerCert  []byte
+	APIServerKey   []byte
+	WorkerCert     []byte
+	WorkerKey      []byte
+	AdminCert      []byte
+	AdminKey       []byte
+	EtcdCert       []byte
+	EtcdClientCert []byte
+	EtcdKey        []byte
+	EtcdClientKey  []byte
 }
 
 // PEM -> gzip -> base64 encoded TLS assets.
 type CompactTLSAssets struct {
-	CACert        string
-	CAKey         string
-	APIServerCert string
-	APIServerKey  string
-	WorkerCert    string
-	WorkerKey     string
-	AdminCert     string
-	AdminKey      string
+	CACert         string
+	CAKey          string
+	APIServerCert  string
+	APIServerKey   string
+	WorkerCert     string
+	WorkerKey      string
+	AdminCert      string
+	AdminKey       string
+	EtcdCert       string
+	EtcdClientCert string
+	EtcdClientKey  string
+	EtcdKey        string
 }
 
 func (c *Cluster) NewTLSAssets() (*RawTLSAssets, error) {
 	// Generate keys for the various components.
-	keys := make([]*rsa.PrivateKey, 4)
+	keys := make([]*rsa.PrivateKey, 6)
 	var err error
 	for i := range keys {
 		if keys[i], err = tlsutil.NewPrivateKey(); err != nil {
 			return nil, err
 		}
 	}
-	caKey, apiServerKey, workerKey, adminKey := keys[0], keys[1], keys[2], keys[3]
+	caKey, apiServerKey, workerKey, adminKey, etcdKey, etcdClientKey := keys[0], keys[1], keys[2], keys[3], keys[4], keys[5]
 
 	caConfig := tlsutil.CACertConfig{
 		CommonName:   "kube-ca",
@@ -85,14 +93,36 @@ func (c *Cluster) NewTLSAssets() (*RawTLSAssets, error) {
 		return nil, err
 	}
 
+	etcdConfig := tlsutil.ServerCertConfig{
+		CommonName: "kube-etcd",
+		DNSNames: []string{
+			fmt.Sprintf("*.%s.compute.internal", c.Region),
+			"*.ec2.internal",
+		},
+	}
+
+	etcdCert, err := tlsutil.NewSignedServerCertificate(etcdConfig, etcdKey, caCert, caKey)
+	if err != nil {
+		return nil, err
+	}
+
 	workerConfig := tlsutil.ClientCertConfig{
 		CommonName: "kube-worker",
 		DNSNames: []string{
-			"*.*.compute.internal",
+			fmt.Sprintf("*.%s.compute.internal", c.Region),
 			"*.ec2.internal",
 		},
 	}
 	workerCert, err := tlsutil.NewSignedClientCertificate(workerConfig, workerKey, caCert, caKey)
+	if err != nil {
+		return nil, err
+	}
+
+	etcdClientConfig := tlsutil.ClientCertConfig{
+		CommonName: "kube-etcd-client",
+	}
+
+	etcdClientCert, err := tlsutil.NewSignedClientCertificate(etcdClientConfig, etcdClientKey, caCert, caKey)
 	if err != nil {
 		return nil, err
 	}
@@ -106,14 +136,18 @@ func (c *Cluster) NewTLSAssets() (*RawTLSAssets, error) {
 	}
 
 	return &RawTLSAssets{
-		CACert:        tlsutil.EncodeCertificatePEM(caCert),
-		APIServerCert: tlsutil.EncodeCertificatePEM(apiServerCert),
-		WorkerCert:    tlsutil.EncodeCertificatePEM(workerCert),
-		AdminCert:     tlsutil.EncodeCertificatePEM(adminCert),
-		CAKey:         tlsutil.EncodePrivateKeyPEM(caKey),
-		APIServerKey:  tlsutil.EncodePrivateKeyPEM(apiServerKey),
-		WorkerKey:     tlsutil.EncodePrivateKeyPEM(workerKey),
-		AdminKey:      tlsutil.EncodePrivateKeyPEM(adminKey),
+		CACert:         tlsutil.EncodeCertificatePEM(caCert),
+		APIServerCert:  tlsutil.EncodeCertificatePEM(apiServerCert),
+		WorkerCert:     tlsutil.EncodeCertificatePEM(workerCert),
+		AdminCert:      tlsutil.EncodeCertificatePEM(adminCert),
+		EtcdCert:       tlsutil.EncodeCertificatePEM(etcdCert),
+		EtcdClientCert: tlsutil.EncodeCertificatePEM(etcdClientCert),
+		CAKey:          tlsutil.EncodePrivateKeyPEM(caKey),
+		APIServerKey:   tlsutil.EncodePrivateKeyPEM(apiServerKey),
+		WorkerKey:      tlsutil.EncodePrivateKeyPEM(workerKey),
+		AdminKey:       tlsutil.EncodePrivateKeyPEM(adminKey),
+		EtcdKey:        tlsutil.EncodePrivateKeyPEM(etcdKey),
+		EtcdClientKey:  tlsutil.EncodePrivateKeyPEM(etcdClientKey),
 	}, nil
 }
 
@@ -127,6 +161,8 @@ func ReadTLSAssets(dirname string) (*RawTLSAssets, error) {
 		{"apiserver", &r.APIServerCert, &r.APIServerKey},
 		{"worker", &r.WorkerCert, &r.WorkerKey},
 		{"admin", &r.AdminCert, &r.AdminKey},
+		{"etcd", &r.EtcdCert, &r.EtcdKey},
+		{"etcd-client", &r.EtcdClientCert, &r.EtcdClientKey},
 	}
 	for _, file := range files {
 		certPath := filepath.Join(dirname, file.name+".pem")
@@ -155,6 +191,8 @@ func (r *RawTLSAssets) WriteToDir(dirname string) error {
 		{"apiserver", r.APIServerCert, r.APIServerKey},
 		{"worker", r.WorkerCert, r.WorkerKey},
 		{"admin", r.AdminCert, r.AdminKey},
+		{"etcd", r.EtcdCert, r.EtcdKey},
+		{"etcd-client", r.EtcdClientCert, r.EtcdClientKey},
 	}
 	for _, asset := range assets {
 		certPath := filepath.Join(dirname, asset.name+".pem")
@@ -210,14 +248,18 @@ func (r *RawTLSAssets) compact(cfg *Config, kmsSvc encryptService) (*CompactTLSA
 		return out
 	}
 	compactAssets := CompactTLSAssets{
-		CACert:        compact(r.CACert),
-		CAKey:         compact(r.CAKey),
-		APIServerCert: compact(r.APIServerCert),
-		APIServerKey:  compact(r.APIServerKey),
-		WorkerCert:    compact(r.WorkerCert),
-		WorkerKey:     compact(r.WorkerKey),
-		AdminCert:     compact(r.AdminCert),
-		AdminKey:      compact(r.AdminKey),
+		CACert:         compact(r.CACert),
+		CAKey:          compact(r.CAKey),
+		APIServerCert:  compact(r.APIServerCert),
+		APIServerKey:   compact(r.APIServerKey),
+		WorkerCert:     compact(r.WorkerCert),
+		WorkerKey:      compact(r.WorkerKey),
+		AdminCert:      compact(r.AdminCert),
+		AdminKey:       compact(r.AdminKey),
+		EtcdCert:       compact(r.EtcdCert),
+		EtcdClientCert: compact(r.EtcdClientCert),
+		EtcdClientKey:  compact(r.EtcdClientKey),
+		EtcdKey:        compact(r.EtcdKey),
 	}
 	if err != nil {
 		return nil, err

--- a/multi-node/aws/pkg/config/tls_config.go
+++ b/multi-node/aws/pkg/config/tls_config.go
@@ -84,7 +84,6 @@ func (c *Cluster) NewTLSAssets() (*RawTLSAssets, error) {
 			c.ExternalDNSName,
 		},
 		IPAddresses: []string{
-			c.ControllerIP,
 			kubernetesServiceIPAddr.String(),
 		},
 	}

--- a/multi-node/aws/pkg/config/tls_config_test.go
+++ b/multi-node/aws/pkg/config/tls_config_test.go
@@ -53,6 +53,11 @@ func TestTLSGeneration(t *testing.T) {
 			KeyBytes:  assets.WorkerKey,
 			CertBytes: assets.WorkerCert,
 		},
+		{
+			Name:      "etcd",
+			KeyBytes:  assets.EtcdKey,
+			CertBytes: assets.EtcdCert,
+		},
 	}
 
 	var err error

--- a/multi-node/aws/pkg/config/tls_config_test.go
+++ b/multi-node/aws/pkg/config/tls_config_test.go
@@ -14,7 +14,11 @@ func genTLSAssets(t *testing.T) *RawTLSAssets {
 		t.Fatalf("failed generating config: %v", err)
 	}
 
-	assets, err := cluster.NewTLSAssets()
+	caKey, caCert, err := NewTLSCA()
+	if err != nil {
+		t.Fatalf("failed generating tls ca: %v", err)
+	}
+	assets, err := cluster.NewTLSAssets(caKey, caCert)
 	if err != nil {
 		t.Fatalf("failed generating tls: %v", err)
 	}

--- a/multi-node/aws/pkg/config/user_data_config_test.go
+++ b/multi-node/aws/pkg/config/user_data_config_test.go
@@ -23,7 +23,11 @@ func TestCloudConfigTemplating(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to load cluster config: %v", err)
 	}
-	assets, err := cluster.NewTLSAssets()
+	caKey, caCert, err := NewTLSCA()
+	if err != nil {
+		t.Fatalf("failed generating tls ca: %v", err)
+	}
+	assets, err := cluster.NewTLSAssets(caKey, caCert)
 	if err != nil {
 		t.Fatalf("Error generating default assets: %v", err)
 	}

--- a/multi-node/aws/pkg/tlsutil/pem.go
+++ b/multi-node/aws/pkg/tlsutil/pem.go
@@ -14,10 +14,20 @@ func EncodePrivateKeyPEM(key *rsa.PrivateKey) []byte {
 	return pem.EncodeToMemory(&block)
 }
 
+func DecodePrivateKeyPEM(data []byte) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode(data)
+	return x509.ParsePKCS1PrivateKey(block.Bytes)
+}
+
 func EncodeCertificatePEM(cert *x509.Certificate) []byte {
 	block := pem.Block{
 		Type:  "CERTIFICATE",
 		Bytes: cert.Raw,
 	}
 	return pem.EncodeToMemory(&block)
+}
+
+func DecodeCertificatePEM(data []byte) (*x509.Certificate, error) {
+	block, _ := pem.Decode(data)
+	return x509.ParseCertificate(block.Bytes)
 }

--- a/multi-node/aws/pkg/tlsutil/x509.go
+++ b/multi-node/aws/pkg/tlsutil/x509.go
@@ -25,6 +25,7 @@ type ServerCertConfig struct {
 	CommonName  string
 	DNSNames    []string
 	IPAddresses []string
+	Duration    time.Duration
 }
 
 type ClientCertConfig struct {
@@ -66,6 +67,9 @@ func NewSignedServerCertificate(cfg ServerCertConfig, key *rsa.PrivateKey, caCer
 		return nil, err
 	}
 
+	if cfg.Duration == time.Hour*0 {
+		cfg.Duration = Duration90d
+	}
 	certTmpl := x509.Certificate{
 		Subject: pkix.Name{
 			CommonName:   cfg.CommonName,
@@ -75,7 +79,7 @@ func NewSignedServerCertificate(cfg ServerCertConfig, key *rsa.PrivateKey, caCer
 		IPAddresses:  ips,
 		SerialNumber: serial,
 		NotBefore:    caCert.NotBefore,
-		NotAfter:     time.Now().Add(Duration90d).UTC(),
+		NotAfter:     time.Now().Add(cfg.Duration).UTC(),
 		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 	}


### PR DESCRIPTION
Drain nodes before shutting them down to give running pods time to gracefully stop.

This change basically achieves it by running `docker run IMAGE kubectl drain THE_NODE --force` on the to-be-shut-down node before the kubelet gets SIGTERM in a CoreOS' shutdown process.

Depends #608
Refs #340

Without this change, kubelets getting SIGTERM without a prior `drain` results in unfunctional(actually not schedulable) pods to have statuses `Ready`.

With this change, when an ASG's desired cap decreased, a node's status changes over time as follows:

On desired cap change:
=> STATUS=Ready

On shut-down started:
=> STATUS=Ready,SchedulingDisabled (<- Pods are stopped and status is changed by `kubectl drain`)

On shut-down finished:
=> Status=NotReady,SchedulingDisabled (<- It's `NotReady` but it won't result in a down-time because we already stopped both further scheduling and pods)

After a minute:
=> The node disappears from the output of `kubectl get nodes`

Note that:
- This applies to manual shutdowns(via running `sudo systemctl shutdown` for example) and automated shutdowns(triggered by AWS AutoScaling when nodes get rotated out of a group)
- We currently depend on the community docker image `mumoshu/kubectl` because `kubectl` included in the official `coreos/hyperkube` image doesn't work due to the issue https://github.com/kubernetes/kubernetes/issues/24088 in Kubernetes. Once the issue is fixed and the CoreOS team published the new hyperkube image with the updated Kubernetes, we can remove that dependency.
- I consider this an experimental feature. So you shouldn't expect configuration API regarding this stable. It may change in the future.
