### PR TITLE
kube-aws: Fix two bugs with subnets & existing VPCs

### DIFF
--- a/multi-node/aws/pkg/config/config.go
+++ b/multi-node/aws/pkg/config/config.go
@@ -565,7 +565,7 @@ func (c *Cluster) ValidateExistingVPC(existingVPCCIDR string, existingSubnetCIDR
 		}
 	}
 	_, instanceNet, err := net.ParseCIDR(c.InstanceCIDR)
-	if err != nil {
+	if len(c.Subnets) == 0 && err != nil {
 		return fmt.Errorf("error parsing instances cidr %s : %v", c.InstanceCIDR, err)
 	}
 	_, vpcNet, err := net.ParseCIDR(c.VPCCIDR)

--- a/multi-node/aws/pkg/config/templates/stack-template.json
+++ b/multi-node/aws/pkg/config/templates/stack-template.json
@@ -615,7 +615,7 @@
     ,
     "{{$subnetLogicalName}}RouteTableAssociation": {
       "Properties": {
-        "RouteTableId": "{{.RouteTableID}}",
+        "RouteTableId": "{{$.RouteTableID}}",
         "SubnetId": {
           "Ref": "{{$subnetLogicalName}}"
         }


### PR DESCRIPTION
Bug #1: Before this patch, when specifying a route table ID in the
cluster.yml file, the substitution on line 618 fails because the
RouteTableID is not available in that scope. This patch modifies the
substitution to read from the correct scope.

Bug #2: Before this patch, the validation code that is run during
'kube-aws up' expects ``c.InstanceCIDR`` to be a valid CIDR even when
the Subnets parameter is set instead. This patch modifies the validation
to avoid raising errors in this case.