### PR TITLE
docs: mention optional config for all platforms (rdb, iscsi, etc)

### DIFF
--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -99,7 +99,13 @@ Note that the kubelet running on a master node may log repeated attempts to post
 * Replace `${DNS_SERVICE_IP}`
 * Replace `${K8S_VER}` This will map to: `quay.io/coreos/hyperkube:${K8S_VER}` release, e.g. `v1.3.4_coreos.0`.
 * Replace `${NETWORK_PLUGIN}` with `cni` if using Calico. Otherwise just leave it blank.
-* Decide if you will use [additional features][rkt-opts-examples] such as cluster logging, iSCSI volumes, or addressing workers by hostname in addition to IPs.
+* Decide if you will use [additional features][rkt-opts-examples] such as:
+  - [mounting ephemeral disks][mount-disks]
+  - [allow pods to mount RDB][rdb] or [iSCSI volumes][iscsi]
+  - [allowing access to insecure container registries][insecure-registry]
+  - [use host DNS configuration instead of a public DNS server][host-dns]
+  - [enable the cluster logging add-on][cluster-logging]
+  - [changing your CoreOS auto-update settings][update]
 
 **/etc/systemd/system/kubelet.service**
 
@@ -123,8 +129,6 @@ RestartSec=10
 [Install]
 WantedBy=multi-user.target
 ```
-
-[rkt-opts-examples]: kubelet-wrapper.md#customizing-rkt-options
 
 ### Set Up the kube-apiserver Pod
 
@@ -541,3 +545,9 @@ kube-proxy-$node
   <p><strong>Did the containers start downloading?</strong> As long as the kubelet knows about them, everything is working properly.</p>
   <a href="deploy-workers.md" class="btn btn-primary btn-icon-right" data-category="Docs Next" data-event="Kubernetes: Workers">Yes, ready to deploy the Workers</a>
 </div>
+
+[rkt-opts-examples]: kubelet-wrapper.md#customizing-rkt-options
+[rdb]: kubelet-wrapper.md#allow-pods-to-use-rbd-volumes
+[iscsi]: kubelet-wrapper.md#allow-pods-to-use-iscsi-mounts
+[host-dns]: kubelet-wrapper.md#use-the-hosts-dns-configuration
+[cluster-logging]: kubelet-wrapper.md#use-the-cluster-logging-add-on

--- a/Documentation/deploy-workers.md
+++ b/Documentation/deploy-workers.md
@@ -82,6 +82,13 @@ Create `/etc/systemd/system/kubelet.service` and substitute the following variab
 * Replace `${DNS_SERVICE_IP}`
 * Replace `${K8S_VER}` This will map to: `quay.io/coreos/hyperkube:${K8S_VER}` release, e.g. `v1.3.4_coreos.0`.
 * Replace `${NETWORK_PLUGIN}` with `cni` if using Calico. Otherwise just leave it blank.
+* Decide if you will use [additional features][rkt-opts-examples] such as:
+  - [mounting ephemeral disks][mount-disks]
+  - [allow pods to mount RDB][rdb] or [iSCSI volumes][iscsi]
+  - [allowing access to insecure container registries][insecure-registry]
+  - [use host DNS configuration instead of a public DNS server][host-dns]
+  - [enable the cluster logging add-on][cluster-logging]
+  - [changing your CoreOS auto-update settings][update]
 
 **/etc/systemd/system/kubelet.service**
 
@@ -299,3 +306,9 @@ To check the health of the calico-node systemd unit that we created, run `system
   <p><strong>Is the kubelet running?</strong></p>
   <a href="configure-kubectl.md" class="btn btn-primary btn-icon-right"  data-category="Docs Next" data-event="Kubernetes: kubectl">Yes, ready to configure `kubectl`</a>
 </div>
+
+[rkt-opts-examples]: kubelet-wrapper.md#customizing-rkt-options
+[rdb]: kubelet-wrapper.md#allow-pods-to-use-rbd-volumes
+[iscsi]: kubelet-wrapper.md#allow-pods-to-use-iscsi-mounts
+[host-dns]: kubelet-wrapper.md#use-the-hosts-dns-configuration
+[cluster-logging]: kubelet-wrapper.md#use-the-cluster-logging-add-on

--- a/Documentation/kubernetes-on-aws-render.md
+++ b/Documentation/kubernetes-on-aws-render.md
@@ -138,7 +138,10 @@ You can now customize your cluster by editing asset files. Any changes to these 
   Some common customizations are:
 
   - [mounting ephemeral disks][mount-disks]
+  - [allow pods to mount RDB][rdb] or [iSCSI volumes][iscsi]
   - [allowing access to insecure container registries][insecure-registry]
+  - [use host DNS configuration instead of a public DNS server][host-dns]
+  - [enable the cluster logging add-on][cluster-logging]
   - [changing your CoreOS auto-update settings][update]
   <br/><br/>
 
@@ -265,3 +268,7 @@ If your files are valid, you are ready to [launch your cluster][aws-step-3].
 [k8s-openssl]: openssl.md
 [tls-note]: #certificates-and-keys
 [route53]: https://aws.amazon.com/route53/
+[rdb]: kubelet-wrapper.md#allow-pods-to-use-rbd-volumes
+[iscsi]: kubelet-wrapper.md#allow-pods-to-use-iscsi-mounts
+[host-dns]: kubelet-wrapper.md#use-the-hosts-dns-configuration
+[cluster-logging]: kubelet-wrapper.md#use-the-cluster-logging-add-on

--- a/Documentation/kubernetes-on-generic-platforms.md
+++ b/Documentation/kubernetes-on-generic-platforms.md
@@ -38,6 +38,17 @@ In addition to identifying itself with `ADVERTISE_IP`, each worker must be confi
 
 To view the complete list of environment variables, view the top of the `worker-install.sh` script.
 
+## Optional Configuration
+
+You may modify the kubelet's unit file to use [additional features][rkt-opts-examples] such as:
+
+- [mounting ephemeral disks][mount-disks]
+- [allow pods to mount RDB][rdb] or [iSCSI volumes][iscsi]
+- [allowing access to insecure container registries][insecure-registry]
+- [use host DNS configuration instead of a public DNS server][host-dns]
+- [enable the cluster logging add-on][cluster-logging]
+- [changing your CoreOS auto-update settings][update]
+
 ## Boot Controllers
 
 Follow these instructions for each controller you wish to boot:
@@ -79,3 +90,8 @@ $ journalctl -u kubelet -f
 
 [openssl]: openssl.md
 [networking]: kubernetes-networking.md
+[rkt-opts-examples]: kubelet-wrapper.md#customizing-rkt-options
+[rdb]: kubelet-wrapper.md#allow-pods-to-use-rbd-volumes
+[iscsi]: kubelet-wrapper.md#allow-pods-to-use-iscsi-mounts
+[host-dns]: kubelet-wrapper.md#use-the-hosts-dns-configuration
+[cluster-logging]: kubelet-wrapper.md#use-the-cluster-logging-add-on


### PR DESCRIPTION
Directly linking to these and listing them out will make more folks get the install they are looking for. This also uses terms that folks are more apt to be looking for (`rbd`, `iscsi`).

Should land near https://github.com/coreos/coreos-kubernetes/pull/638