### PR TITLE
kube-aws:  allow all ICMP traffic

### DIFF
--- a/multi-node/aws/pkg/config/templates/stack-template.json
+++ b/multi-node/aws/pkg/config/templates/stack-template.json
@@ -332,6 +332,12 @@
         "SecurityGroupEgress": [
           {
             "CidrIp": "0.0.0.0/0",
+            "FromPort": -1,
+            "IpProtocol": "icmp",
+            "ToPort": -1
+          },
+          {
+            "CidrIp": "0.0.0.0/0",
             "FromPort": 0,
             "IpProtocol": "tcp",
             "ToPort": 65535
@@ -346,7 +352,7 @@
         "SecurityGroupIngress": [
           {
             "CidrIp": "0.0.0.0/0",
-            "FromPort": 3,
+            "FromPort": -1,
             "IpProtocol": "icmp",
             "ToPort": -1
           },
@@ -395,6 +401,12 @@
         "SecurityGroupEgress": [
           {
             "CidrIp": "0.0.0.0/0",
+            "FromPort": -1,
+            "IpProtocol": "icmp",
+            "ToPort": -1
+          },
+          {
+            "CidrIp": "0.0.0.0/0",
             "FromPort": 0,
             "IpProtocol": "tcp",
             "ToPort": 65535
@@ -409,7 +421,7 @@
         "SecurityGroupIngress": [
           {
             "CidrIp": "0.0.0.0/0",
-            "FromPort": 3,
+            "FromPort": -1,
             "IpProtocol": "icmp",
             "ToPort": -1
           },


### PR DESCRIPTION
ICMP doesn't use ports, it uses types and codes, when using ICMP setting toport and fromport to -1 allows all types and codes. 

fixes #526 

cc @colhom 