### PR TITLE
Update releaseChannel in cluster.yaml template

### DIFF
--- a/multi-node/aws/pkg/config/templates/cluster.yaml
+++ b/multi-node/aws/pkg/config/templates/cluster.yaml
@@ -9,9 +9,9 @@ clusterName: {{.ClusterName}}
 # for you.  Otherwise the deployer is responsible for making this name routable
 externalDNSName: {{.ExternalDNSName}}
 
-# CoreOS release channel to use. Currently supported options: [ alpha, beta ]
+# CoreOS release channel to use. Currently supported options: alpha, beta, stable
 # See coreos.com/releases for more information
-#releaseChannel: alpha
+#releaseChannel: stable
 
 # Set to true if you want kube-aws to create a Route53 A Record for you.
 #createRecordSet: false


### PR DESCRIPTION
stable is now the default in [v0.7.1](https://github.com/coreos/coreos-kubernetes/releases/tag/v0.7.1)