### PR TITLE
kublet.service picks up proxy settings from /etc/environment

### DIFF
--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -94,6 +94,7 @@ function init_templates {
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
 [Service]
+EnvironmentFile=/etc/environment
 Environment=KUBELET_VERSION=${K8S_VER}
 Environment=KUBELET_ACI=${HYPERKUBE_IMAGE_REPO}
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests

--- a/multi-node/generic/worker-install.sh
+++ b/multi-node/generic/worker-install.sh
@@ -60,6 +60,7 @@ function init_templates {
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
 [Service]
+EnvironmentFile=/etc/environment
 Environment=KUBELET_VERSION=${K8S_VER}
 Environment=KUBELET_ACI=${HYPERKUBE_IMAGE_REPO}
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests


### PR DESCRIPTION
doesn't currently work behind network proxy. with vagrant-proxyconf /etc/environment has the appropriate http_proxy and https_proxy environment variables set. pull them into the kubelet.service definition and running process.