### PR TITLE
kube-aws: add optional root volume configs

### DIFF
--- a/multi-node/aws/pkg/config/templates/cluster.yaml
+++ b/multi-node/aws/pkg/config/templates/cluster.yaml
@@ -48,6 +48,12 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # Disk size (GiB) for controller node
 #controllerRootVolumeSize: 30
 
+# Disk type for controller node (one of standard, io1, or gp2)
+#controllerRootVolumeType: gp2
+
+# Number of I/O operations per second (IOPS) that the controller node disk supports. Leave blank if controllerRootVolumeType is not io1
+#controllerRootVolumeIOPS: 0
+
 # Number of worker nodes to create
 #workerCount: 1
 
@@ -56,6 +62,12 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 
 # Disk size (GiB) for worker nodes
 #workerRootVolumeSize: 30
+
+# Disk type for worker node (one of standard, io1, or gp2)
+#workerRootVolumeType: gp2
+
+# Number of I/O operations per second (IOPS) that the worker node disk supports. Leave blank if workerRootVolumeType is not io1
+#workerRootVolumeIOPS: 0
 
 # Price (Dollars) to bid for spot instances. Omit for on-demand instances.
 # workerSpotPrice: "0.05"

--- a/multi-node/aws/pkg/config/templates/stack-template.json
+++ b/multi-node/aws/pkg/config/templates/stack-template.json
@@ -256,7 +256,11 @@
           {
             "DeviceName": "/dev/xvda",
             "Ebs": {
-              "VolumeSize": "{{.ControllerRootVolumeSize}}"
+              "VolumeSize": "{{.ControllerRootVolumeSize}}",
+              {{if gt .ControllerRootVolumeIOPS 0}}
+              "Iops": "{{.ControllerRootVolumeIOPS}}",
+              {{end}}
+              "VolumeType": "{{.ControllerRootVolumeType}}"
             }
           }
         ],
@@ -302,7 +306,11 @@
           {
             "DeviceName": "/dev/xvda",
             "Ebs": {
-              "VolumeSize": "{{.WorkerRootVolumeSize}}"
+              "VolumeSize": "{{.WorkerRootVolumeSize}}",
+              {{if gt .WorkerRootVolumeIOPS 0}}
+              "Iops": "{{.WorkerRootVolumeIOPS}}",
+              {{end}}
+              "VolumeType": "{{.WorkerRootVolumeType}}"
             }
           }
         ],


### PR DESCRIPTION
Uses General Purpose SSD `'gp2'` disks for worker and controller root volumes by default, but allows the user to choose a different volume type, such as the previously used `'standard'`, or `'io1'` for the provisioned IOPS SSD.

If the user set `'io1'` as the volume type, the code also ensures that the IOPS are set to a valid number.

Fixes #554