### PR TITLE
*: Remove unused K8S_SERVICE_IP from scripts

### DIFF
--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -21,10 +21,6 @@ export POD_NETWORK=10.2.0.0/16
 # Routing to these IPs is handled by a proxy service local to each node, and are not required to be routable between nodes.
 export SERVICE_IP_RANGE=10.3.0.0/24
 
-# The IP address of the Kubernetes API Service
-# If the SERVICE_IP_RANGE is changed above, this must be set to the first IP in that range.
-export K8S_SERVICE_IP=10.3.0.1
-
 # The IP address of the cluster DNS service.
 # This IP must be in the range of the SERVICE_IP_RANGE and cannot be the first IP in the range.
 # This same IP must be configured on all worker nodes to enable DNS service discovery.
@@ -40,7 +36,7 @@ ENV_FILE=/run/coreos-kubernetes/options.env
 # -------------
 
 function init_config {
-    local REQUIRED=('ADVERTISE_IP' 'POD_NETWORK' 'ETCD_ENDPOINTS' 'SERVICE_IP_RANGE' 'K8S_SERVICE_IP' 'DNS_SERVICE_IP' 'K8S_VER' 'HYPERKUBE_IMAGE_REPO' 'USE_CALICO')
+    local REQUIRED=('ADVERTISE_IP' 'POD_NETWORK' 'ETCD_ENDPOINTS' 'SERVICE_IP_RANGE' 'DNS_SERVICE_IP' 'K8S_VER' 'HYPERKUBE_IMAGE_REPO' 'USE_CALICO')
 
     if [ -f $ENV_FILE ]; then
         export $(cat $ENV_FILE | xargs)

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -21,10 +21,6 @@ export POD_NETWORK=10.2.0.0/16
 # Routing to these IPs is handled by a proxy service local to each node, and are not required to be routable between nodes.
 export SERVICE_IP_RANGE=10.3.0.0/24
 
-# The IP address of the Kubernetes API Service
-# If the SERVICE_IP_RANGE is changed above, this must be set to the first IP in that range.
-export K8S_SERVICE_IP=10.3.0.1
-
 # The IP address of the cluster DNS service.
 # This IP must be in the range of the SERVICE_IP_RANGE and cannot be the first IP in the range.
 # This same IP must be configured on all worker nodes to enable DNS service discovery.
@@ -37,7 +33,7 @@ export USE_CALICO=true
 # -------------
 
 function init_config {
-    local REQUIRED=('ADVERTISE_IP' 'POD_NETWORK' 'ETCD_ENDPOINTS' 'SERVICE_IP_RANGE' 'K8S_SERVICE_IP' 'DNS_SERVICE_IP' 'K8S_VER' 'USE_CALICO')
+    local REQUIRED=('ADVERTISE_IP' 'POD_NETWORK' 'ETCD_ENDPOINTS' 'SERVICE_IP_RANGE' 'DNS_SERVICE_IP' 'K8S_VER' 'USE_CALICO')
 
     if [ -z $ADVERTISE_IP ]; then
         export ADVERTISE_IP=$(awk -F= '/COREOS_PUBLIC_IPV4/ {print $2}' /etc/environment)


### PR DESCRIPTION
`K8S_SERVICE_IP` does not seem to be used within the scripts, vagrant examples work fine without it.

* Last use seems to be https://github.com/coreos/coreos-kubernetes/commit/c6ef8ddeb5dae1c2ab778350783f443a395eebba#diff-349be742aedc3ca1d5af305a74e1c4bcL63
* Removed in coreos-baremetal https://github.com/coreos/coreos-baremetal/pull/150

cc @aaronlevy 