### PR TITLE
Propagate aws kms decrypt's exit code in decrypt-tls-assets

### DIFF
--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -234,7 +234,8 @@ write_files:
 
       for encKey in $(find /etc/kubernetes/ssl/*.pem.enc);do
         tmpPath="/tmp/$(basename $encKey).tmp"
-        docker run --rm -v /etc/kubernetes/ssl:/etc/kubernetes/ssl --rm quay.io/coreos/awscli aws --region {{.Region}} kms decrypt --ciphertext-blob fileb://$encKey --output text --query Plaintext | base64 --decode > $tmpPath
+        docker run --rm -v /etc/kubernetes/ssl:/etc/kubernetes/ssl --rm quay.io/coreos/awscli aws --region {{.Region}} kms decrypt --ciphertext-blob fileb://$encKey --output text --query Plaintext > $tmpPath.b64
+        base64 --decode < $tmpPath.b64 > $tmpPath
         mv  $tmpPath /etc/kubernetes/ssl/$(basename $encKey .enc)
       done
 

--- a/multi-node/aws/pkg/config/templates/cloud-config-worker
+++ b/multi-node/aws/pkg/config/templates/cloud-config-worker
@@ -166,7 +166,8 @@ write_files:
 
       for encKey in $(find /etc/kubernetes/ssl/*.pem.enc);do
         tmpPath="/tmp/$(basename $encKey).tmp"
-        docker run --rm -v /etc/kubernetes/ssl:/etc/kubernetes/ssl --rm quay.io/coreos/awscli aws --region {{.Region}} kms decrypt --ciphertext-blob fileb://$encKey --output text --query Plaintext | base64 --decode > $tmpPath
+        docker run --rm -v /etc/kubernetes/ssl:/etc/kubernetes/ssl --rm quay.io/coreos/awscli aws --region {{.Region}} kms decrypt --ciphertext-blob fileb://$encKey --output text --query Plaintext > $tmpPath.b64
+        base64 --decode < $tmpPath.b64 > $tmpPath
         mv  $tmpPath /etc/kubernetes/ssl/$(basename $encKey .enc)
       done
 


### PR DESCRIPTION
decrypt-tls-assets runs `aws kms` in a docker container, and then
pipes the output to `base64`. This does not return a non-zero exit
code when decryption fails, and so the unit is not retried.

This commit adds an explicit test, forcing a non-zero exit code,
causing bash -e to barf.
