### PR TITLE
Update NetworkPolicy API to v1beta1

### DIFF
--- a/Documentation/conformance-tests.md
+++ b/Documentation/conformance-tests.md
@@ -4,55 +4,25 @@ The conformance test checks that a kubernetes installation supports a minimum re
 
 ## Prerequisites
 
-You will need to have a Kubernetes cluster already running, and a kubeconfig with the current-context set to the cluster you wish to test.
+You will need to have a Kubernetes cluster already running.
 
 Make sure only the essential pods are running, and there are no failed or pending pods. If you are testing a small / development cluster, you may need to increase the node memory or tests could inconsistently fail (e.g. 2048mb for single-node vagrant).
 
-
 ## Running the Tests
 
-Follow these steps to run the conformance test against the desired Kubernetes release:
+If you are running the conformance tests against a vagrant cluster, you can use the `conformance-test.sh` script located either in the `single-node` or `multi-node/vagrant` directories.
 
-### Clone Kubernetes
+To test a running cluster:
 
-First, clone the Kubernetes codebase:
-
-```sh
-$ git clone https://github.com/kubernetes/kubernetes.git
-```
-
-### Checkout Branch
-
-Next, checkout the branch or release you'd like to test against:
+First, clone a copy of this repository to a host with ssh access to the Kubernetes cluster.
 
 ```sh
-$ cd kubernetes
-$ git checkout v1.2.4
+$ git clone https://github.com/coreos/coreos-kubernetes
 ```
 
-### Create Kubernetes Binaries
-
-Build binaries from the codebase:
+Then run the `contrib/conformance-test.sh` helper script, replacing the <ssh-host> <ssh-port> and <path-to-ssh-key>
 
 ```sh
-$ make clean
-$ make quick-release
+$ cd coreos-kubernets/contrib
+$ ./conformance-test.sh <ssh-host> <ssh-port> <path-to-ssh-key>
 ```
-
-### Set Worker Count
-
-Modify the `WORKERS` count to match the deployment you are testing:
-
-```sh
-$ WORKERS=1; sed -i '' "s/NUM_NODES=[0-9]/NUM_NODES=${WORKERS}/" hack/conformance-test.sh
-```
-
-### Run Conformance Tests
-
-The command below expects a kubeconfig with the current context set to the cluster you wish to test. To set the path, update `KUBECONFIG` in the command below.
-
-```sh
-$ KUBECONFIG=$HOME/.kube/config hack/conformance-test.sh 2>&1 | tee conformance.$(date +%FT%T%z).log
-```
-
-**NOTE:** In single-node installations the test `should function for intra-pod communication`, will not pass because there are no additional workers to communicate with.

--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -97,7 +97,7 @@ Note that the kubelet running on a master node may log repeated attempts to post
 
 * Replace `${ADVERTISE_IP}` with this node's publicly routable IP.
 * Replace `${DNS_SERVICE_IP}`
-* Replace `${K8S_VER}` This will map to: `quay.io/coreos/hyperkube:${K8S_VER}` release. If using Calico a version that includes CNI binaries should be used. e.g. `v1.2.4_coreos.cni.1`
+* Replace `${K8S_VER}` This will map to: `quay.io/coreos/hyperkube:${K8S_VER}` release.
 * Replace `${NETWORK_PLUGIN}` with `cni` if using Calico. Otherwise just leave it blank.
 * Decide if you will use [additional features][rkt-opts-examples] such as cluster logging, iSCSI volumes, or addressing workers by hostname in addition to IPs.
 
@@ -150,7 +150,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-apiserver
-    image: quay.io/coreos/hyperkube:v1.2.4_coreos.1
+    image: quay.io/coreos/hyperkube:v1.3.0-beta.2_coreos.0
     command:
     - /hyperkube
     - apiserver
@@ -209,7 +209,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-proxy
-    image: quay.io/coreos/hyperkube:v1.2.4_coreos.1
+    image: quay.io/coreos/hyperkube:v1.3.0-beta.2_coreos.0
     command:
     - /hyperkube
     - proxy
@@ -249,7 +249,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-controller-manager
-    image: quay.io/coreos/hyperkube:v1.2.4_coreos.1
+    image: quay.io/coreos/hyperkube:v1.3.0-beta.2_coreos.0
     command:
     - /hyperkube
     - controller-manager
@@ -298,7 +298,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-scheduler
-    image: quay.io/coreos/hyperkube:v1.2.4_coreos.1
+    image: quay.io/coreos/hyperkube:v1.3.0-beta.2_coreos.0
     command:
     - /hyperkube
     - scheduler

--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -150,7 +150,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-apiserver
-    image: quay.io/coreos/hyperkube:v1.3.0-beta.2_coreos.0
+    image: quay.io/coreos/hyperkube:v1.3.0_coreos.1
     command:
     - /hyperkube
     - apiserver
@@ -209,7 +209,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-proxy
-    image: quay.io/coreos/hyperkube:v1.3.0-beta.2_coreos.0
+    image: quay.io/coreos/hyperkube:v1.3.0_coreos.1
     command:
     - /hyperkube
     - proxy
@@ -249,7 +249,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-controller-manager
-    image: quay.io/coreos/hyperkube:v1.3.0-beta.2_coreos.0
+    image: quay.io/coreos/hyperkube:v1.3.0_coreos.1
     command:
     - /hyperkube
     - controller-manager
@@ -298,7 +298,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-scheduler
-    image: quay.io/coreos/hyperkube:v1.3.0-beta.2_coreos.0
+    image: quay.io/coreos/hyperkube:v1.3.0_coreos.1
     command:
     - /hyperkube
     - scheduler

--- a/Documentation/deploy-workers.md
+++ b/Documentation/deploy-workers.md
@@ -159,7 +159,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-proxy
-    image: quay.io/coreos/hyperkube:v1.3.0-beta.2_coreos.0
+    image: quay.io/coreos/hyperkube:v1.3.0_coreos.1
     command:
     - /hyperkube
     - proxy

--- a/Documentation/deploy-workers.md
+++ b/Documentation/deploy-workers.md
@@ -80,7 +80,7 @@ Create `/etc/systemd/system/kubelet.service` and substitute the following variab
 * Replace `${MASTER_HOST}`
 * Replace `${ADVERTISE_IP}` with this node's publicly routable IP.
 * Replace `${DNS_SERVICE_IP}`
-* Replace `${K8S_VER}` This will map to: `quay.io/coreos/hyperkube:${K8S_VER}` release. If using Calico a version that includes CNI binaries should be used. e.g. `v1.2.4_coreos.cni.1`
+* Replace `${K8S_VER}` This will map to: `quay.io/coreos/hyperkube:${K8S_VER}` release.
 * Replace `${NETWORK_PLUGIN}` with `cni` if using Calico. Otherwise just leave it blank.
 
 **/etc/systemd/system/kubelet.service**
@@ -159,7 +159,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-proxy
-    image: quay.io/coreos/hyperkube:v1.2.4_coreos.1
+    image: quay.io/coreos/hyperkube:v1.3.0-beta.2_coreos.0
     command:
     - /hyperkube
     - proxy

--- a/Documentation/kubelet-wrapper.md
+++ b/Documentation/kubelet-wrapper.md
@@ -19,7 +19,7 @@ An example systemd kubelet.service file which takes advantage of the kubelet-wra
 
 ```ini
 [Service]
-Environment=KUBELET_VERSION=v1.2.4_coreos.1
+Environment=KUBELET_VERSION=v1.3.0-beta.2_coreos.0
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=http://127.0.0.1:8080 \
   --config=/etc/kubernetes/manifests
@@ -38,7 +38,7 @@ Mount the host's `/etc/resolv.conf` file directly into the container in order to
 ```ini
 [Service]
 Environment="RKT_OPTS=--volume=resolv,kind=host,source=/etc/resolv.conf --mount volume=resolv,target=/etc/resolv.conf"
-Environment=KUBELET_VERSION=v1.2.4_coreos.1
+Environment=KUBELET_VERSION=v1.3.0-beta.2_coreos.0
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=http://127.0.0.1:8080 \
   --config=/etc/kubernetes/manifests
@@ -52,7 +52,7 @@ Pods running in your cluster can reference remote storage volumes located on an 
 ```ini
 [Service]
 Environment="RKT_OPTS=--volume iscsiadm,kind=host,source=/usr/sbin/iscsiadm --mount volume=iscsiadm,target=/usr/sbin/iscsiadm"
-Environment=KUBELET_VERSION=v1.2.4_coreos.1
+Environment=KUBELET_VERSION=v1.3.0-beta.2_coreos.0
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=http://127.0.0.1:8080 \
   --config=/etc/kubernetes/manifests
@@ -66,7 +66,7 @@ Export the logs collected by the kubelet via a volume mount, so that [other logg
 ```ini
 [Service]
 Environment="RKT_OPTS=--volume var-log,kind=host,source=/var/log --mount volume=var-log,target=/var/log"
-Environment=KUBELET_VERSION=v1.2.4_coreos.1
+Environment=KUBELET_VERSION=v1.3.0-beta.2_coreos.0
 ExecStartPre=/usr/bin/mkdir -p /var/log/containers
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=http://127.0.0.1:8080 \
@@ -87,7 +87,7 @@ For example:
 
 ```ini
 [Service]
-Environment=KUBELET_VERSION=v1.2.4_coreos.1
+Environment=KUBELET_VERSION=v1.3.0-beta.2_coreos.0
 ExecStart=/opt/bin/kubelet-wrapper \
   --api-servers=http://127.0.0.1:8080 \
   --config=/etc/kubernetes/manifests

--- a/Documentation/kubelet-wrapper.md
+++ b/Documentation/kubelet-wrapper.md
@@ -19,7 +19,7 @@ An example systemd kubelet.service file which takes advantage of the kubelet-wra
 
 ```ini
 [Service]
-Environment=KUBELET_VERSION=v1.3.0-beta.2_coreos.0
+Environment=KUBELET_VERSION=v1.3.0_coreos.1
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=http://127.0.0.1:8080 \
   --config=/etc/kubernetes/manifests
@@ -38,7 +38,7 @@ Mount the host's `/etc/resolv.conf` file directly into the container in order to
 ```ini
 [Service]
 Environment="RKT_OPTS=--volume=resolv,kind=host,source=/etc/resolv.conf --mount volume=resolv,target=/etc/resolv.conf"
-Environment=KUBELET_VERSION=v1.3.0-beta.2_coreos.0
+Environment=KUBELET_VERSION=v1.3.0_coreos.1
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=http://127.0.0.1:8080 \
   --config=/etc/kubernetes/manifests
@@ -52,7 +52,7 @@ Pods running in your cluster can reference remote storage volumes located on an 
 ```ini
 [Service]
 Environment="RKT_OPTS=--volume iscsiadm,kind=host,source=/usr/sbin/iscsiadm --mount volume=iscsiadm,target=/usr/sbin/iscsiadm"
-Environment=KUBELET_VERSION=v1.3.0-beta.2_coreos.0
+Environment=KUBELET_VERSION=v1.3.0_coreos.1
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=http://127.0.0.1:8080 \
   --config=/etc/kubernetes/manifests
