### PR TITLE
Fix vpc validation for multiple subnets

### DIFF
--- a/multi-node/aws/pkg/config/config.go
+++ b/multi-node/aws/pkg/config/config.go
@@ -98,41 +98,41 @@ func ClusterFromBytes(data []byte) (*Cluster, error) {
 }
 
 type Cluster struct {
-	ClusterName              string            `yaml:"clusterName"`
-	ExternalDNSName          string            `yaml:"externalDNSName"`
-	KeyName                  string            `yaml:"keyName"`
-	Region                   string            `yaml:"region"`
-	AvailabilityZone         string            `yaml:"availabilityZone"`
-	ReleaseChannel           string            `yaml:"releaseChannel"`
-	ControllerInstanceType   string            `yaml:"controllerInstanceType"`
-	ControllerRootVolumeSize int               `yaml:"controllerRootVolumeSize"`
-	WorkerCount              int               `yaml:"workerCount"`
-	WorkerInstanceType       string            `yaml:"workerInstanceType"`
-	WorkerRootVolumeSize     int               `yaml:"workerRootVolumeSize"`
-	WorkerSpotPrice          string            `yaml:"workerSpotPrice"`
-	VPCID                    string            `yaml:"vpcId"`
-	RouteTableID             string            `yaml:"routeTableId"`
-	VPCCIDR                  string            `yaml:"vpcCIDR"`
-	InstanceCIDR             string            `yaml:"instanceCIDR"`
-	ControllerIP             string            `yaml:"controllerIP"`
-	PodCIDR                  string            `yaml:"podCIDR"`
-	ServiceCIDR              string            `yaml:"serviceCIDR"`
-	DNSServiceIP             string            `yaml:"dnsServiceIP"`
-	K8sVer                   string            `yaml:"kubernetesVersion"`
-	HyperkubeImageRepo       string            `yaml:"hyperkubeImageRepo"`
-	KMSKeyARN                string            `yaml:"kmsKeyArn"`
-	CreateRecordSet          bool              `yaml:"createRecordSet"`
-	RecordSetTTL             int               `yaml:"recordSetTTL"`
-	HostedZone               string            `yaml:"hostedZone"`
-	HostedZoneID             string            `yaml:"hostedZoneId"`
-	StackTags                map[string]string `yaml:"stackTags"`
-	UseCalico                bool              `yaml:"useCalico"`
-	Subnets                  []Subnet          `yaml:"subnets"`
+	ClusterName              string            `yaml:"clusterName,omitempty"`
+	ExternalDNSName          string            `yaml:"externalDNSName,omitempty"`
+	KeyName                  string            `yaml:"keyName,omitempty"`
+	Region                   string            `yaml:"region,omitempty"`
+	AvailabilityZone         string            `yaml:"availabilityZone,omitempty"`
+	ReleaseChannel           string            `yaml:"releaseChannel,omitempty"`
+	ControllerInstanceType   string            `yaml:"controllerInstanceType,omitempty"`
+	ControllerRootVolumeSize int               `yaml:"controllerRootVolumeSize,omitempty"`
+	WorkerCount              int               `yaml:"workerCount,omitempty"`
+	WorkerInstanceType       string            `yaml:"workerInstanceType,omitempty"`
+	WorkerRootVolumeSize     int               `yaml:"workerRootVolumeSize,omitempty"`
+	WorkerSpotPrice          string            `yaml:"workerSpotPrice,omitempty"`
+	VPCID                    string            `yaml:"vpcId,omitempty"`
+	RouteTableID             string            `yaml:"routeTableId,omitempty"`
+	VPCCIDR                  string            `yaml:"vpcCIDR,omitempty"`
+	InstanceCIDR             string            `yaml:"instanceCIDR,omitempty"`
+	ControllerIP             string            `yaml:"controllerIP,omitempty"`
+	PodCIDR                  string            `yaml:"podCIDR,omitempty"`
+	ServiceCIDR              string            `yaml:"serviceCIDR,omitempty"`
+	DNSServiceIP             string            `yaml:"dnsServiceIP,omitempty"`
+	K8sVer                   string            `yaml:"kubernetesVersion,omitempty"`
+	HyperkubeImageRepo       string            `yaml:"hyperkubeImageRepo,omitempty"`
+	KMSKeyARN                string            `yaml:"kmsKeyArn,omitempty"`
+	CreateRecordSet          bool              `yaml:"createRecordSet,omitempty"`
+	RecordSetTTL             int               `yaml:"recordSetTTL,omitempty"`
+	HostedZone               string            `yaml:"hostedZone,omitempty"`
+	HostedZoneID             string            `yaml:"hostedZoneId,omitempty"`
+	StackTags                map[string]string `yaml:"stackTags,omitempty"`
+	UseCalico                bool              `yaml:"useCalico,omitempty"`
+	Subnets                  []Subnet          `yaml:"subnets,omitempty"`
 }
 
 type Subnet struct {
-	AvailabilityZone string `yaml:"availabilityZone"`
-	InstanceCIDR     string `yaml:"instanceCIDR"`
+	AvailabilityZone string `yaml:"availabilityZone,omitempty"`
+	InstanceCIDR     string `yaml:"instanceCIDR,omitempty"`
 }
 
 const (


### PR DESCRIPTION
I have a kind-of-off-topic commit which introduces omitempty tags for the Cluster yaml fields. This is subtly desirable behavior I would think, in that defining an empty value in `cluster.yaml` should probably imply the preset default rather than empty.

Fixes bug 2 in #500

\cc @aaronlevy @michaeldiscala 