### PR TITLE
docs: fix minor formatting error

### DIFF
--- a/Documentation/kubernetes-on-aws-launch.md
+++ b/Documentation/kubernetes-on-aws-launch.md
@@ -30,7 +30,9 @@ $ kubectl --kubeconfig=kubeconfig get nodes
 
 If the container images are still downloading and/or the API server isn't accessible yet, the kubectl command above may show output similar to:
 
-`The connection to the server <externalDNSName>:443 was refused - did you specify the right host or port?`
+```
+The connection to the server <externalDNSName>:443 was refused - did you specify the right host or port?
+```
 
 Wait a few more minutes for everything to complete.
 


### PR DESCRIPTION
Text is expanding out of the page due to single backtick instead of triple.

![image](https://cloud.githubusercontent.com/assets/755540/17314916/9bdbaa40-581c-11e6-8522-4343e1ce481f.png)
