### PR TITLE
kube-aws: improve user-data error messages

### DIFF
--- a/multi-node/aws/pkg/config/config.go
+++ b/multi-node/aws/pkg/config/config.go
@@ -275,11 +275,11 @@ func (c Cluster) ValidateUserData(opts StackTemplateOptions) error {
 	}{
 		{
 			Content: stackConfig.UserDataWorker,
-			Name:    "UserDataWorker",
+			Name:    "cloud-config-worker",
 		},
 		{
 			Content: stackConfig.UserDataController,
-			Name:    "UserDataController",
+			Name:    "cloud-config-controller",
 		},
 	} {
 		report, err := validate.Validate([]byte(userData.Content))


### PR DESCRIPTION
It wasn't very clear that errors for "UserDataWorker"
meant there was a problem in the "cloud-config-worker" file.

fixes #530