### PR TITLE
stack-template: global scope for subnet routetableid

### DIFF
--- a/multi-node/aws/pkg/config/templates/stack-template.json
+++ b/multi-node/aws/pkg/config/templates/stack-template.json
@@ -632,7 +632,7 @@
     ,
     "{{$subnetLogicalName}}RouteTableAssociation": {
       "Properties": {
-        "RouteTableId": "{{.RouteTableID}}",
+        "RouteTableId": "{{$.RouteTableID}}",
         "SubnetId": {
           "Ref": "{{$subnetLogicalName}}"
         }


### PR DESCRIPTION
thanks @michaeldiscala for the bug report and fix.

\cc @cgag 

ref #500