### PR TITLE
cloud-config-worker: kubelet.service no longer depends on docker.service

### DIFF
--- a/multi-node/aws/pkg/config/templates/cloud-config-worker
+++ b/multi-node/aws/pkg/config/templates/cloud-config-worker
@@ -18,10 +18,6 @@ coreos:
       enable: true
       command: start
       content: |
-        [Unit]
-        Requires=docker.service
-        After=docker.service
-
         [Service]
         Environment=KUBELET_VERSION={{.K8sVer}}
         Environment=KUBELET_ACI={{.HyperkubeImageRepo}}


### PR DESCRIPTION
The controller [`kubelet.service`]( https://github.com/coreos/coreos-kubernetes/blob/master/multi-node/aws/pkg/config/templates/cloud-config-controller#L35) definition already does without an explicit dependency on docker.


Fixes #545 