### PR TITLE
multi-node/vagrant: use binary mode for temp files to avoid EOL conve…

### DIFF
--- a/multi-node/vagrant/Vagrantfile
+++ b/multi-node/vagrant/Vagrantfile
@@ -107,7 +107,7 @@ Vagrant.configure("2") do |config|
       data = YAML.load(IO.readlines(ETCD_CLOUD_CONFIG_PATH)[1..-1].join)
       data['coreos']['etcd2']['initial-cluster'] = initial_etcd_cluster
       data['coreos']['etcd2']['name'] = vm_name
-      etcd_config_file = Tempfile.new('etcd_config')
+      etcd_config_file = Tempfile.new('etcd_config', :binmode => true)
       etcd_config_file.write("#cloud-config\n#{data.to_yaml}")
       etcd_config_file.close
 
@@ -134,7 +134,7 @@ Vagrant.configure("2") do |config|
   (1..$controller_count).each do |i|
     config.vm.define vm_name = "c%d" % i do |controller|
 
-      env_file = Tempfile.new('env_file')
+      env_file = Tempfile.new('env_file', :binmode => true)
       env_file.write("ETCD_ENDPOINTS=#{etcd_endpoints}\n")
       env_file.close
 
@@ -168,7 +168,7 @@ Vagrant.configure("2") do |config|
     config.vm.define vm_name = "w%d" % i do |worker|
       worker.vm.hostname = vm_name
 
-      env_file = Tempfile.new('env_file')
+      env_file = Tempfile.new('env_file', :binmode => true)
       env_file.write("ETCD_ENDPOINTS=#{etcd_endpoints}\n")
       env_file.write("CONTROLLER_ENDPOINT=https://#{controllerIPs[0]}\n") #TODO(aaron): LB or DNS across control nodes
       env_file.close


### PR DESCRIPTION
…rsion on Windows

Files created from Ruby on Windows undergo an implicit EOL <-> CRLF
conversion. This causes the ENV variables set from the `options.env`
file copied to the VMs to include trailing `<CR>`s and results in
initialization failing.

Fixes #610