### PR TITLE
`stack-template.json`: use spaces only for indenting

### DIFF
--- a/multi-node/aws/pkg/config/templates/stack-template.json
+++ b/multi-node/aws/pkg/config/templates/stack-template.json
@@ -70,7 +70,7 @@
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "UpdatePolicy" : {
-	"AutoScalingRollingUpdate" : {
+        "AutoScalingRollingUpdate" : {
           "MinInstancesInService" :
           {{if .WorkerSpotPrice}}
           "0"
@@ -79,7 +79,7 @@
           {{end}},
           "MaxBatchSize" : "1",
           "PauseTime" : "PT2M"
-	}
+        }
       }
     },
     "EIPController": {
@@ -158,11 +158,11 @@
                   "Effect": "Allow",
                   "Resource": "*"
                 },
-		{
-		  "Action" : "kms:Decrypt",
-		  "Effect" : "Allow",
-		  "Resource" : "{{.KMSKeyARN}}"
-		}
+                {
+                  "Action" : "kms:Decrypt",
+                  "Effect" : "Allow",
+                  "Resource" : "{{.KMSKeyARN}}"
+                }
               ],
               "Version": "2012-10-17"
             },


### PR DESCRIPTION
The whole file was using spaces for indentation except for a few
lines where tabs were used. Using spaces here keeps things also
visually consistent when a tab is not displayed as 8 spaces