### PR TITLE
all: make docker cni configuration flexible

### DIFF
--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -24,8 +24,7 @@ coreos:
             Requires=flanneld.service
             After=flanneld.service
             [Service]
-            ExecStart=
-            ExecStart=/usr/lib/coreos/dockerd daemon --host=fd:// $DOCKER_OPTS $DOCKER_CGROUPS $DOCKER_OPT_MTU
+            EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
 
     - name: flanneld.service
       drop-ins:
@@ -199,6 +198,11 @@ write_files:
           -d @"/srv/kubernetes/manifests/$manifest" \
           "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services"
       done
+
+  - path: /etc/kubernetes/cni/docker_opts_cni.env
+    content: |
+      DOCKER_OPT_BIP=""
+      DOCKER_OPT_IPMASQ=""
 
   - path: /opt/bin/host-rkt
     permissions: 0755

--- a/multi-node/aws/pkg/config/templates/cloud-config-worker
+++ b/multi-node/aws/pkg/config/templates/cloud-config-worker
@@ -14,8 +14,7 @@ coreos:
             Requires=flanneld.service
             After=flanneld.service
             [Service]
-            ExecStart=
-            ExecStart=/usr/lib/coreos/dockerd daemon --host=fd:// $DOCKER_OPTS $DOCKER_CGROUPS $DOCKER_OPT_MTU
+            EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
 
     - name: kubelet.service
       enable: true
@@ -131,6 +130,11 @@ coreos:
         RequiredBy=kubelet.service
 
 write_files:
+  - path: /etc/kubernetes/cni/docker_opts_cni.env
+    content: |
+      DOCKER_OPT_BIP=""
+      DOCKER_OPT_IPMASQ=""
+
   - path: /opt/bin/host-rkt
     permissions: 0755
     owner: root:root

--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -884,8 +884,17 @@ EOF
 Requires=flanneld.service
 After=flanneld.service
 [Service]
-ExecStart=
-ExecStart=/usr/lib/coreos/dockerd daemon --host=fd:// \$DOCKER_OPTS \$DOCKER_CGROUPS \$DOCKER_OPT_MTU
+EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
+EOF
+    fi
+
+    local TEMPLATE=/etc/kubernetes/cni/docker_opts_cni.env
+    if [ ! -f $TEMPLATE ]; then
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+DOCKER_OPT_BIP=""
+DOCKER_OPT_IPMASQ=""
 EOF
     fi
 

--- a/multi-node/generic/worker-install.sh
+++ b/multi-node/generic/worker-install.sh
@@ -287,8 +287,17 @@ EOF
 Requires=flanneld.service
 After=flanneld.service
 [Service]
-ExecStart=
-ExecStart=/usr/lib/coreos/dockerd daemon --host=fd:// \$DOCKER_OPTS \$DOCKER_CGROUPS \$DOCKER_OPT_MTU
+EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
+EOF
+    fi
+
+    local TEMPLATE=/etc/kubernetes/cni/docker_opts_cni.env
+    if [ ! -f $TEMPLATE ]; then
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+DOCKER_OPT_BIP=""
+DOCKER_OPT_IPMASQ=""
 EOF
     fi
 

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -875,8 +875,17 @@ EOF
 Requires=flanneld.service
 After=flanneld.service
 [Service]
-ExecStart=
-ExecStart=/usr/lib/coreos/dockerd daemon --host=fd:// \$DOCKER_OPTS \$DOCKER_CGROUPS \$DOCKER_OPT_MTU
+EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
+EOF
+    fi
+
+    local TEMPLATE=/etc/kubernetes/cni/docker_opts_cni.env
+    if [ ! -f $TEMPLATE ]; then
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+DOCKER_OPT_BIP=""
+DOCKER_OPT_IPMASQ=""
 EOF
     fi
 


### PR DESCRIPTION
Overriding the 'ExecStart' to remove some environment variables will
break in CoreOS 1151.0.0 because Docker v1.12 will balk if given a
'daemon' argument to dockerd. We need to override the environment
variables set from an EnvironmentFile directive which requires another
EnvironmentFile directive. This way things will work with Docker v1.11
and Docker v1.12