### PR TITLE
docs: Deprecate HostedZone, use HostedZoneId instead

### DIFF
--- a/Documentation/kubernetes-on-aws.md
+++ b/Documentation/kubernetes-on-aws.md
@@ -178,8 +178,11 @@ Edit the `cluster.yaml` file:
 ```yaml
 externalDNSName: my-cluster.staging.core-os.net
 createRecordSet: true
-hostedZone: staging.core-os.net
+hostedZoneId: /hostedzone/Z123456789012
 ```
+
+**Note**: Query the HostedZoneId with the following command:
+`aws route53 list-hosted-zones-by-name --dns-name "staging.core-os.net" | jq -r .HostedZones[0].Id`
 
 If `createRecordSet` is not set to true, the deployer will be responsible for making externalDNSName routable to the controller IP after the cluster is created.
 

--- a/multi-node/aws/README.md
+++ b/multi-node/aws/README.md
@@ -127,8 +127,11 @@ Edit the `cluster.yaml` file:
 ```yaml
 externalDNSName: my-cluster.staging.core-os.net
 createRecordSet: true
-hostedZone: staging.core-os.net
+hostedZoneId: /hostedzone/Z123456789012
 ```
+
+Note: Query the HostedZoneId with the following command:
+`aws route53 list-hosted-zones-by-name --dns-name "saigon.events" | jq -r .HostedZones[0].Id`
 
 If `createRecordSet` is not set to true, the deployer will be responsible for making externalDNSName routable to the controller IP after the cluster is created.
 

--- a/multi-node/aws/README.md
+++ b/multi-node/aws/README.md
@@ -131,7 +131,7 @@ hostedZoneId: /hostedzone/Z123456789012
 ```
 
 Note: Query the HostedZoneId with the following command:
-`aws route53 list-hosted-zones-by-name --dns-name "saigon.events" | jq -r .HostedZones[0].Id`
+`aws route53 list-hosted-zones-by-name --dns-name "staging.core-os.net" | jq -r .HostedZones[0].Id`
 
 If `createRecordSet` is not set to true, the deployer will be responsible for making externalDNSName routable to the controller IP after the cluster is created.
 


### PR DESCRIPTION
cluster.yaml comments indicate HostedZoneId's should be used when asking `kube-aws` to create DNS records. I added this change as well as provided a method for retrieving the HostedZoneId from a HostedZone using AWS cli.