@@ -66,7 +66,7 @@ Export the logs collected by the kubelet via a volume mount, so that [other logg
 ```ini
 [Service]
 Environment="RKT_OPTS=--volume var-log,kind=host,source=/var/log --mount volume=var-log,target=/var/log"
-Environment=KUBELET_VERSION=v1.3.0-beta.2_coreos.0
+Environment=KUBELET_VERSION=v1.3.0_coreos.1
 ExecStartPre=/usr/bin/mkdir -p /var/log/containers
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=http://127.0.0.1:8080 \
@@ -87,7 +87,7 @@ For example:
 
 ```ini
 [Service]
-Environment=KUBELET_VERSION=v1.3.0-beta.2_coreos.0
+Environment=KUBELET_VERSION=v1.3.0_coreos.1
 ExecStart=/opt/bin/kubelet-wrapper \
   --api-servers=http://127.0.0.1:8080 \
   --config=/etc/kubernetes/manifests

--- a/Documentation/kubernetes-on-aws.md
+++ b/Documentation/kubernetes-on-aws.md
@@ -165,9 +165,8 @@ The cluster can be configured to use Calico to provide network policy.
 Edit the `cluster.yaml` file:
 ```yaml
 useCalico: true
-kubernetesVersion: v1.2.4_coreos.cni.1
+kubernetesVersion: v1.3.0-beta.2_coreos.0
 ```
-The hyperkube image version needs to contain the CNI binaries (these are tagged with `_cni`)
 
 ### Optional Route53 Host Record
 

--- a/Documentation/kubernetes-on-aws.md
+++ b/Documentation/kubernetes-on-aws.md
@@ -165,7 +165,7 @@ The cluster can be configured to use Calico to provide network policy.
 Edit the `cluster.yaml` file:
 ```yaml
 useCalico: true
-kubernetesVersion: v1.3.0-beta.2_coreos.0
+kubernetesVersion: v1.3.0_coreos.1
 ```
 
 ### Optional Route53 Host Record

--- a/Documentation/kubernetes-on-vagrant.md
+++ b/Documentation/kubernetes-on-vagrant.md
@@ -18,13 +18,13 @@ Navigate to the [Vagrant downloads page][vagrant-downloads] and grab the appropr
 The linux `kubectl` binary can be fetched with a command like:
 
 ```sh
-$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.2.4/bin/linux/amd64/kubectl
+$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.3.0-beta.2/bin/linux/amd64/kubectl
 ```
 
 On an OS X workstation, replace `linux` in the URL above with `darwin`:
 
 ```sh
-$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.2.4/bin/darwin/amd64/kubectl
+$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.3.0-beta.2/bin/darwin/amd64/kubectl
 ```
 
 After downloading the binary, ensure it is executable and move it into your PATH:
@@ -60,7 +60,7 @@ The default cluster configuration is to start a virtual machine for each role &m
 #$etcd_vm_memory=512
 ```
 
-By default, Calico network policy is disabled. To enable it, change the line `export USE_CALICO=false` to `export USE_CALICO=true` in both the `../generic/controller-install.sh` and the `../generic/worker-install.sh` scripts. With Calico enabled, ensure that the `K8S_VER` variable in both of those files refers to a version of the hyperkube image that bundles the CNI binaries, e.g. `export K8S_VER=v1.2.4_coreos.cni.1`. This is not the default, and must be manually changed when using Calico.
+By default, Calico network policy is disabled. To enable it, change the line `export USE_CALICO=false` to `export USE_CALICO=true` in both the `../generic/controller-install.sh` and the `../generic/worker-install.sh` scripts.
 
 Ensure the latest CoreOS vagrant image will be used by running `vagrant box update`.
 

--- a/Documentation/kubernetes-upgrade.md
+++ b/Documentation/kubernetes-upgrade.md
@@ -43,7 +43,7 @@ Master nodes consist of the following Kubernetes components:
 * kube-apiserver
 * kube-controller-manager
 * kube-scheduler
-* policy-agent
+* policy-controller
 
 While upgrading the master components, user pods on worker nodes will continue to run normally.
 

--- a/Documentation/kubernetes-upgrade.md
+++ b/Documentation/kubernetes-upgrade.md
@@ -15,7 +15,7 @@ For example, modifying the `KUBELET_VERSION` environment variable in the followi
 **/etc/systemd/system/kubelet.service**
 
 ```
-Environment=KUBELET_VERSION=v1.3.0-beta.2_coreos.0
+Environment=KUBELET_VERSION=v1.3.0_coreos.1
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=https://master [...]
 ```

--- a/Documentation/kubernetes-upgrade.md
+++ b/Documentation/kubernetes-upgrade.md
@@ -15,7 +15,7 @@ For example, modifying the `KUBELET_VERSION` environment variable in the followi
 **/etc/systemd/system/kubelet.service**
 
 ```
-Environment=KUBELET_VERSION=v1.2.4_coreos.1
+Environment=KUBELET_VERSION=v1.3.0-beta.2_coreos.0
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=https://master [...]
 ```

--- a/contrib/bump-version.sh
+++ b/contrib/bump-version.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# This script will go through each of the tracked files in this repo and update
+# the CURRENT_VERSION to the TARGET_VERSION. This is meant as a helper - but
+# probably should still double-check the changes are correct
+
+if [ $# -ne 1 ]; then
+    echo "USAGE: $0 <target-version>"
+    echo "  example: $0 'v1.3.0-beta.1_coreos.0'"
+    exit 1
+fi
+
+CURRENT_VERSION=${CURRENT_VERSION:-"v1.3.0-beta.1_coreos.0"}
+TARGET_VERSION=${1}
+
+GIT_ROOT=$(git rev-parse --show-toplevel)
+
+cd $GIT_ROOT
+TRACKED=($(git grep -F "${CURRENT_VERSION}"| awk -F : '{print $1}' | sort -u))
+for i in "${TRACKED[@]}"; do
+    echo Updating $i
+    if [ "$(uname -s)" == "Darwin" ]; then
+        sed -i "" "s/${CURRENT_VERSION}/${TARGET_VERSION}/g" $i
+    else
+        sed -i "s/${CURRENT_VERSION}/${TARGET_VERSION}/g" $i
+    fi
+done

--- a/contrib/bump-version.sh
+++ b/contrib/bump-version.sh
@@ -10,7 +10,7 @@ if [ $# -ne 1 ]; then
     exit 1
 fi
 
-CURRENT_VERSION=${CURRENT_VERSION:-"v1.3.0-beta.1_coreos.0"}
+CURRENT_VERSION=${CURRENT_VERSION:-"v1.3.0_coreos.1"}
 TARGET_VERSION=${1}
 
 GIT_ROOT=$(git rev-parse --show-toplevel)

--- a/contrib/conformance-test.sh
+++ b/contrib/conformance-test.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -euo pipefail
+
+CHECK_NODE_COUNT=${CHECK_NODE_COUNT:-true}
+CONFORMANCE_REPO=${CONFORMANCE_REPO:-github.com/coreos/kubernetes}
+CONFORMANCE_VERSION=${CONFORMANCE_VERSION:-v1.3.0-beta.2+coreos.0}
+SSH_OPTS=${SSH_OPTS:-}
+
+usage() {
+    echo "USAGE:"
+    echo "  $0 <ssh-host> <ssh-port> <ssh-key>"
+    echo
+    exit 1
+}
+
+if [ $# -ne 3 ]; then
+    usage
+    exit 1
+fi
+
+ssh_host=$1
+ssh_port=$2
+ssh_key=$3
+
+kubeconfig=$(cat <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: http://127.0.0.1:8080
+EOF
+)
+
+K8S_SRC=/home/core/go/src/k8s.io/kubernetes
+ssh ${SSH_OPTS} -i ${ssh_key} -p ${ssh_port} core@${ssh_host} \
+    "mkdir -p ${K8S_SRC} && [[ -d ${K8S_SRC}/.git ]] || git clone https://${CONFORMANCE_REPO} ${K8S_SRC}"
+
+ssh ${SSH_OPTS} -i ${ssh_key} -p ${ssh_port} core@${ssh_host} \
+    "[[ -f /home/core/kubeconfig ]] || echo '${kubeconfig}' > /home/core/kubeconfig"
+
+# Init steps necessary to run conformance in docker://golang:1.6.2 container
+INIT="apt-get update && apt-get install -y rsync"
+
+TEST_FLAGS="-v --test -check_version_skew=false -check_node_count=${CHECK_NODE_COUNT} --test_args=\"ginkgo.focus='\[Conformance\]'\""
+
+CONFORMANCE=$(echo \
+    "cd /go/src/k8s.io/kubernetes && " \
+    "git checkout ${CONFORMANCE_VERSION} && " \
+    "make all WHAT=cmd/kubectl && " \
+    "make all WHAT=vendor/github.com/onsi/ginkgo/ginkgo && " \
+    "make all WHAT=test/e2e/e2e.test && " \
+    "KUBECONFIG=/kubeconfig KUBERNETES_PROVIDER=skeleton KUBERNETES_CONFORMANCE_TEST=Y go run hack/e2e.go ${TEST_FLAGS}")
+
+RKT_OPTS=$(echo \
+    "--volume=kc,kind=host,source=/home/core/kubeconfig "\
+    "--volume=k8s,kind=host,source=${K8S_SRC} " \
+    "--mount volume=kc,target=/kubeconfig " \
+    "--mount volume=k8s,target=/go/src/k8s.io/kubernetes")
+
+CMD="sudo rkt run --net=host --insecure-options=image ${RKT_OPTS} docker://golang:1.6.2 --exec /bin/bash -- -c \"${INIT} && ${CONFORMANCE}\""
+
+ssh ${SSH_OPTS} -i ${ssh_key} -p ${ssh_port} core@${ssh_host} "${CMD}"

--- a/multi-node/aws/pkg/config/config.go
+++ b/multi-node/aws/pkg/config/config.go
@@ -36,7 +36,7 @@ func newDefaultCluster() *Cluster {
 		PodCIDR:                  "10.2.0.0/16",
 		ServiceCIDR:              "10.3.0.0/24",
 		DNSServiceIP:             "10.3.0.10",
-		K8sVer:                   "v1.2.4_coreos.1",
+		K8sVer:                   "v1.3.0-beta.2_coreos.0",
 		HyperkubeImageRepo:       "quay.io/coreos/hyperkube",
 		ControllerInstanceType:   "m3.medium",
 		ControllerRootVolumeSize: 30,

--- a/multi-node/aws/pkg/config/config.go
+++ b/multi-node/aws/pkg/config/config.go
@@ -36,7 +36,7 @@ func newDefaultCluster() *Cluster {
 		PodCIDR:                  "10.2.0.0/16",
 		ServiceCIDR:              "10.3.0.0/24",
 		DNSServiceIP:             "10.3.0.10",
-		K8sVer:                   "v1.3.0-beta.2_coreos.0",
+		K8sVer:                   "v1.3.0_coreos.1",
 		HyperkubeImageRepo:       "quay.io/coreos/hyperkube",
 		ControllerInstanceType:   "m3.medium",
 		ControllerRootVolumeSize: 30,

--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -42,8 +42,6 @@ coreos:
         Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf --mount volume=dns,target=/etc/resolv.conf"
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
         --api-servers=http://localhost:8080 \
-        --network-plugin-dir=/etc/kubernetes/cni/net.d \
-        --network-plugin={{.K8sNetworkPlugin}} \
         --register-schedulable=false \
         --allow-privileged=true \
         --config=/etc/kubernetes/manifests \

--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -136,17 +136,19 @@ write_files:
     owner: root:root
     content: |
       #!/bin/bash -e
-      /usr/bin/curl -H "Content-Type: application/json" -XPOST -d @"/srv/kubernetes/manifests/kube-system.json" "http://127.0.0.1:8080/api/v1/namespaces"
-
       /usr/bin/curl  -H "Content-Type: application/json" -XPOST \
       -d @"/srv/kubernetes/manifests/kube-dns-rc.json" \
+      "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers"
+
+      /usr/bin/curl  -H "Content-Type: application/json" -XPOST \
+      -d @"/srv/kubernetes/manifests/kube-dashboard-rc.json" \
       "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers"
 
       /usr/bin/curl  -H "Content-Type: application/json" -XPOST \
       -d @"/srv/kubernetes/manifests/heapster-dc.json" \
       "http://127.0.0.1:8080/apis/extensions/v1beta1/namespaces/kube-system/deployments"
 
-      for manifest in {kube-dns,heapster}-svc.json;do
+      for manifest in {kube-dns,heapster,kube-dashboard}-svc.json;do
           /usr/bin/curl  -H "Content-Type: application/json" -XPOST \
           -d @"/srv/kubernetes/manifests/$manifest" \
           "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services"
@@ -162,7 +164,6 @@ write_files:
       /usr/bin/curl -H "Content-Type: application/json" -XPOST \
       -d @"/srv/kubernetes/manifests/network-policy.json" \
       "http://127.0.0.1:8080/apis/extensions/v1beta1/namespaces/default/thirdpartyresources"
-
 
       /usr/bin/cp /srv/kubernetes/manifests/calico-policy-agent.yaml /etc/kubernetes/manifests
 
@@ -194,7 +195,6 @@ write_files:
             - /hyperkube
             - proxy
             - --master=http://127.0.0.1:8080
-            - --proxy-mode=iptables
             securityContext:
               privileged: true
             volumeMounts:
@@ -232,8 +232,15 @@ write_files:
           - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
           - --client-ca-file=/etc/kubernetes/ssl/ca.pem
           - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
-          - --runtime-config=extensions/v1beta1/deployments=true,extensions/v1beta1/daemonsets=true,extensions/v1beta1=true,extensions/v1beta1/thirdpartyresources=true
+          - --runtime-config=extensions/v1beta1/thirdpartyresources=true
           - --cloud-provider=aws
+          livenessProbe:
+            httpGet:
+              host: 127.0.0.1
+              port: 8080
+              path: /healthz
+            initialDelaySeconds: 15
+            timeoutSeconds: 15
           ports:
           - containerPort: 443
             hostPort: 443
@@ -275,13 +282,16 @@ write_files:
           - --service-account-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
           - --root-ca-file=/etc/kubernetes/ssl/ca.pem
           - --cloud-provider=aws
+          resources:
+            requests:
+              cpu: 200m
           livenessProbe:
             httpGet:
               host: 127.0.0.1
               path: /healthz
               port: 10252
             initialDelaySeconds: 15
-            timeoutSeconds: 1
+            timeoutSeconds: 15
           volumeMounts:
           - mountPath: /etc/kubernetes/ssl
             name: ssl-certs-kubernetes
@@ -315,13 +325,16 @@ write_files:
           - scheduler
           - --master=http://127.0.0.1:8080
           - --leader-elect=true
+          resources:
+            requests:
+              cpu: 100m
           livenessProbe:
             httpGet:
               host: 127.0.0.1
               path: /healthz
               port: 10251
             initialDelaySeconds: 15
-            timeoutSeconds: 1
+            timeoutSeconds: 15
 
   - path: /srv/kubernetes/manifests/calico-policy-agent.yaml
     content: |
@@ -351,16 +364,6 @@ write_files:
               - "--election=calico-policy-election"
               - "--election-namespace=calico-system"
               - "--http=127.0.0.1:4040"
-
-  - path: /srv/kubernetes/manifests/kube-system.json
-    content: |
-        {
-          "apiVersion": "v1",
-          "kind": "Namespace",
-          "metadata": {
-            "name": "kube-system"
-          }
-        }
 
   - path: /srv/kubernetes/manifests/calico-system.json
     content: |
@@ -397,63 +400,33 @@ write_files:
             "labels": {
               "k8s-app": "kube-dns",
               "kubernetes.io/cluster-service": "true",
-              "version": "v11"
+              "version": "v15"
             },
-            "name": "kube-dns-v11",
+            "name": "kube-dns-v15",
             "namespace": "kube-system"
           },
           "spec": {
             "replicas": 1,
             "selector": {
               "k8s-app": "kube-dns",
-              "version": "v11"
+              "version": "v15"
             },
             "template": {
               "metadata": {
                 "labels": {
                   "k8s-app": "kube-dns",
                   "kubernetes.io/cluster-service": "true",
-                  "version": "v11"
+                  "version": "v15"
                 }
               },
               "spec": {
                 "containers": [
                   {
-                    "command": [
-                      "/usr/local/bin/etcd",
-                      "-data-dir",
-                      "/var/etcd/data",
-                      "-listen-client-urls",
-                      "http://127.0.0.1:2379,http://127.0.0.1:4001",
-                      "-advertise-client-urls",
-                      "http://127.0.0.1:2379,http://127.0.0.1:4001",
-                      "-initial-cluster-token",
-                      "skydns-etcd"
-                    ],
-                    "image": "gcr.io/google_containers/etcd-amd64:2.2.1",
-                    "name": "etcd",
-                    "resources": {
-                      "limits": {
-                        "cpu": "100m",
-                        "memory": "500Mi"
-                      },
-                      "requests": {
-                        "cpu": "100m",
-                        "memory": "50Mi"
-                      }
-                    },
-                    "volumeMounts": [
-                      {
-                        "mountPath": "/var/etcd/data",
-                        "name": "etcd-storage"
-                      }
-                    ]
-                  },
-                  {
                     "args": [
-                      "--domain=cluster.local"
+                      "--domain=cluster.local.",
+                      "--dns-port=10053"
                     ],
-                    "image": "gcr.io/google_containers/kube2sky:1.14",
+                    "image": "gcr.io/google_containers/kubedns-amd64:1.3",
                     "livenessProbe": {
                       "failureThreshold": 5,
                       "httpGet": {
@@ -465,7 +438,19 @@ write_files:
                       "successThreshold": 1,
                       "timeoutSeconds": 5
                     },
-                    "name": "kube2sky",
+                    "name": "kubedns",
+                    "ports": [
+                      {
+                        "containerPort": 10053,
+                        "name": "dns-local",
+                        "protocol": "UDP"
+                      },
+                      {
+                        "containerPort": 10053,
+                        "name": "dns-tcp-local",
+                        "protocol": "TCP"
+                      }
+                    ],
                     "readinessProbe": {
                       "httpGet": {
                         "path": "/readiness",
@@ -488,13 +473,12 @@ write_files:
                   },
                   {
                     "args": [
-                      "-machines=http://127.0.0.1:4001",
-                      "-addr=0.0.0.0:53",
-                      "-ns-rotate=false",
-                      "-domain=cluster.local."
+                      "--cache-size=1000",
+                      "--no-resolv",
+                      "--server=127.0.0.1#10053"
                     ],
-                    "image": "gcr.io/google_containers/skydns:2015-10-13-8c72f8c",
-                    "name": "skydns",
+                    "image": "gcr.io/google_containers/kube-dnsmasq-amd64:1.3",
+                    "name": "dnsmasq",
                     "ports": [
                       {
                         "containerPort": 53,
@@ -506,24 +490,15 @@ write_files:
                         "name": "dns-tcp",
                         "protocol": "TCP"
                       }
-                    ],
-                    "resources": {
-                      "limits": {
-                        "cpu": "100m",
-                        "memory": "200Mi"
-                      },
-                      "requests": {
-                        "cpu": "100m",
-                        "memory": "50Mi"
-                      }
-                    }
+                    ]
                   },
                   {
                     "args": [
                       "-cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1 >/dev/null",
-                      "-port=8080"
+                      "-port=8080",
+                      "-quiet"
                     ],
-                    "image": "gcr.io/google_containers/exechealthz:1.0",
+                    "image": "gcr.io/google_containers/exechealthz-amd64:1.0",
                     "name": "healthz",
                     "ports": [
                       {
@@ -543,13 +518,7 @@ write_files:
                     }
                   }
                 ],
-                "dnsPolicy": "Default",
-                "volumes": [
-                  {
-                    "emptyDir": {},
-                    "name": "etcd-storage"
-                  }
-                ]
+                "dnsPolicy": "Default"
               }
             }
           }
@@ -561,26 +530,26 @@ write_files:
           "apiVersion": "v1",
           "kind": "Service",
           "metadata": {
-            "name": "kube-dns",
-            "namespace": "kube-system",
             "labels": {
               "k8s-app": "kube-dns",
-              "kubernetes.io/name": "KubeDNS",
-              "kubernetes.io/cluster-service": "true"
-            }
+              "kubernetes.io/cluster-service": "true",
+              "kubernetes.io/name": "KubeDNS"
+            },
+            "name": "kube-dns",
+            "namespace": "kube-system"
           },
           "spec": {
-            "clusterIP": "{{.DNSServiceIP}}",
+            "clusterIP": "$DNS_SERVICE_IP",
             "ports": [
               {
-                "protocol": "UDP",
                 "name": "dns",
-                "port": 53
+                "port": 53,
+                "protocol": "UDP"
               },
               {
-                "protocol": "TCP",
                 "name": "dns-tcp",
-                "port": 53
+                "port": 53,
+                "protocol": "TCP"
               }
             ],
             "selector": {
@@ -598,9 +567,9 @@ write_files:
             "labels": {
               "k8s-app": "heapster",
               "kubernetes.io/cluster-service": "true",
-              "version": "v1.0.2"
+              "version": "v1.1.0"
             },
-            "name": "heapster-v1.0.2",
+            "name": "heapster-v1.1.0",
             "namespace": "kube-system"
           },
           "spec": {
@@ -608,14 +577,14 @@ write_files:
             "selector": {
               "matchLabels": {
                 "k8s-app": "heapster",
-                "version": "v1.0.2"
+                "version": "v1.1.0"
               }
             },
             "template": {
               "metadata": {
                 "labels": {
                   "k8s-app": "heapster",
-                  "version": "v1.0.2"
+                  "version": "v1.1.0"
                 }
               },
               "spec": {
@@ -623,19 +592,18 @@ write_files:
                   {
                     "command": [
                       "/heapster",
-                      "--source=kubernetes.summary_api:''",
-                      "--metric_resolution=60s"
+                      "--source=kubernetes.summary_api:''"
                     ],
-                    "image": "gcr.io/google_containers/heapster:v1.0.2",
+                    "image": "gcr.io/google_containers/heapster:v1.1.0",
                     "name": "heapster",
                     "resources": {
                       "limits": {
                         "cpu": "100m",
-                        "memory": "250Mi"
+                        "memory": "200Mi"
                       },
                       "requests": {
                         "cpu": "100m",
-                        "memory": "250Mi"
+                        "memory": "200Mi"
                       }
                     }
                   },
@@ -643,13 +611,14 @@ write_files:
                     "command": [
                       "/pod_nanny",
                       "--cpu=100m",
-                      "--extra-cpu=0m",
-                      "--memory=250Mi",
+                      "--extra-cpu=0.5m",
+                      "--memory=200Mi",
                       "--extra-memory=4Mi",
                       "--threshold=5",
-                      "--deployment=heapster-v1.0.2",
+                      "--deployment=heapster-v1.1.0",
                       "--container=heapster",
-                      "--poll-period=300000"
+                      "--poll-period=300000",
+                      "--estimator=exponential"
                     ],
                     "env": [
                       {
@@ -669,7 +638,7 @@ write_files:
                         }
                       }
                     ],
-                    "image": "gcr.io/google_containers/addon-resizer:1.0",
+                    "image": "gcr.io/google_containers/addon-resizer:1.3",
                     "name": "heapster-nanny",
                     "resources": {
                       "limits": {
@@ -691,15 +660,103 @@ write_files:
   - path: /srv/kubernetes/manifests/heapster-svc.json
     content: |
         {
-          "kind": "Service",
           "apiVersion": "v1",
+          "kind": "Service",
           "metadata": {
-            "name": "heapster",
-            "namespace": "kube-system",
             "labels": {
               "kubernetes.io/cluster-service": "true",
               "kubernetes.io/name": "Heapster"
+            },
+            "name": "heapster",
+            "namespace": "kube-system"
+          },
+          "spec": {
+            "ports": [
+              {
+                "port": 80,
+                "targetPort": 8082
+              }
+            ],
+            "selector": {
+              "k8s-app": "heapster"
             }
+          }
+        }
+
+  - path: /srv/kubernetes/manifests/kube-dashboard-rc.json
+    content: |
+        {
+          "apiVersion": "v1",
+          "kind": "ReplicationController",
+          "metadata": {
+            "labels": {
+              "k8s-app": "kubernetes-dashboard",
+              "kubernetes.io/cluster-service": "true",
+              "version": "v1.1.0-beta3"
+            },
+            "name": "kubernetes-dashboard-v1.1.0-beta3",
+            "namespace": "kube-system"
+          },
+          "spec": {
+            "replicas": 1,
+            "selector": {
+              "k8s-app": "kubernetes-dashboard"
+            },
+            "template": {
+              "metadata": {
+                "labels": {
+                  "k8s-app": "kubernetes-dashboard",
+                  "kubernetes.io/cluster-service": "true",
+                  "version": "v1.1.0-beta3"
+                }
+              },
+              "spec": {
+                "containers": [
+                  {
+                    "image": "gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0-beta3",
+                    "livenessProbe": {
+                      "httpGet": {
+                        "path": "/",
+                        "port": 9090
+                      },
+                      "initialDelaySeconds": 30,
+                      "timeoutSeconds": 30
+                    },
+                    "name": "kubernetes-dashboard",
+                    "ports": [
+                      {
+                        "containerPort": 9090
+                      }
+                    ],
+                    "resources": {
+                      "limits": {
+                        "cpu": "100m",
+                        "memory": "50Mi"
+                      },
+                      "requests": {
+                        "cpu": "100m",
+                        "memory": "50Mi"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+
+  - path: /srv/kubernetes/manifests/kube-dashboard-svc.json
+    content: |
+        {
+          "apiVersion": "v1",
+          "kind": "Service",
+          "metadata": {
+            "labels": {
+              "kubernetes.io/cluster-service": "true",
+              "kubernetes.io/name": "Heapster"
+            },
+            "name": "heapster",
+            "namespace": "kube-system"
           },
           "spec": {
             "ports": [

--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -757,27 +757,27 @@ write_files:
   - path: /srv/kubernetes/manifests/kube-dashboard-svc.json
     content: |
         {
-          "apiVersion": "v1",
-          "kind": "Service",
-          "metadata": {
-            "labels": {
-              "kubernetes.io/cluster-service": "true",
-              "kubernetes.io/name": "Heapster"
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "labels": {
+                    "k8s-app": "kubernetes-dashboard",
+                    "kubernetes.io/cluster-service": "true"
+                },
+                "name": "kubernetes-dashboard",
+                "namespace": "kube-system"
             },
-            "name": "heapster",
-            "namespace": "kube-system"
-          },
-          "spec": {
-            "ports": [
-              {
-                "port": 80,
-                "targetPort": 8082
-              }
-            ],
-            "selector": {
-              "k8s-app": "heapster"
+            "spec": {
+                "ports": [
+                    {
+                        "port": 80,
+                        "targetPort": 9090
+                    }
+                ],
+                "selector": {
+                    "k8s-app": "kubernetes-dashboard"
+                }
             }
-          }
         }
 
   - path: /etc/kubernetes/ssl/ca.pem.enc

--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -48,7 +48,8 @@ coreos:
         --allow-privileged=true \
         --config=/etc/kubernetes/manifests \
         --cluster_dns={{.DNSServiceIP}} \
-        --cluster_domain=cluster.local
+        --cluster_domain=cluster.local \
+        --cloud-provider=aws
         Restart=always
         RestartSec=10
 

--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -56,9 +56,9 @@ coreos:
         [Install]
         WantedBy=multi-user.target
 
+{{ if .UseCalico }}
     - name: calico-node.service
       command: start
-      enable: {{.UseCalico}}
       content: |
         [Unit]
         Description=Calico per-host agent
@@ -84,6 +84,7 @@ coreos:
 
         [Install]
         WantedBy=multi-user.target
+{{ end }}
 
     - name: decrypt-tls-assets.service
       enable: true
@@ -116,9 +117,9 @@ coreos:
         ExecStartPre=/usr/bin/curl http://127.0.0.1:8080/version
         ExecStart=/opt/bin/install-kube-system
 
+{{ if .UseCalico }}
     - name: install-calico-system.service
       command: start
-      enable: {{.UseCalico}}
       content: |
         [Unit]
         Requires=kubelet.service docker.service
@@ -130,6 +131,7 @@ coreos:
         Restart=on-failure
         ExecStartPre=/usr/bin/curl http://127.0.0.1:8080/version
         ExecStart=/opt/bin/install-calico-system
+{{ end }}
 
 write_files:
   - path: /opt/bin/install-kube-system
@@ -155,6 +157,7 @@ write_files:
           "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services"
       done
 
+{{ if .UseCalico }}
   - path: /opt/bin/install-calico-system
     permissions: 0700
     owner: root:root
@@ -167,6 +170,7 @@ write_files:
       "http://127.0.0.1:8080/apis/extensions/v1beta1/namespaces/default/thirdpartyresources"
 
       /usr/bin/cp /srv/kubernetes/manifests/calico-policy-agent.yaml /etc/kubernetes/manifests
+{{ end }}
 
   - path: /opt/bin/decrypt-tls-assets
     owner: root:root
@@ -337,6 +341,7 @@ write_files:
             initialDelaySeconds: 15
             timeoutSeconds: 15
 
+{{ if .UseCalico }}
   - path: /srv/kubernetes/manifests/calico-policy-agent.yaml
     content: |
       apiVersion: v1
@@ -365,7 +370,9 @@ write_files:
               - "--election=calico-policy-election"
               - "--election-namespace=calico-system"
               - "--http=127.0.0.1:4040"
+{{ end }}
 
+{{ if .UseCalico }}
   - path: /srv/kubernetes/manifests/calico-system.json
     content: |
         {
@@ -375,7 +382,9 @@ write_files:
             "name": "calico-system"
           }
         }
+{{ end }}
 
+{{ if .UseCalico }}
   - path: /srv/kubernetes/manifests/network-policy.json
     content: |
         {
@@ -391,6 +400,7 @@ write_files:
             }
           ]
         }
+{{ end }}
 
   - path: /srv/kubernetes/manifests/kube-dns-rc.json
     content: |
@@ -784,6 +794,7 @@ write_files:
     encoding: gzip+base64
     content: {{.TLSConfig.APIServerKey}}
 
+{{ if .UseCalico }}
   - path: /etc/kubernetes/cni/net.d/10-calico.conf
     content: |
         {
@@ -801,3 +812,4 @@ write_files:
                 }
             }
         }
+{{ end }}

--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -701,9 +701,9 @@ write_files:
             "labels": {
               "k8s-app": "kubernetes-dashboard",
               "kubernetes.io/cluster-service": "true",
-              "version": "v1.1.0-beta3"
+              "version": "v1.1.0"
             },
-            "name": "kubernetes-dashboard-v1.1.0-beta3",
+            "name": "kubernetes-dashboard-v1.1.0",
             "namespace": "kube-system"
           },
           "spec": {
@@ -716,13 +716,13 @@ write_files:
                 "labels": {
                   "k8s-app": "kubernetes-dashboard",
                   "kubernetes.io/cluster-service": "true",
-                  "version": "v1.1.0-beta3"
+                  "version": "v1.1.0"
                 }
               },
               "spec": {
                 "containers": [
                   {
-                    "image": "gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0-beta3",
+                    "image": "gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0",
                     "livenessProbe": {
                       "httpGet": {
                         "path": "/",

--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -163,11 +163,7 @@ write_files:
       #!/bin/bash -e
       /usr/bin/curl -H "Content-Type: application/json" -XPOST -d @"/srv/kubernetes/manifests/calico-system.json" "http://127.0.0.1:8080/api/v1/namespaces"
 
-      /usr/bin/curl -H "Content-Type: application/json" -XPOST \
-      -d @"/srv/kubernetes/manifests/network-policy.json" \
-      "http://127.0.0.1:8080/apis/extensions/v1beta1/namespaces/default/thirdpartyresources"
-
-      /usr/bin/cp /srv/kubernetes/manifests/calico-policy-agent.yaml /etc/kubernetes/manifests
+      /usr/bin/cp /srv/kubernetes/manifests/calico-policy-controller.yaml /etc/kubernetes/manifests
 {{ end }}
 
   - path: /opt/bin/decrypt-tls-assets
@@ -235,7 +231,7 @@ write_files:
           - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
           - --client-ca-file=/etc/kubernetes/ssl/ca.pem
           - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
-          - --runtime-config=extensions/v1beta1/thirdpartyresources=true
+          - --runtime-config=extensions/v1beta1/networkpolicies=true
           - --cloud-provider=aws
           livenessProbe:
             httpGet:
@@ -340,19 +336,19 @@ write_files:
             timeoutSeconds: 15
 
 {{ if .UseCalico }}
-  - path: /srv/kubernetes/manifests/calico-policy-agent.yaml
+  - path: /srv/kubernetes/manifests/calico-policy-controller.yaml
     content: |
       apiVersion: v1
       kind: Pod
       metadata:
-        name: calico-policy-agent
+        name: calico-policy-controller
         namespace: calico-system
       spec:
         hostNetwork: true
         containers:
-          # The Calico policy agent.
-          - name: k8s-policy-agent
-            image: calico/k8s-policy-agent:v0.1.4
+          # The Calico policy controller.
+          - name: kube-policy-controller
+            image: calico/kube-policy-controller:v0.2.0
             env:
               - name: ETCD_ENDPOINTS
                 value: "{{ .ETCDEndpoints }}"
@@ -360,7 +356,7 @@ write_files:
                 value: "http://127.0.0.1:8080"
               - name: LEADER_ELECTION
                 value: "true"
-          # Leader election container used by the policy agent.
+          # Leader election container used by the policy controller.
           - name: leader-elector
             image: quay.io/calico/leader-elector:v0.1.0
             imagePullPolicy: IfNotPresent
@@ -379,24 +375,6 @@ write_files:
           "metadata": {
             "name": "calico-system"
           }
-        }
-{{ end }}
-
-{{ if .UseCalico }}
-  - path: /srv/kubernetes/manifests/network-policy.json
-    content: |
-        {
-          "kind": "ThirdPartyResource",
-          "apiVersion": "extensions/v1beta1",
-          "metadata": {
-            "name": "network-policy.net.alpha.kubernetes.io"
-          },
-          "description": "Specification for a network isolation policy",
-          "versions": [
-            {
-              "name": "v1alpha1"
-            }
-          ]
         }
 {{ end }}
 

--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -148,7 +148,7 @@ write_files:
       "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers"
 
       /usr/bin/curl  -H "Content-Type: application/json" -XPOST \
-      -d @"/srv/kubernetes/manifests/heapster-dc.json" \
+      -d @"/srv/kubernetes/manifests/heapster-de.json" \
       "http://127.0.0.1:8080/apis/extensions/v1beta1/namespaces/kube-system/deployments"
 
       for manifest in {kube-dns,heapster,kube-dashboard}-svc.json;do
@@ -550,7 +550,7 @@ write_files:
             "namespace": "kube-system"
           },
           "spec": {
-            "clusterIP": "$DNS_SERVICE_IP",
+            "clusterIP": "{{.DNSServiceIP}}",
             "ports": [
               {
                 "name": "dns",
@@ -569,7 +569,7 @@ write_files:
           }
         }
 
-  - path: /srv/kubernetes/manifests/heapster-dc.json
+  - path: /srv/kubernetes/manifests/heapster-de.json
     content: |
         {
           "apiVersion": "extensions/v1beta1",

--- a/multi-node/aws/pkg/config/templates/cloud-config-worker
+++ b/multi-node/aws/pkg/config/templates/cloud-config-worker
@@ -128,7 +128,6 @@ write_files:
             - proxy
             - --master=https://{{.ControllerIP}}:443
             - --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml
-            - --proxy-mode=iptables
             securityContext:
               privileged: true
             volumeMounts:

--- a/multi-node/aws/pkg/config/templates/cloud-config-worker
+++ b/multi-node/aws/pkg/config/templates/cloud-config-worker
@@ -24,8 +24,6 @@ coreos:
         Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf --mount volume=dns,target=/etc/resolv.conf"
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
         --api-servers={{.SecureAPIServers}} \
-        --network-plugin-dir=/etc/kubernetes/cni/net.d \
-        --network-plugin={{.K8sNetworkPlugin}} \
         --register-node=true \
         --allow-privileged=true \
         --config=/etc/kubernetes/manifests \

--- a/multi-node/aws/pkg/config/templates/cloud-config-worker
+++ b/multi-node/aws/pkg/config/templates/cloud-config-worker
@@ -40,9 +40,9 @@ coreos:
         [Install]
         WantedBy=multi-user.target
 
+{{ if .UseCalico }}
     - name: calico-node.service
       command: start
-      enable: {{.UseCalico}}
       content: |
         [Unit]
         Description=Calico per-host agent
@@ -68,6 +68,7 @@ coreos:
 
         [Install]
         WantedBy=multi-user.target
+{{ end }}
 
     - name: decrypt-tls-assets.service
       enable: true
@@ -170,6 +171,7 @@ write_files:
           name: kubelet-context
         current-context: kubelet-context
 
+{{ if .UseCalico }}
   - path: /etc/kubernetes/cni/net.d/10-calico.conf
     content: |
         {
@@ -189,4 +191,5 @@ write_files:
                 }
             }
         }
+{{ end }}
 

--- a/multi-node/aws/pkg/config/templates/cluster.yaml
+++ b/multi-node/aws/pkg/config/templates/cluster.yaml
@@ -92,7 +92,7 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # dnsServiceIP: 10.3.0.10
 
 # Version of hyperkube image to use. This is the tag for the hyperkube image repository.
-# kubernetesVersion: v1.3.0-beta.2_coreos.0
+# kubernetesVersion: v1.3.0_coreos.1
 
 # Hyperkube image repository to use.
 # hyperkubeImageRepo: quay.io/coreos/hyperkube

--- a/multi-node/aws/pkg/config/templates/cluster.yaml
+++ b/multi-node/aws/pkg/config/templates/cluster.yaml
@@ -92,16 +92,15 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # dnsServiceIP: 10.3.0.10
 
 # Version of hyperkube image to use. This is the tag for the hyperkube image repository.
-# kubernetesVersion: v1.2.4_coreos.1
+# kubernetesVersion: v1.3.0-beta.2_coreos.0
 
 # Hyperkube image repository to use.
 # hyperkubeImageRepo: quay.io/coreos/hyperkube
 
-# Use Calico for network policy. When set to "true" the kubernetesVersion (above)
-# must also be updated to include a version tagged with CNI e.g. v1.2.4_coreos.cni.1
+# Use Calico for network policy.
 # useCalico: false
 
-# AWS Tags for cloudformation stack resources 
+# AWS Tags for cloudformation stack resources
 #stackTags:
-#  Name: "Kubernetes" 
+#  Name: "Kubernetes"
 #  Environment: "Production"

--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -717,9 +717,9 @@ EOF
     "labels": {
       "k8s-app": "kubernetes-dashboard",
       "kubernetes.io/cluster-service": "true",
-      "version": "v1.1.0-beta3"
+      "version": "v1.1.0"
     },
-    "name": "kubernetes-dashboard-v1.1.0-beta3",
+    "name": "kubernetes-dashboard-v1.1.0",
     "namespace": "kube-system"
   },
   "spec": {
@@ -732,13 +732,13 @@ EOF
         "labels": {
           "k8s-app": "kubernetes-dashboard",
           "kubernetes.io/cluster-service": "true",
-          "version": "v1.1.0-beta3"
+          "version": "v1.1.0"
         }
       },
       "spec": {
         "containers": [
           {
-            "image": "gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0-beta3",
+            "image": "gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0",
             "livenessProbe": {
               "httpGet": {
                 "path": "/",

--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -870,8 +870,8 @@ function start_addons {
     curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-de.json)" "http://127.0.0.1:8080/apis/extensions/v1beta1/namespaces/kube-system/deployments" > /dev/null
     curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
     echo "K8S: Dashboard addon"
-    curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dashboard-rc.json)" "http://127.0.0.1:8080/apis/extensions/v1beta1/namespaces/kube-system/deployments" > /dev/null
-    curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dashbaord-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
+    curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dashboard-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
+    curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dashboard-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
 }
 
 function enable_calico_policy {

--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -88,7 +88,7 @@ function init_flannel {
 
 function init_templates {
     local TEMPLATE=/etc/systemd/system/kubelet.service
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -112,11 +112,10 @@ RestartSec=10
 [Install]
 WantedBy=multi-user.target
 EOF
-    }
-
+    fi
 
     local TEMPLATE=/etc/systemd/system/calico-node.service
-    [ "$USE_CALICO" = "true" ] && [ ! -f $TEMPLATE ] && {
+    if [ "${USE_CALICO}" = "true" ] && [ ! -f "${TEMPLATE}" ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -145,11 +144,10 @@ TimeoutStartSec=0
 [Install]
 WantedBy=multi-user.target
 EOF
-    }
-
+    fi
 
     local TEMPLATE=/etc/kubernetes/manifests/kube-proxy.yaml
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -178,10 +176,10 @@ spec:
       path: /usr/share/ca-certificates
     name: ssl-certs-host
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/kubernetes/manifests/kube-apiserver.yaml
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -239,10 +237,10 @@ spec:
       path: /usr/share/ca-certificates
     name: ssl-certs-host
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/kubernetes/manifests/kube-controller-manager.yaml
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -288,10 +286,10 @@ spec:
       path: /usr/share/ca-certificates
     name: ssl-certs-host
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/kubernetes/manifests/kube-scheduler.yaml
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -321,10 +319,10 @@ spec:
       initialDelaySeconds: 15
       timeoutSeconds: 15
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/kubernetes/manifests/calico-policy-agent.yaml
-    [ "$USE_CALICO" = "true" ] && [ ! -f $TEMPLATE ] && {
+    if [ "${USE_CALICO}" = "true" ] && [ ! -f "${TEMPLATE}" ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -355,10 +353,10 @@ spec:
         - "--election-namespace=calico-system"
         - "--http=127.0.0.1:4040"
 EOF
-    }
+    fi
 
     local TEMPLATE=/srv/kubernetes/manifests/calico-system.json
-    [ "$USE_CALICO" = "true" ] && [ ! -f $TEMPLATE ] && {
+    if [ "${USE_CALICO}" = "true" ] && [ ! -f "${TEMPLATE}" ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -370,10 +368,10 @@ EOF
   }
 }
 EOF
-    }
+    fi
 
     local TEMPLATE=/srv/kubernetes/manifests/network-policy.json
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -391,10 +389,10 @@ EOF
   ]
 }
 EOF
-    }
+    fi
 
     local TEMPLATE=/srv/kubernetes/manifests/kube-dns-rc.json
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -529,10 +527,10 @@ EOF
   }
 }
 EOF
-    }
+    fi
 
     local TEMPLATE=/srv/kubernetes/manifests/kube-dns-svc.json
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -568,10 +566,10 @@ EOF
   }
 }
 EOF
-    }
+    fi
 
     local TEMPLATE=/srv/kubernetes/manifests/heapster-de.json
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -672,10 +670,10 @@ EOF
   }
 }
 EOF
-    }
+    fi
 
     local TEMPLATE=/srv/kubernetes/manifests/heapster-svc.json
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -703,10 +701,10 @@ EOF
   }
 }
 EOF
-    }
+    fi
 
     local TEMPLATE=/srv/kubernetes/manifests/kube-dashboard-rc.json
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -770,10 +768,10 @@ EOF
   }
 }
 EOF
-    }
+    fi
 
     local TEMPLATE=/srv/kubernetes/manifests/kube-dashboard-svc.json
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -801,30 +799,30 @@ EOF
     }
 }
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/flannel/options.env
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
 FLANNELD_IFACE=$ADVERTISE_IP
 FLANNELD_ETCD_ENDPOINTS=$ETCD_ENDPOINTS
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/systemd/system/flanneld.service.d/40-ExecStartPre-symlink.conf.conf
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
 [Service]
 ExecStartPre=/usr/bin/ln -sf /etc/flannel/options.env /run/flannel/options.env
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/systemd/system/docker.service.d/40-flannel.conf
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -832,10 +830,10 @@ EOF
 Requires=flanneld.service
 After=flanneld.service
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/kubernetes/cni/net.d/10-calico.conf
-    [ "$USE_CALICO" = "true" ] && [ ! -f $TEMPLATE ] && {
+    if [ "${USE_CALICO}" = "true" ] && [ ! -f "${TEMPLATE}" ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -855,8 +853,7 @@ EOF
     }
 }
 EOF
-    }
-
+    fi
 }
 
 function start_addons {

--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -778,27 +778,27 @@ EOF
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
 {
-  "apiVersion": "v1",
-  "kind": "Service",
-  "metadata": {
-    "labels": {
-      "kubernetes.io/cluster-service": "true",
-      "kubernetes.io/name": "Heapster"
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": {
+        "labels": {
+            "k8s-app": "kubernetes-dashboard",
+            "kubernetes.io/cluster-service": "true"
+        },
+        "name": "kubernetes-dashboard",
+        "namespace": "kube-system"
     },
-    "name": "heapster",
-    "namespace": "kube-system"
-  },
-  "spec": {
-    "ports": [
-      {
-        "port": 80,
-        "targetPort": 8082
-      }
-    ],
-    "selector": {
-      "k8s-app": "heapster"
+    "spec": {
+        "ports": [
+            {
+                "port": 80,
+                "targetPort": 9090
+            }
+        ],
+        "selector": {
+            "k8s-app": "kubernetes-dashboard"
+        }
     }
-  }
 }
 EOF
     }

--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -5,7 +5,7 @@ set -e
 export ETCD_ENDPOINTS=
 
 # Specify the version (vX.Y.Z) of Kubernetes assets to deploy
-export K8S_VER=v1.2.4_coreos.1
+export K8S_VER=v1.3.0-beta.2_coreos.0
 
 # Hyperkube image repository to use.
 export HYPERKUBE_IMAGE_REPO=quay.io/coreos/hyperkube
@@ -30,8 +30,7 @@ export K8S_SERVICE_IP=10.3.0.1
 # This same IP must be configured on all worker nodes to enable DNS service discovery.
 export DNS_SERVICE_IP=10.3.0.10
 
-# Whether to use Calico for Kubernetes network policy. When using Calico,
-# K8S_VER (above) must be changed to an image tagged with CNI (e.g. v1.2.4_coreos.cni.1).
+# Whether to use Calico for Kubernetes network policy.
 export USE_CALICO=false
 
 # The above settings can optionally be overridden using an environment file:

--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -5,7 +5,7 @@ set -e
 export ETCD_ENDPOINTS=
 
 # Specify the version (vX.Y.Z) of Kubernetes assets to deploy
-export K8S_VER=v1.3.0-beta.2_coreos.0
+export K8S_VER=v1.3.0_coreos.1
 
 # Hyperkube image repository to use.
 export HYPERKUBE_IMAGE_REPO=quay.io/coreos/hyperkube

--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -207,7 +207,7 @@ spec:
     - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
     - --client-ca-file=/etc/kubernetes/ssl/ca.pem
     - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
-    - --runtime-config=extensions/v1beta1/thirdpartyresources=true
+    - --runtime-config=extensions/v1beta1/networkpolicies=true
     livenessProbe:
       httpGet:
         host: 127.0.0.1
@@ -321,7 +321,7 @@ spec:
 EOF
     fi
 
-    local TEMPLATE=/etc/kubernetes/manifests/calico-policy-agent.yaml
+    local TEMPLATE=/etc/kubernetes/manifests/calico-policy-controller.yaml
     if [ "${USE_CALICO}" = "true" ] && [ ! -f "${TEMPLATE}" ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
@@ -329,14 +329,14 @@ EOF
 apiVersion: v1
 kind: Pod
 metadata:
-  name: calico-policy-agent
+  name: calico-policy-controller
   namespace: calico-system
 spec:
   hostNetwork: true
   containers:
-    # The Calico policy agent.
-    - name: k8s-policy-agent
-      image: calico/k8s-policy-agent:v0.1.4
+    # The Calico policy controller.
+    - name: kube-policy-controller
+      image: calico/kube-policy-controller:v0.2.0
       env:
         - name: ETCD_ENDPOINTS
           value: "${ETCD_ENDPOINTS}"
@@ -344,7 +344,7 @@ spec:
           value: "http://127.0.0.1:8080"
         - name: LEADER_ELECTION
           value: "true"
-    # Leader election container used by the policy agent.
+    # Leader election container used by the policy controller.
     - name: leader-elector
       image: quay.io/calico/leader-elector:v0.1.0
       imagePullPolicy: IfNotPresent
@@ -366,27 +366,6 @@ EOF
   "metadata": {
     "name": "calico-system"
   }
-}
-EOF
-    fi
-
-    local TEMPLATE=/srv/kubernetes/manifests/network-policy.json
-    if [ ! -f $TEMPLATE ]; then
-        echo "TEMPLATE: $TEMPLATE"
-        mkdir -p $(dirname $TEMPLATE)
-        cat << EOF > $TEMPLATE
-{
-  "kind": "ThirdPartyResource",
-  "apiVersion": "extensions/v1beta1",
-  "metadata": {
-    "name": "network-policy.net.alpha.kubernetes.io"
-  },
-  "description": "Specification for a network isolation policy",
-  "versions": [
-    {
-      "name": "v1alpha1"
-    }
-  ]
 }
 EOF
     fi
@@ -883,7 +862,6 @@ function enable_calico_policy {
     echo
     echo "K8S: Calico Policy"
     curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/calico-system.json)" "http://127.0.0.1:8080/api/v1/namespaces/" > /dev/null
-    curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/network-policy.json)" "http://127.0.0.1:8080/apis/extensions/v1beta1/namespaces/default/thirdpartyresources" >/dev/null
 }
 
 init_config

--- a/multi-node/generic/worker-install.sh
+++ b/multi-node/generic/worker-install.sh
@@ -54,7 +54,7 @@ function init_config {
 
 function init_templates {
     local TEMPLATE=/etc/systemd/system/kubelet.service
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -81,10 +81,10 @@ RestartSec=10
 [Install]
 WantedBy=multi-user.target
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/systemd/system/calico-node.service
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -113,10 +113,10 @@ TimeoutStartSec=0
 [Install]
 WantedBy=multi-user.target
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/kubernetes/worker-kubeconfig.yaml
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -138,10 +138,10 @@ contexts:
   name: kubelet-context
 current-context: kubelet-context
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/kubernetes/manifests/kube-proxy.yaml
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -182,30 +182,30 @@ spec:
       hostPath:
         path: "/etc/kubernetes/ssl"
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/flannel/options.env
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
 FLANNELD_IFACE=$ADVERTISE_IP
 FLANNELD_ETCD_ENDPOINTS=$ETCD_ENDPOINTS
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/systemd/system/flanneld.service.d/40-ExecStartPre-symlink.conf.conf
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
 [Service]
 ExecStartPre=/usr/bin/ln -sf /etc/flannel/options.env /run/flannel/options.env
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/systemd/system/docker.service.d/40-flannel.conf
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -213,10 +213,10 @@ EOF
 Requires=flanneld.service
 After=flanneld.service
 EOF
-    }
+    fi
 
      local TEMPLATE=/etc/kubernetes/cni/net.d/10-calico.conf
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -238,7 +238,7 @@ EOF
     }
 }
 EOF
-    }
+    fi
 
 }
 

--- a/multi-node/generic/worker-install.sh
+++ b/multi-node/generic/worker-install.sh
@@ -10,7 +10,7 @@ export ETCD_ENDPOINTS=
 export CONTROLLER_ENDPOINT=
 
 # Specify the version (vX.Y.Z) of Kubernetes assets to deploy
-export K8S_VER=v1.2.4_coreos.1
+export K8S_VER=v1.3.0-beta.2_coreos.0
 
 # Hyperkube image repository to use.
 export HYPERKUBE_IMAGE_REPO=quay.io/coreos/hyperkube
@@ -19,8 +19,7 @@ export HYPERKUBE_IMAGE_REPO=quay.io/coreos/hyperkube
 # This must be the same DNS_SERVICE_IP used when configuring the controller nodes.
 export DNS_SERVICE_IP=10.3.0.10
 
-# Whether to use Calico for Kubernetes network policy. When using Calico,
-# K8S_VER (above) must be changed to an image tagged with CNI (e.g. v1.2.4_coreos.cni.1).
+# Whether to use Calico for Kubernetes network policy.
 export USE_CALICO=false
 
 # The above settings can optionally be overridden using an environment file:
@@ -161,7 +160,6 @@ spec:
     - proxy
     - --master=${CONTROLLER_ENDPOINT}
     - --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml
-    - --proxy-mode=iptables
     securityContext:
       privileged: true
     volumeMounts:

--- a/multi-node/generic/worker-install.sh
+++ b/multi-node/generic/worker-install.sh
@@ -10,7 +10,7 @@ export ETCD_ENDPOINTS=
 export CONTROLLER_ENDPOINT=
 
 # Specify the version (vX.Y.Z) of Kubernetes assets to deploy
-export K8S_VER=v1.3.0-beta.2_coreos.0
+export K8S_VER=v1.3.0_coreos.1
 
 # Hyperkube image repository to use.
 export HYPERKUBE_IMAGE_REPO=quay.io/coreos/hyperkube

--- a/multi-node/vagrant/conformance-test.sh
+++ b/multi-node/vagrant/conformance-test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+ssh_key="$(vagrant ssh-config c1 | awk '/IdentityFile/ {print $2}' | tr -d '"')"
+ssh_port="$(vagrant ssh-config c1 | awk '/Port [0-9]+/ {print $2}')"
+
+SSH_OPTS='-q -o stricthostkeychecking=no' ../../contrib/conformance-test.sh "127.0.0.1" "${ssh_port}" "${ssh_key}"

--- a/single-node/conformance-test.sh
+++ b/single-node/conformance-test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+ssh_key="$(vagrant ssh-config | awk '/IdentityFile/ {print $2}' | tr -d '"')"
+ssh_port="$(vagrant ssh-config | awk '/Port [0-9]+/ {print $2}')"
+
+export CHECK_NODE_COUNT=false
+SSH_OPTS='-q -o stricthostkeychecking=no' ../contrib/conformance-test.sh "127.0.0.1" "${ssh_port}" "${ssh_key}"

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -31,7 +31,7 @@ export K8S_SERVICE_IP=10.3.0.1
 export DNS_SERVICE_IP=10.3.0.10
 
 # Whether to use Calico for Kubernetes network policy.
-export USE_CALICO=true
+export USE_CALICO=false
 
 # -------------
 
@@ -110,7 +110,7 @@ EOF
     }
 
     local TEMPLATE=/etc/systemd/system/calico-node.service
-    [ -f $TEMPLATE ] || {
+    [ "$USE_CALICO" = "true" ] && [ ! -f $TEMPLATE ] && {
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -160,7 +160,6 @@ spec:
     - /hyperkube
     - proxy
     - --master=http://127.0.0.1:8080
-    - --proxy-mode=iptables
     securityContext:
       privileged: true
     volumeMounts:
@@ -203,7 +202,14 @@ spec:
     - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
     - --client-ca-file=/etc/kubernetes/ssl/ca.pem
     - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
-    - --runtime-config=extensions/v1beta1/deployments=true,extensions/v1beta1/daemonsets=true,extensions/v1beta1=true,extensions/v1beta1/thirdpartyresources=true
+    - --runtime-config=extensions/v1beta1/thirdpartyresources=true
+    livenessProbe:
+      httpGet:
+        host: 127.0.0.1
+        port: 8080
+        path: /healthz
+      initialDelaySeconds: 15
+      timeoutSeconds: 15
     ports:
     - containerPort: 443
       hostPort: 443
@@ -248,13 +254,16 @@ spec:
     - --master=http://127.0.0.1:8080
     - --service-account-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
     - --root-ca-file=/etc/kubernetes/ssl/ca.pem
+    resources:
+      requests:
+        cpu: 200m
     livenessProbe:
       httpGet:
         host: 127.0.0.1
         path: /healthz
         port: 10252
       initialDelaySeconds: 15
-      timeoutSeconds: 1
+      timeoutSeconds: 15
     volumeMounts:
     - mountPath: /etc/kubernetes/ssl
       name: ssl-certs-kubernetes
@@ -292,18 +301,21 @@ spec:
     - /hyperkube
     - scheduler
     - --master=http://127.0.0.1:8080
+    resources:
+      requests:
+        cpu: 100m
     livenessProbe:
       httpGet:
         host: 127.0.0.1
         path: /healthz
         port: 10251
       initialDelaySeconds: 15
-      timeoutSeconds: 1
+      timeoutSeconds: 15
 EOF
     }
 
-    local TEMPLATE=/srv/kubernetes/manifests/calico-policy-agent.yaml
-    [ -f $TEMPLATE ] || {
+    local TEMPLATE=/etc/kubernetes/manifests/calico-policy-agent.yaml
+    [ "$USE_CALICO" = "true" ] && [ ! -f $TEMPLATE ] && {
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -334,21 +346,6 @@ spec:
         - "--election-namespace=calico-system"
         - "--http=127.0.0.1:4040"
 
-EOF
-    }
-
-    local TEMPLATE=/srv/kubernetes/manifests/kube-system.json
-    [ -f $TEMPLATE ] || {
-        echo "TEMPLATE: $TEMPLATE"
-        mkdir -p $(dirname $TEMPLATE)
-        cat << EOF > $TEMPLATE
-{
-  "apiVersion": "v1",
-  "kind": "Namespace",
-  "metadata": {
-    "name": "kube-system"
-  }
-}
 EOF
     }
 
@@ -400,63 +397,33 @@ EOF
     "labels": {
       "k8s-app": "kube-dns",
       "kubernetes.io/cluster-service": "true",
-      "version": "v11"
+      "version": "v15"
     },
-    "name": "kube-dns-v11",
+    "name": "kube-dns-v15",
     "namespace": "kube-system"
   },
   "spec": {
     "replicas": 1,
     "selector": {
       "k8s-app": "kube-dns",
-      "version": "v11"
+      "version": "v15"
     },
     "template": {
       "metadata": {
         "labels": {
           "k8s-app": "kube-dns",
           "kubernetes.io/cluster-service": "true",
-          "version": "v11"
+          "version": "v15"
         }
       },
       "spec": {
         "containers": [
           {
-            "command": [
-              "/usr/local/bin/etcd",
-              "-data-dir",
-              "/var/etcd/data",
-              "-listen-client-urls",
-              "http://127.0.0.1:2379,http://127.0.0.1:4001",
-              "-advertise-client-urls",
-              "http://127.0.0.1:2379,http://127.0.0.1:4001",
-              "-initial-cluster-token",
-              "skydns-etcd"
-            ],
-            "image": "gcr.io/google_containers/etcd-amd64:2.2.1",
-            "name": "etcd",
-            "resources": {
-              "limits": {
-                "cpu": "100m",
-                "memory": "500Mi"
-              },
-              "requests": {
-                "cpu": "100m",
-                "memory": "50Mi"
-              }
-            },
-            "volumeMounts": [
-              {
-                "mountPath": "/var/etcd/data",
-                "name": "etcd-storage"
-              }
-            ]
-          },
-          {
             "args": [
-              "--domain=cluster.local"
+              "--domain=cluster.local.",
+              "--dns-port=10053"
             ],
-            "image": "gcr.io/google_containers/kube2sky:1.14",
+            "image": "gcr.io/google_containers/kubedns-amd64:1.3",
             "livenessProbe": {
               "failureThreshold": 5,
               "httpGet": {
@@ -468,7 +435,19 @@ EOF
               "successThreshold": 1,
               "timeoutSeconds": 5
             },
-            "name": "kube2sky",
+            "name": "kubedns",
+            "ports": [
+              {
+                "containerPort": 10053,
+                "name": "dns-local",
+                "protocol": "UDP"
+              },
+              {
+                "containerPort": 10053,
+                "name": "dns-tcp-local",
+                "protocol": "TCP"
+              }
+            ],
             "readinessProbe": {
               "httpGet": {
                 "path": "/readiness",
@@ -491,13 +470,12 @@ EOF
           },
           {
             "args": [
-              "-machines=http://127.0.0.1:4001",
-              "-addr=0.0.0.0:53",
-              "-ns-rotate=false",
-              "-domain=cluster.local."
+              "--cache-size=1000",
+              "--no-resolv",
+              "--server=127.0.0.1#10053"
             ],
-            "image": "gcr.io/google_containers/skydns:2015-10-13-8c72f8c",
-            "name": "skydns",
+            "image": "gcr.io/google_containers/kube-dnsmasq-amd64:1.3",
+            "name": "dnsmasq",
             "ports": [
               {
                 "containerPort": 53,
@@ -509,24 +487,15 @@ EOF
                 "name": "dns-tcp",
                 "protocol": "TCP"
               }
-            ],
-            "resources": {
-              "limits": {
-                "cpu": "100m",
-                "memory": "200Mi"
-              },
-              "requests": {
-                "cpu": "100m",
-                "memory": "50Mi"
-              }
-            }
+            ]
           },
           {
             "args": [
               "-cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1 >/dev/null",
-              "-port=8080"
+              "-port=8080",
+              "-quiet"
             ],
-            "image": "gcr.io/google_containers/exechealthz:1.0",
+            "image": "gcr.io/google_containers/exechealthz-amd64:1.0",
             "name": "healthz",
             "ports": [
               {
@@ -546,13 +515,7 @@ EOF
             }
           }
         ],
-        "dnsPolicy": "Default",
-        "volumes": [
-          {
-            "emptyDir": {},
-            "name": "etcd-storage"
-          }
-        ]
+        "dnsPolicy": "Default"
       }
     }
   }
@@ -569,26 +532,26 @@ EOF
   "apiVersion": "v1",
   "kind": "Service",
   "metadata": {
-    "name": "kube-dns",
-    "namespace": "kube-system",
     "labels": {
       "k8s-app": "kube-dns",
-      "kubernetes.io/name": "KubeDNS",
-      "kubernetes.io/cluster-service": "true"
-    }
+      "kubernetes.io/cluster-service": "true",
+      "kubernetes.io/name": "KubeDNS"
+    },
+    "name": "kube-dns",
+    "namespace": "kube-system"
   },
   "spec": {
     "clusterIP": "$DNS_SERVICE_IP",
     "ports": [
       {
-        "protocol": "UDP",
         "name": "dns",
-        "port": 53
+        "port": 53,
+        "protocol": "UDP"
       },
       {
-        "protocol": "TCP",
         "name": "dns-tcp",
-        "port": 53
+        "port": 53,
+        "protocol": "TCP"
       }
     ],
     "selector": {
@@ -599,7 +562,7 @@ EOF
 EOF
     }
 
-    local TEMPLATE=/srv/kubernetes/manifests/heapster-dc.json
+    local TEMPLATE=/srv/kubernetes/manifests/heapster-de.json
     [ -f $TEMPLATE ] || {
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
@@ -611,9 +574,9 @@ EOF
     "labels": {
       "k8s-app": "heapster",
       "kubernetes.io/cluster-service": "true",
-      "version": "v1.0.2"
+      "version": "v1.1.0"
     },
-    "name": "heapster-v1.0.2",
+    "name": "heapster-v1.1.0",
     "namespace": "kube-system"
   },
   "spec": {
@@ -621,14 +584,14 @@ EOF
     "selector": {
       "matchLabels": {
         "k8s-app": "heapster",
-        "version": "v1.0.2"
+        "version": "v1.1.0"
       }
     },
     "template": {
       "metadata": {
         "labels": {
           "k8s-app": "heapster",
-          "version": "v1.0.2"
+          "version": "v1.1.0"
         }
       },
       "spec": {
@@ -636,19 +599,18 @@ EOF
           {
             "command": [
               "/heapster",
-              "--source=kubernetes.summary_api:''",
-              "--metric_resolution=60s"
+              "--source=kubernetes.summary_api:''"
             ],
-            "image": "gcr.io/google_containers/heapster:v1.0.2",
+            "image": "gcr.io/google_containers/heapster:v1.1.0",
             "name": "heapster",
             "resources": {
               "limits": {
                 "cpu": "100m",
-                "memory": "250Mi"
+                "memory": "200Mi"
               },
               "requests": {
                 "cpu": "100m",
-                "memory": "250Mi"
+                "memory": "200Mi"
               }
             }
           },
@@ -656,13 +618,14 @@ EOF
             "command": [
               "/pod_nanny",
               "--cpu=100m",
-              "--extra-cpu=0m",
-              "--memory=250Mi",
+              "--extra-cpu=0.5m",
+              "--memory=200Mi",
               "--extra-memory=4Mi",
               "--threshold=5",
-              "--deployment=heapster-v1.0.2",
+              "--deployment=heapster-v1.1.0",
               "--container=heapster",
-              "--poll-period=300000"
+              "--poll-period=300000",
+              "--estimator=exponential"
             ],
             "env": [
               {
@@ -682,7 +645,7 @@ EOF
                 }
               }
             ],
-            "image": "gcr.io/google_containers/addon-resizer:1.0",
+            "image": "gcr.io/google_containers/addon-resizer:1.3",
             "name": "heapster-nanny",
             "resources": {
               "limits": {
@@ -709,15 +672,113 @@ EOF
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
 {
-  "kind": "Service",
   "apiVersion": "v1",
+  "kind": "Service",
   "metadata": {
-    "name": "heapster",
-    "namespace": "kube-system",
     "labels": {
       "kubernetes.io/cluster-service": "true",
       "kubernetes.io/name": "Heapster"
+    },
+    "name": "heapster",
+    "namespace": "kube-system"
+  },
+  "spec": {
+    "ports": [
+      {
+        "port": 80,
+        "targetPort": 8082
+      }
+    ],
+    "selector": {
+      "k8s-app": "heapster"
     }
+  }
+}
+EOF
+    }
+
+    local TEMPLATE=/srv/kubernetes/manifests/kube-dashboard-rc.json
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+{
+  "apiVersion": "v1",
+  "kind": "ReplicationController",
+  "metadata": {
+    "labels": {
+      "k8s-app": "kubernetes-dashboard",
+      "kubernetes.io/cluster-service": "true",
+      "version": "v1.1.0-beta3"
+    },
+    "name": "kubernetes-dashboard-v1.1.0-beta3",
+    "namespace": "kube-system"
+  },
+  "spec": {
+    "replicas": 1,
+    "selector": {
+      "k8s-app": "kubernetes-dashboard"
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "k8s-app": "kubernetes-dashboard",
+          "kubernetes.io/cluster-service": "true",
+          "version": "v1.1.0-beta3"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "image": "gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0-beta3",
+            "livenessProbe": {
+              "httpGet": {
+                "path": "/",
+                "port": 9090
+              },
+              "initialDelaySeconds": 30,
+              "timeoutSeconds": 30
+            },
+            "name": "kubernetes-dashboard",
+            "ports": [
+              {
+                "containerPort": 9090
+              }
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "100m",
+                "memory": "50Mi"
+              },
+              "requests": {
+                "cpu": "100m",
+                "memory": "50Mi"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+EOF
+    }
+
+    local TEMPLATE=/srv/kubernetes/manifests/kube-dashboard-svc.json
+    [ -f $TEMPLATE ] || {
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "labels": {
+      "kubernetes.io/cluster-service": "true",
+      "kubernetes.io/name": "Heapster"
+    },
+    "name": "heapster",
+    "namespace": "kube-system"
   },
   "spec": {
     "ports": [
@@ -797,13 +858,11 @@ function start_addons {
         sleep 5
     done
     echo
-    echo "K8S: kube-system namespace"
-    curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-system.json)" "http://127.0.0.1:8080/api/v1/namespaces" > /dev/null
     echo "K8S: DNS addon"
     curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
     curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
     echo "K8S: Heapster addon"
-    curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-dc.json)" "http://127.0.0.1:8080/apis/extensions/v1beta1/namespaces/kube-system/deployments" > /dev/null
+    curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-de.json)" "http://127.0.0.1:8080/apis/extensions/v1beta1/namespaces/kube-system/deployments" > /dev/null
     curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
 }
 
@@ -817,7 +876,6 @@ function enable_calico_policy {
     echo "K8S: Calico Policy"
     curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/calico-system.json)" "http://127.0.0.1:8080/api/v1/namespaces/" > /dev/null
     curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/network-policy.json)" "http://127.0.0.1:8080/apis/extensions/v1beta1/namespaces/default/thirdpartyresources" >/dev/null
-    cp /srv/kubernetes/manifests/calico-policy-agent.yaml /etc/kubernetes/manifests
 }
 
 init_config

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -5,7 +5,7 @@ set -e
 export ETCD_ENDPOINTS="http://127.0.0.1:2379"
 
 # Specify the version (vX.Y.Z) of Kubernetes assets to deploy
-export K8S_VER=v1.2.4_coreos.cni.1
+export K8S_VER=v1.3.0-beta.2_coreos.0
 
 # Hyperkube image repository to use.
 export HYPERKUBE_IMAGE_REPO=quay.io/coreos/hyperkube
@@ -30,8 +30,7 @@ export K8S_SERVICE_IP=10.3.0.1
 # This same IP must be configured on all worker nodes to enable DNS service discovery.
 export DNS_SERVICE_IP=10.3.0.10
 
-# Whether to use Calico for Kubernetes network policy. When using Calico,
-# K8S_VER (above) must be changed to an image tagged with CNI (e.g. v1.2.4_coreos.cni.1).
+# Whether to use Calico for Kubernetes network policy.
 export USE_CALICO=true
 
 # -------------

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -709,9 +709,9 @@ EOF
     "labels": {
       "k8s-app": "kubernetes-dashboard",
       "kubernetes.io/cluster-service": "true",
-      "version": "v1.1.0-beta3"
+      "version": "v1.1.0"
     },
-    "name": "kubernetes-dashboard-v1.1.0-beta3",
+    "name": "kubernetes-dashboard-v1.1.0",
     "namespace": "kube-system"
   },
   "spec": {
@@ -724,13 +724,13 @@ EOF
         "labels": {
           "k8s-app": "kubernetes-dashboard",
           "kubernetes.io/cluster-service": "true",
-          "version": "v1.1.0-beta3"
+          "version": "v1.1.0"
         }
       },
       "spec": {
         "containers": [
           {
-            "image": "gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0-beta3",
+            "image": "gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0",
             "livenessProbe": {
               "httpGet": {
                 "path": "/",

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -864,6 +864,9 @@ function start_addons {
     echo "K8S: Heapster addon"
     curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-de.json)" "http://127.0.0.1:8080/apis/extensions/v1beta1/namespaces/kube-system/deployments" > /dev/null
     curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
+    echo "K8S: Dashboard addon"
+    curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dashboard-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
+    curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dashboard-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
 }
 
 function enable_calico_policy {

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -81,7 +81,7 @@ function init_flannel {
 
 function init_templates {
     local TEMPLATE=/etc/systemd/system/kubelet.service
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -107,10 +107,10 @@ RestartSec=10
 [Install]
 WantedBy=multi-user.target
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/systemd/system/calico-node.service
-    [ "$USE_CALICO" = "true" ] && [ ! -f $TEMPLATE ] && {
+    if [ "${USE_CALICO}" = "true" ] && [ ! -f "${TEMPLATE}" ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -139,10 +139,10 @@ TimeoutStartSec=0
 [Install]
 WantedBy=multi-user.target
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/kubernetes/manifests/kube-proxy.yaml
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -171,10 +171,10 @@ spec:
       path: /usr/share/ca-certificates
     name: ssl-certs-host
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/kubernetes/manifests/kube-apiserver.yaml
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -232,10 +232,10 @@ spec:
       path: /usr/share/ca-certificates
     name: ssl-certs-host
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/kubernetes/manifests/kube-controller-manager.yaml
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -280,10 +280,10 @@ spec:
       path: /usr/share/ca-certificates
     name: ssl-certs-host
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/kubernetes/manifests/kube-scheduler.yaml
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -312,10 +312,10 @@ spec:
       initialDelaySeconds: 15
       timeoutSeconds: 15
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/kubernetes/manifests/calico-policy-agent.yaml
-    [ "$USE_CALICO" = "true" ] && [ ! -f $TEMPLATE ] && {
+    if [ "${USE_CALICO}" = "true" ] && [ ! -f "${TEMPLATE}" ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -347,10 +347,10 @@ spec:
         - "--http=127.0.0.1:4040"
 
 EOF
-    }
+    fi
 
     local TEMPLATE=/srv/kubernetes/manifests/calico-system.json
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -362,10 +362,10 @@ EOF
   }
 }
 EOF
-    }
+    fi
 
     local TEMPLATE=/srv/kubernetes/manifests/network-policy.json
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -383,10 +383,10 @@ EOF
   ]
 }
 EOF
-    }
+    fi
 
     local TEMPLATE=/srv/kubernetes/manifests/kube-dns-rc.json
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -521,10 +521,10 @@ EOF
   }
 }
 EOF
-    }
+    fi
 
     local TEMPLATE=/srv/kubernetes/manifests/kube-dns-svc.json
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -560,10 +560,10 @@ EOF
   }
 }
 EOF
-    }
+    fi
 
     local TEMPLATE=/srv/kubernetes/manifests/heapster-de.json
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -664,10 +664,10 @@ EOF
   }
 }
 EOF
-    }
+    fi
 
     local TEMPLATE=/srv/kubernetes/manifests/heapster-svc.json
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -695,10 +695,10 @@ EOF
   }
 }
 EOF
-    }
+    fi
 
     local TEMPLATE=/srv/kubernetes/manifests/kube-dashboard-rc.json
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -762,10 +762,10 @@ EOF
   }
 }
 EOF
-    }
+    fi
 
     local TEMPLATE=/srv/kubernetes/manifests/kube-dashboard-svc.json
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -793,30 +793,30 @@ EOF
     }
 }
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/flannel/options.env
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
 FLANNELD_IFACE=$ADVERTISE_IP
 FLANNELD_ETCD_ENDPOINTS=$ETCD_ENDPOINTS
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/systemd/system/flanneld.service.d/40-ExecStartPre-symlink.conf.conf
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
 [Service]
 ExecStartPre=/usr/bin/ln -sf /etc/flannel/options.env /run/flannel/options.env
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/systemd/system/docker.service.d/40-flannel.conf
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -824,10 +824,10 @@ EOF
 Requires=flanneld.service
 After=flanneld.service
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/kubernetes/cni/net.d/10-calico.conf
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -847,7 +847,7 @@ EOF
     }
 }
 EOF
-    }
+    fi
 
 }
 

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -770,27 +770,27 @@ EOF
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
 {
-  "apiVersion": "v1",
-  "kind": "Service",
-  "metadata": {
-    "labels": {
-      "kubernetes.io/cluster-service": "true",
-      "kubernetes.io/name": "Heapster"
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": {
+        "labels": {
+            "k8s-app": "kubernetes-dashboard",
+            "kubernetes.io/cluster-service": "true"
+        },
+        "name": "kubernetes-dashboard",
+        "namespace": "kube-system"
     },
-    "name": "heapster",
-    "namespace": "kube-system"
-  },
-  "spec": {
-    "ports": [
-      {
-        "port": 80,
-        "targetPort": 8082
-      }
-    ],
-    "selector": {
-      "k8s-app": "heapster"
+    "spec": {
+        "ports": [
+            {
+                "port": 80,
+                "targetPort": 9090
+            }
+        ],
+        "selector": {
+            "k8s-app": "kubernetes-dashboard"
+        }
     }
-  }
 }
 EOF
     }

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -202,7 +202,7 @@ spec:
     - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
     - --client-ca-file=/etc/kubernetes/ssl/ca.pem
     - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
-    - --runtime-config=extensions/v1beta1/thirdpartyresources=true
+    - --runtime-config=extensions/v1beta1/networkpolicies=true
     livenessProbe:
       httpGet:
         host: 127.0.0.1
@@ -314,7 +314,7 @@ spec:
 EOF
     fi
 
-    local TEMPLATE=/etc/kubernetes/manifests/calico-policy-agent.yaml
+    local TEMPLATE=/etc/kubernetes/manifests/calico-policy-controller.yaml
     if [ "${USE_CALICO}" = "true" ] && [ ! -f "${TEMPLATE}" ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
@@ -322,14 +322,14 @@ EOF
 apiVersion: v1
 kind: Pod
 metadata:
-  name: calico-policy-agent
+  name: calico-policy-controller
   namespace: calico-system
 spec:
   hostNetwork: true
   containers:
-    # The Calico policy agent.
-    - name: k8s-policy-agent
-      image: calico/k8s-policy-agent:v0.1.4
+    # The Calico policy controller.
+    - name: kube-policy-controller
+      image: calico/kube-policy-controller:v0.2.0
       env:
         - name: ETCD_ENDPOINTS
           value: "${ETCD_ENDPOINTS}"
@@ -337,7 +337,7 @@ spec:
           value: "http://127.0.0.1:8080"
         - name: LEADER_ELECTION
           value: "true"
-    # Leader election container used by the policy agent.
+    # Leader election container used by the policy controller.
     - name: leader-elector
       image: quay.io/calico/leader-elector:v0.1.0
       imagePullPolicy: IfNotPresent
@@ -360,27 +360,6 @@ EOF
   "metadata": {
     "name": "calico-system"
   }
-}
-EOF
-    fi
-
-    local TEMPLATE=/srv/kubernetes/manifests/network-policy.json
-    if [ ! -f $TEMPLATE ]; then
-        echo "TEMPLATE: $TEMPLATE"
-        mkdir -p $(dirname $TEMPLATE)
-        cat << EOF > $TEMPLATE
-{
-  "kind": "ThirdPartyResource",
-  "apiVersion": "extensions/v1beta1",
-  "metadata": {
-    "name": "network-policy.net.alpha.kubernetes.io"
-  },
-  "description": "Specification for a network isolation policy",
-  "versions": [
-    {
-      "name": "v1alpha1"
-    }
-  ]
 }
 EOF
     fi
@@ -878,7 +857,6 @@ function enable_calico_policy {
     echo
     echo "K8S: Calico Policy"
     curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/calico-system.json)" "http://127.0.0.1:8080/api/v1/namespaces/" > /dev/null
-    curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/network-policy.json)" "http://127.0.0.1:8080/apis/extensions/v1beta1/namespaces/default/thirdpartyresources" >/dev/null
 }
 
 init_config

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -5,7 +5,7 @@ set -e
 export ETCD_ENDPOINTS="http://127.0.0.1:2379"
 
 # Specify the version (vX.Y.Z) of Kubernetes assets to deploy
-export K8S_VER=v1.3.0-beta.2_coreos.0
+export K8S_VER=v1.3.0_coreos.1
 
 # Hyperkube image repository to use.
 export HYPERKUBE_IMAGE_REPO=quay.io/coreos/hyperkube


### PR DESCRIPTION
This PR makes changes to enable the v1beta1 NetworkPolicy API release as part of Kubernetes v1.3.0, as well as the corresponding Calico installation changes.

This PR:
  - No longer enables and creates `ThirdPartyResources`
  - Uses a new version of the Calico policy controller.
  - Enabled the v1beta1 NetworkPolicy in the API.


Need to test:
- [x] Vagrant single-node
- [x] Vagrant multi-node
- [ ] AWS multi-node