### PR TITLE
docs: Mark parts to skip for no calico.

### DIFF
--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -313,13 +313,13 @@ spec:
       timeoutSeconds: 1
 ```
 
-### Set Up Calico Node Container
+### Set Up Calico Node Container (optional)
+
+This step can be skipped if you do not wish to provide network policy to your cluster using Calico.
 
 The Calico node container runs on all hosts, including the master node. It performs two functions:
 * Connects containers to the flannel overlay network, which enables the "one IP per pod" concept.
 * Enforces network policy created through the Kubernetes policy API, ensuring pods talk to authorized resources only.
-
-This step can be skipped if not using Calico.
 
 When creating `/etc/systemd/system/calico-node.service`:
 
@@ -356,9 +356,11 @@ TimeoutStartSec=0
 WantedBy=multi-user.target
 ```
 
-### Set Up the policy-agent Pod
+### Set Up the policy-agent Pod (optional)
 
-The policy agent is the last major piece of the master node. It monitors the API for changes related to network policy and configures Calico to implement that policy. This step can be skipped if not using Calico.
+This step can be skipped if you do not wish to provide network policy to your cluster using Calico.
+
+The policy agent is the last major piece of the master node. It monitors the API for changes related to network policy and configures Calico to implement that policy. 
 
 When creating `/etc/kubernetes/manifests/policy-agent.yaml`:
 
@@ -395,7 +397,9 @@ spec:
         - "--http=127.0.0.1:4040"
 ```
 
-### Set Up the CNI config
+### Set Up the CNI config (optional)
+This step can be skipped if you do not wish to provide network policy to your cluster using Calico.
+
 The kubelet reads the CNI configuration on startup and uses that to determine which CNI plugin to call. Create the following file which tells the kubelet to call the flannel plugin but to then delegate control to the Calico plugin. Using the flannel plugin ensures that the Calico plugin is called with the IP range for the host that was selected by flannel.
 
 * Replace `${ADVERTISE_IP}` with this node's publicly routable IP.
@@ -460,7 +464,8 @@ $ sudo systemctl enable kubelet
 Created symlink from /etc/systemd/system/multi-user.target.wants/kubelet.service to /etc/systemd/system/kubelet.service.
 ```
 
-### Start Calico
+### Start Calico (optional)
+This step can be skipped if you do not wish to provide network policy to your cluster using Calico.
 
 Start Calico if you configured your kubelet to use CNI plugins earlier:
 

--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -398,6 +398,7 @@ spec:
 ```
 
 ### Set Up the CNI config (optional)
+
 This step can be skipped if you do not wish to provide network policy to your cluster using Calico.
 
 The kubelet reads the CNI configuration on startup and uses that to determine which CNI plugin to call. Create the following file which tells the kubelet to call the flannel plugin but to then delegate control to the Calico plugin. Using the flannel plugin ensures that the Calico plugin is called with the IP range for the host that was selected by flannel.
@@ -465,6 +466,7 @@ Created symlink from /etc/systemd/system/multi-user.target.wants/kubelet.service
 ```
 
 ### Start Calico (optional)
+
 This step can be skipped if you do not wish to provide network policy to your cluster using Calico.
 
 Start Calico if you configured your kubelet to use CNI plugins earlier:


### PR DESCRIPTION

Make it obvious which parts can be skipped if user does not want to use Calico 
(for example, if they are setting up the simplest possible test cluster).
