### PR TITLE
docs: update calico hyperkube instructions

### DIFF
--- a/Documentation/kubernetes-on-aws-render.md
+++ b/Documentation/kubernetes-on-aws-render.md
@@ -169,9 +169,7 @@ Edit the `cluster.yaml` file:
 
 ```yaml
 useCalico: true
-kubernetesVersion: v1.2.4_coreos.cni.1
 ```
-The hyperkube image version needs to contain the CNI binaries (these are tagged with `_cni`)
 
 ### Route53 Host Record
 


### PR DESCRIPTION
Missed a few things in the AWS guide when we updated the Calico process.