### PR TITLE
Dedicated etcd instances (in multiple AZs)

### DIFF
--- a/multi-node/aws/cmd/kube-aws/command_render.go
+++ b/multi-node/aws/cmd/kube-aws/command_render.go
@@ -69,6 +69,7 @@ func runCmdRender(cmd *cobra.Command, args []string) error {
 		mode os.FileMode
 	}{
 		{"credentials/.gitignore", []byte("*"), 0644},
+		{"userdata/cloud-config-etcd", config.CloudConfigEtcd, 0644},
 		{"userdata/cloud-config-controller", config.CloudConfigController, 0644},
 		{"userdata/cloud-config-worker", config.CloudConfigWorker, 0644},
 		{"stack-template.json", config.StackTemplateTemplate, 0644},

--- a/multi-node/aws/cmd/kube-aws/main.go
+++ b/multi-node/aws/cmd/kube-aws/main.go
@@ -19,6 +19,7 @@ const configPath = "cluster.yaml"
 
 var stackTemplateOptions = config.StackTemplateOptions{
 	TLSAssetsDir:          "credentials",
+	EtcdTmplFile:          "userdata/cloud-config-etcd",
 	ControllerTmplFile:    "userdata/cloud-config-controller",
 	WorkerTmplFile:        "userdata/cloud-config-worker",
 	StackTemplateTmplFile: "stack-template.json",

--- a/multi-node/aws/pkg/config/config.go
+++ b/multi-node/aws/pkg/config/config.go
@@ -38,6 +38,8 @@ func newDefaultCluster() *Cluster {
 		DNSServiceIP:             "10.3.0.10",
 		K8sVer:                   "v1.2.4_coreos.1",
 		HyperkubeImageRepo:       "quay.io/coreos/hyperkube",
+		EtcdInstanceType:         "m3.medium",
+		EtcdRootVolumeSize:       8,
 		ControllerInstanceType:   "m3.medium",
 		ControllerRootVolumeSize: 30,
 		WorkerCount:              1,
@@ -46,6 +48,7 @@ func newDefaultCluster() *Cluster {
 		CreateRecordSet:          false,
 		RecordSetTTL:             300,
 		Subnets:                  []Subnet{},
+		EtcdIPs:                  []string{},
 	}
 }
 
@@ -128,6 +131,9 @@ type Cluster struct {
 	StackTags                map[string]string `yaml:"stackTags,omitempty"`
 	UseCalico                bool              `yaml:"useCalico,omitempty"`
 	Subnets                  []Subnet          `yaml:"subnets,omitempty"`
+	EtcdInstanceType         string            `yaml:"etcdInstanceType,omitempty"`
+	EtcdRootVolumeSize       int               `yaml:"etcdRootVolumeSize,omitempty"`
+	EtcdIPs                  []string          `yaml:"etcdIPs,omitempty"`
 }
 
 type Subnet struct {
@@ -147,7 +153,12 @@ var supportedReleaseChannels = map[string]bool{
 
 func (c Cluster) Config() (*Config, error) {
 	config := Config{Cluster: c}
-	config.ETCDEndpoints = fmt.Sprintf("http://%s:2379", c.ControllerIP)
+	config.DedicatedEtcd = len(config.EtcdIPs) > 0
+	if config.DedicatedEtcd {
+		config.ETCDEndpoints = "http://" + strings.Join(c.EtcdIPs, ":2379,http://") + ":2379"
+	} else {
+		config.ETCDEndpoints = fmt.Sprintf("http://%s:2379", c.ControllerIP)
+	}
 	config.APIServers = fmt.Sprintf("http://%s:8080", c.ControllerIP)
 	config.SecureAPIServers = fmt.Sprintf("https://%s:443", c.ControllerIP)
 	config.APIServerEndpoint = fmt.Sprintf("https://%s", c.ExternalDNSName)
@@ -177,6 +188,7 @@ func (c Cluster) Config() (*Config, error) {
 
 type StackTemplateOptions struct {
 	TLSAssetsDir          string
+	EtcdTmplFile          string
 	ControllerTmplFile    string
 	WorkerTmplFile        string
 	StackTemplateTmplFile string
@@ -186,7 +198,9 @@ type stackConfig struct {
 	*Config
 	UserDataWorker        string
 	UserDataController    string
+	UserDataEtcd          []string
 	ControllerSubnetIndex int
+	EtcdSubnetIndex       []int
 }
 
 func execute(filename string, data interface{}, compress bool) (string, error) {
@@ -236,19 +250,36 @@ func (c Cluster) stackConfig(opts StackTemplateOptions, compressUserData bool) (
 	if controllerIPAddr == nil {
 		return nil, fmt.Errorf("invalid controllerIP: %s", stackConfig.ControllerIP)
 	}
-	controllerSubnetFound := false
-	for i, subnet := range stackConfig.Subnets {
-		_, instanceCIDR, err := net.ParseCIDR(subnet.InstanceCIDR)
-		if err != nil {
-			return nil, fmt.Errorf("invalid instanceCIDR: %v", err)
-		}
-		if instanceCIDR.Contains(controllerIPAddr) {
-			stackConfig.ControllerSubnetIndex = i
-			controllerSubnetFound = true
-		}
+
+	stackConfig.ControllerSubnetIndex, err = stackConfig.SubnetIndexForInstanceIP(controllerIPAddr)
+	if err != nil {
+		return nil, fmt.Errorf("cannot determine controller instance subnet: %v", err)
 	}
-	if !controllerSubnetFound {
-		return nil, fmt.Errorf("Fail-fast occurred possibly because of a bug: ControllerSubnetIndex couldn't be determined for subnets (%v) and controllerIP (%v)", stackConfig.Subnets, stackConfig.ControllerIP)
+
+	etcdClusterMembers := []string{}
+	stackConfig.EtcdSubnetIndex = make([]int, len(c.EtcdIPs))
+	stackConfig.UserDataEtcd = make([]string, len(c.EtcdIPs))
+	for i, etcdIP := range c.EtcdIPs {
+		etcdIPAddr := net.ParseIP(etcdIP)
+		if etcdIPAddr == nil {
+			return nil, fmt.Errorf("invalid etcd IP: %s", etcdIP)
+		}
+
+		stackConfig.EtcdSubnetIndex[i], err = stackConfig.SubnetIndexForInstanceIP(etcdIPAddr)
+		if err != nil {
+			return nil, fmt.Errorf("cannot determine etcd instance subnet: %v", err)
+		}
+
+		etcdClusterMembers = append(etcdClusterMembers, fmt.Sprintf("etcd%d=http://%v:2380", i, etcdIP))
+	}
+
+	stackConfig.Config.EtcdInitialCluster = strings.Join(etcdClusterMembers, ",")
+
+	for i, _ := range etcdClusterMembers {
+		stackConfig.Config.EtcdIndex = i
+		if stackConfig.UserDataEtcd[i], err = execute(opts.EtcdTmplFile, stackConfig.Config, compressUserData); err != nil {
+			return nil, fmt.Errorf("failed to render etcd%d cloud config: %v", i, err)
+		}
 	}
 
 	if stackConfig.UserDataWorker, err = execute(opts.WorkerTmplFile, stackConfig.Config, compressUserData); err != nil {
@@ -261,6 +292,19 @@ func (c Cluster) stackConfig(opts StackTemplateOptions, compressUserData bool) (
 	return &stackConfig, nil
 }
 
+func (s stackConfig) SubnetIndexForInstanceIP(instanceIP net.IP) (int, error) {
+	for i, subnet := range s.Subnets {
+		_, instanceCIDR, err := net.ParseCIDR(subnet.InstanceCIDR)
+		if err != nil {
+			return -1, fmt.Errorf("invalid instanceCIDR: %v", err)
+		}
+		if instanceCIDR.Contains(instanceIP) {
+			return i, nil
+		}
+	}
+	return -1, fmt.Errorf("Fail-fast occurred possibly because of a bug: SubnetIndex couldn't be determined for subnets (%v) and instance IP (%v)", s.Subnets, instanceIP)
+}
+
 func (c Cluster) ValidateUserData(opts StackTemplateOptions) error {
 	stackConfig, err := c.stackConfig(opts, false)
 	if err != nil {
@@ -269,10 +313,12 @@ func (c Cluster) ValidateUserData(opts StackTemplateOptions) error {
 
 	errors := []string{}
 
-	for _, userData := range []struct {
+	type userDataStruct struct {
 		Name    string
 		Content string
-	}{
+	}
+
+	userDataEntries := []userDataStruct{
 		{
 			Content: stackConfig.UserDataWorker,
 			Name:    "UserDataWorker",
@@ -281,7 +327,16 @@ func (c Cluster) ValidateUserData(opts StackTemplateOptions) error {
 			Content: stackConfig.UserDataController,
 			Name:    "UserDataController",
 		},
-	} {
+	}
+
+	for i := range stackConfig.EtcdIPs {
+		userDataEntries = append(userDataEntries, userDataStruct{
+			Content: stackConfig.UserDataEtcd[i],
+			Name:    fmt.Sprintf("UserDataEtcd%d", i),
+		})
+	}
+
+	for _, userData := range userDataEntries {
 		report, err := validate.Validate([]byte(userData.Content))
 
 		if err != nil {
@@ -363,6 +418,7 @@ func getContextString(buf []byte, offset, lineCount int) string {
 type Config struct {
 	Cluster
 
+	DedicatedEtcd     bool
 	ETCDEndpoints     string
 	APIServers        string
 	SecureAPIServers  string
@@ -379,6 +435,9 @@ type Config struct {
 	VPCRef string
 
 	K8sNetworkPlugin string
+
+	EtcdInitialCluster string
+	EtcdIndex          int
 }
 
 func (c Cluster) valid() error {

--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -32,10 +32,14 @@ coreos:
         - name: 10-etcd.conf
           content: |
             [Service]
+            {{if not .DedicatedEtcd}}
             ExecStartPre=/usr/bin/curl --silent -X PUT -d \
             "value={\"Network\" : \"{{.PodCIDR}}\", \"Backend\" : {\"Type\" : \"vxlan\"}}" \
-            {{if not .DedicatedEtcd}}http://localhost:2379/v2/keys/coreos.com/network/config?prevExist=false
-            {{else}}http://{{index .EtcdIPs 0}}:2379/v2/keys/coreos.com/network/config?prevExist=false
+            http://localhost:2379/v2/keys/coreos.com/network/config?prevExist=false
+            {{else}}
+            Environment="ETCDCTL_PEERS={{.ETCDEndpoints}}"
+            ExecStartPre=/usr/bin/etcdctl set coreos.com/network/config \
+            "{\"Network\" : \"{{.PodCIDR}}\", \"Backend\" : {\"Type\" : \"vxlan\"}}"
             {{end}}
     - name: kubelet.service
       command: start

--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -5,6 +5,7 @@ coreos:
   flannel:
     interface: $private_ipv4
     etcd_endpoints: {{ .ETCDEndpoints }}
+  {{if not .DedicatedEtcd}}
   etcd2:
     name: controller
     advertise-client-urls: http://$private_ipv4:2379
@@ -12,10 +13,12 @@ coreos:
     listen-client-urls: http://0.0.0.0:2379
     listen-peer-urls: http://0.0.0.0:2380
     initial-cluster: controller=http://$private_ipv4:2380
+  {{end}}
   units:
+    {{if not .DedicatedEtcd}}
     - name: etcd2.service
       command: start
-
+    {{end}}
     - name: docker.service
       drop-ins:
         - name: 40-flannel.conf
@@ -31,7 +34,9 @@ coreos:
             [Service]
             ExecStartPre=/usr/bin/curl --silent -X PUT -d \
             "value={\"Network\" : \"{{.PodCIDR}}\", \"Backend\" : {\"Type\" : \"vxlan\"}}" \
-            http://localhost:2379/v2/keys/coreos.com/network/config?prevExist=false
+            {{if not .DedicatedEtcd}}http://localhost:2379/v2/keys/coreos.com/network/config?prevExist=false
+            {{else}}http://{{index .EtcdIPs 0}}:2379/v2/keys/coreos.com/network/config?prevExist=false
+            {{end}}
     - name: kubelet.service
       command: start
       enable: true
@@ -222,7 +227,9 @@ write_files:
           - /hyperkube
           - apiserver
           - --bind-address=0.0.0.0
-          - --etcd-servers=http://localhost:2379
+          {{if .DedicatedEtcd }}- --etcd-servers={{.ETCDEndpoints}}
+          {{else}}- --etcd-servers=http://localhost:2379
+          {{end}}
           - --allow-privileged=true
           - --service-cluster-ip-range={{.ServiceCIDR}}
           - --secure-port=443

--- a/multi-node/aws/pkg/config/templates/cloud-config-etcd
+++ b/multi-node/aws/pkg/config/templates/cloud-config-etcd
@@ -1,0 +1,16 @@
+#cloud-config
+coreos:
+  update:
+    reboot-strategy: "off"
+  etcd2:
+    name: etcd{{ .EtcdIndex }}
+    advertise-client-urls: http://$private_ipv4:2379
+    initial-advertise-peer-urls: http://$private_ipv4:2380
+    listen-client-urls: http://$private_ipv4:2379,http://127.0.0.1:2379
+    listen-peer-urls: http://$private_ipv4:2380
+    initial-cluster: {{ .EtcdInitialCluster }}
+    initial-cluster-state: new
+    initial-cluster-token: {{ .ClusterName }}
+  units:
+    - name: etcd2.service
+      command: start

--- a/multi-node/aws/pkg/config/templates/cluster.yaml
+++ b/multi-node/aws/pkg/config/templates/cluster.yaml
@@ -42,6 +42,12 @@ availabilityZone: {{.AvailabilityZone}}
 # ARN of the KMS key used to encrypt TLS assets.
 kmsKeyArn: "{{.KMSKeyARN}}"
 
+# Instance type for etcd node
+#etcdInstanceType: m3.medium
+
+# Disk size (GiB) for etcd node
+#etcdRootVolumeSize: 8
+
 # Instance type for controller node
 #controllerInstanceType: m3.medium
 
@@ -78,6 +84,16 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #     instanceCIDR: "10.0.0.0/24"
 #   - availabilityZone: us-west-1b
 #     instanceCIDR: "10.0.1.0/24"
+#   - availabilityZone: us-west-1c
+#     instanceCIDR: "10.0.2.0/24"
+
+# IP Addresses for dedicated etcd instances (this implicitly determines the number of dedicated etcd instances).
+# Leave empty to run etcd on a single master node.
+# For a high-availability deployment it is recommended to use three nodes, each in a different availability zone.
+# etcdIPs:
+#   - 10.0.0.20
+#   - 10.0.1.20
+#   - 10.0.2.20
 
 # IP Address for the controller in Kubernetes subnet. When we have 2 or more subnets, the controller is placed in the first subnet and controllerIP must be included in the instanceCIDR of the first subnet. This convention will change once we have H/A controllers
 # controllerIP: 10.0.0.50
@@ -101,7 +117,7 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # must also be updated to include a version tagged with CNI e.g. v1.2.4_coreos.cni.1
 # useCalico: false
 
-# AWS Tags for cloudformation stack resources 
+# AWS Tags for cloudformation stack resources
 #stackTags:
-#  Name: "Kubernetes" 
+#  Name: "Kubernetes"
 #  Environment: "Production"

--- a/multi-node/aws/pkg/config/templates/stack-template.json
+++ b/multi-node/aws/pkg/config/templates/stack-template.json
@@ -249,6 +249,87 @@
       },
       "Type": "AWS::IAM::Role"
     },
+    {{ range $index, $ip := .EtcdIPs}}
+      "InstanceEtcd{{ $index }}": {
+        "Properties": {
+          "AvailabilityZone": "{{(index $.Subnets (index $.EtcdSubnetIndex $index)).AvailabilityZone}}",
+          "BlockDeviceMappings": [
+            {
+              "DeviceName": "/dev/xvda",
+              "Ebs": {
+                "VolumeSize": "{{$.EtcdRootVolumeSize}}"
+              }
+            }
+          ],
+          "ImageId": "{{$.AMI}}",
+          "InstanceType": "{{$.EtcdInstanceType}}",
+          "KeyName": "{{$.KeyName}}",
+          "NetworkInterfaces": [
+            {
+              "AssociatePublicIpAddress": true,
+              "DeleteOnTermination": true,
+              "DeviceIndex": "0",
+              "GroupSet": [
+                {
+                  "Ref": "SecurityGroupEtcd"
+                }
+              ],
+              "PrivateIpAddress": "{{ (index $.EtcdIPs $index) }}",
+              "SubnetId": {
+                "Ref": "Subnet{{ (index $.EtcdSubnetIndex $index) }}"
+              }
+            }
+          ],
+          "Tags": [
+            {
+              "Key": "KubernetesCluster",
+              "Value": "{{$.ClusterName}}"
+            },
+            {
+              "Key": "Name",
+              "Value": "{{$.ClusterName}}-kube-aws-etcd{{ $index }}"
+            }
+          ],
+          "UserData": "{{ (index $.UserDataEtcd $index ) }}"
+        },
+        "Type": "AWS::EC2::Instance"
+      },
+      "AlarmEtcd{{ $index }}Recover": {
+        "Properties": {
+          "AlarmActions": [
+            {
+              "Fn::Join": [
+                "",
+                [
+                  "arn:aws:automate:",
+                  {
+                    "Ref": "AWS::Region"
+                  },
+                  ":ec2:recover"
+                ]
+              ]
+            }
+          ],
+          "AlarmDescription": "Trigger a recovery when system check fails for 5 consecutive minutes.",
+          "ComparisonOperator": "GreaterThanThreshold",
+          "Dimensions": [
+            {
+              "Name": "InstanceId",
+              "Value": {
+                "Ref": "InstanceEtcd{{ $index }}"
+              }
+            }
+          ],
+          "EvaluationPeriods": "5",
+          "MetricName": "StatusCheckFailed_System",
+          "Namespace": "AWS/EC2",
+          "Period": "60",
+          "Statistic": "Minimum",
+          "Threshold": "0"
+        },
+        "Type": "AWS::CloudWatch::Alarm"
+      },
+    {{end}}
     "InstanceController": {
       "Properties": {
         "AvailabilityZone": "{{(index .Subnets .ControllerSubnetIndex).AvailabilityZone}}",
@@ -324,6 +405,93 @@
       },
       "Type": "AWS::AutoScaling::LaunchConfiguration"
     },
+    {{if .DedicatedEtcd}}
+    "SecurityGroupEtcd": {
+      "Properties": {
+        "GroupDescription": {
+          "Ref": "AWS::StackName"
+        },
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 0,
+            "IpProtocol": "tcp",
+            "ToPort": 65535
+          },
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 0,
+            "IpProtocol": "udp",
+            "ToPort": 65535
+          }
+        ],
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 3,
+            "IpProtocol": "icmp",
+            "ToPort": -1
+          },
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 22,
+            "IpProtocol": "tcp",
+            "ToPort": 22
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "{{.ClusterName}}"
+          }
+        ],
+        "VpcId": {{.VPCRef}}
+      },
+      "Type": "AWS::EC2::SecurityGroup"
+    },
+    "SecurityGroupEtcdIngressFromEtcdToEtcd": {
+      "Properties": {
+        "FromPort": 2379,
+        "GroupId": {
+          "Ref": "SecurityGroupEtcd"
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupEtcd"
+        },
+        "ToPort": 2380
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    "SecurityGroupEtcdIngressFromControllerToEtcd": {
+      "Properties": {
+        "FromPort": 2379,
+        "GroupId": {
+          "Ref": "SecurityGroupEtcd"
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupController"
+        },
+        "ToPort": 2379
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    "SecurityGroupEtcdIngressFromWorkerToEtcd": {
+      "Properties": {
+        "FromPort": 2379,
+        "GroupId": {
+          "Ref": "SecurityGroupEtcd"
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "ToPort": 2379
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    {{end}}
     "SecurityGroupController": {
       "Properties": {
         "GroupDescription": {
@@ -373,6 +541,7 @@
       },
       "Type": "AWS::EC2::SecurityGroup"
     },
+    {{if not .DedicatedEtcd}}
     "SecurityGroupControllerIngressFromWorkerToEtcd": {
       "Properties": {
         "FromPort": 2379,
@@ -387,6 +556,7 @@
       },
       "Type": "AWS::EC2::SecurityGroupIngress"
     },
+    {{end}}
     "SecurityGroupWorker": {
       "Properties": {
         "GroupDescription": {

--- a/multi-node/aws/pkg/config/templates_gen.go
+++ b/multi-node/aws/pkg/config/templates_gen.go
@@ -35,6 +35,7 @@ var files = []struct {
 }{
 	{"cloud-config-controller", "CloudConfigController"},
 	{"cloud-config-worker", "CloudConfigWorker"},
+	{"cloud-config-etcd", "CloudConfigEtcd"},
 	{"cluster.yaml", "DefaultClusterConfig"},
 	{"kubeconfig.tmpl", "KubeConfigTemplate"},
 	{"stack-template.json", "StackTemplateTemplate"},


### PR DESCRIPTION
This PR enables dedicated and fault tolerant deployments of etcd with kube-aws.

A new optional config property in cluster.yaml (etcdIPs) controls the number of dedicated etcd instances. They are matched to the subnets that can already be configured for high-availability workers to create them in separate AZs.

If etcdIPs is not specified, etcd runs on the controller instance as before. Dedicated etcd instances use CloudWatch instance recovery and EBS to survive machine failures.

The following section of cluster.yaml allows to run etcd in three separate AZs, allowing for complete loss of one AZ without outages:
```
subnets:
  - availabilityZone: us-west-1a
    instanceCIDR: "10.0.0.0/24"
  - availabilityZone: us-west-1b
    instanceCIDR: "10.0.1.0/24"
  - availabilityZone: us-west-1c
    instanceCIDR: "10.0.2.0/24"

etcdIPs:
  - 10.0.0.20
  - 10.0.1.20
  - 10.0.2.20
```

After experimenting a lot with etcd in autoscaling groups and the associated complexity, I find this to be a clean, simple solution to running fault tolerant etcd. From here putting the controllers in an ASG and behind an ELB should be very simple.

(I originally implemented this will full TLS support with client authentication, but since these assets have to be in each of the etcd* cloud-configs, the total stack size quickly exceeds the 52k limit on direct uploads to CloudFormation. When the template is first uploaded to S3 and then referenced there is enough space, any thoughts on this?)