### PR TITLE
lib: Add kubernetes.default.svc as alt_name in openssl config

### DIFF
--- a/lib/init-ssl
+++ b/lib/init-ssl
@@ -45,6 +45,8 @@ subjectAltName = @alt_names
 [alt_names]
 DNS.1 = kubernetes
 DNS.2 = kubernetes.default
+DNS.3 = kubernetes.default.svc
+DNS.4 = kubernetes.default.svc.cluster.local
 "
 echo "Generating SSL artifacts in $OUTDIR"
 


### PR DESCRIPTION
Currently if a pod attempts to connect to kubernetes.default.svc using the ca
provided as a service account it will fail due to that name not being trusted