### PR TITLE
kube-aws: add maxWorkerCount param

### DIFF
--- a/multi-node/aws/pkg/config/config.go
+++ b/multi-node/aws/pkg/config/config.go
@@ -41,6 +41,7 @@ func newDefaultCluster() *Cluster {
 		ControllerInstanceType:   "m3.medium",
 		ControllerRootVolumeSize: 30,
 		WorkerCount:              1,
+		MaxWorkerCount:           1,
 		WorkerInstanceType:       "m3.medium",
 		WorkerRootVolumeSize:     30,
 		CreateRecordSet:          false,
@@ -73,6 +74,11 @@ func ClusterFromBytes(data []byte) (*Cluster, error) {
 	// HostedZone needs to end with a '.', amazon will not append it for you.
 	// as it will with RecordSets
 	c.HostedZone = WithTrailingDot(c.HostedZone)
+
+	// MaxWorkerCount must be greater or equal to the worker count
+	if c.MaxWorkerCount < c.WorkerCount {
+		c.MaxWorkerCount = c.WorkerCount
+	}
 
 	// If the user specified no subnets, we assume that a single AZ configuration with the default instanceCIDR is demanded
 	if len(c.Subnets) == 0 && c.InstanceCIDR == "" {
@@ -107,6 +113,7 @@ type Cluster struct {
 	ControllerInstanceType   string            `yaml:"controllerInstanceType,omitempty"`
 	ControllerRootVolumeSize int               `yaml:"controllerRootVolumeSize,omitempty"`
 	WorkerCount              int               `yaml:"workerCount,omitempty"`
+	MaxWorkerCount           int               `yaml:"maxWorkerCount,omitempty"`
 	WorkerInstanceType       string            `yaml:"workerInstanceType,omitempty"`
 	WorkerRootVolumeSize     int               `yaml:"workerRootVolumeSize,omitempty"`
 	WorkerSpotPrice          string            `yaml:"workerSpotPrice,omitempty"`

--- a/multi-node/aws/pkg/config/templates/cluster.yaml
+++ b/multi-node/aws/pkg/config/templates/cluster.yaml
@@ -51,6 +51,9 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # Number of worker nodes to create
 #workerCount: 1
 
+# Maximum number of workers to auto-scale to. It must be greater or equal to the workerCount.
+#maxWorkerCount: 1
+
 # Instance type for worker nodes
 #workerInstanceType: m3.medium
 

--- a/multi-node/aws/pkg/config/templates/stack-template.json
+++ b/multi-node/aws/pkg/config/templates/stack-template.json
@@ -51,7 +51,7 @@
         "LaunchConfigurationName": {
           "Ref": "LaunchConfigurationWorker"
         },
-        "MaxSize": "{{.WorkerCount}}",
+        "MaxSize": "{{.MaxWorkerCount}}",
         "MinSize": "{{.WorkerCount}}",
         "Tags": [
           {


### PR DESCRIPTION
I had an issue updating my cluster: `MinInstancesInService must be less than the autoscaling group's MaxSize`. This PR allows me to customize the MaxSize to avoid this issue.