### PR TITLE
Improved kubernetes client install instructions for Mac OS

### DIFF
--- a/Documentation/kubernetes-on-vagrant.md
+++ b/Documentation/kubernetes-on-vagrant.md
@@ -21,17 +21,19 @@ The linux `kubectl` binary can be fetched with a command like:
 $ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.3.0-beta.2/bin/linux/amd64/kubectl
 ```
 
-On an OS X workstation, replace `linux` in the URL above with `darwin`:
-
-```sh
-$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.3.0-beta.2/bin/darwin/amd64/kubectl
-```
-
 After downloading the binary, ensure it is executable and move it into your PATH:
 
 ```sh
 $ chmod +x kubectl
 $ mv kubectl /usr/local/bin/kubectl
+```
+
+On an OS X workstation, use [Brew][brew-website] to install the kubernetes-cli package:
+
+[brew-website]: http://brew.sh
+
+```sh
+$ brew install kubernetes-cli
 ```
 
 ## Clone the Repository


### PR DESCRIPTION
I noticed an easier way to install the kubernetes cli commands for MacOS and updated the documentation page for running it with Vagrant.