### PR TITLE
Expose hosts' /var/log to the kubelet by default

### DIFF
--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -104,7 +104,6 @@ Note that the kubelet running on a master node may log repeated attempts to post
   - [allow pods to mount RDB][rdb] or [iSCSI volumes][iscsi]
   - [allowing access to insecure container registries][insecure-registry]
   - [use host DNS configuration instead of a public DNS server][host-dns]
-  - [enable the cluster logging add-on][cluster-logging]
   - [changing your CoreOS auto-update settings][update]
 
 **/etc/systemd/system/kubelet.service**
@@ -112,8 +111,12 @@ Note that the kubelet running on a master node may log repeated attempts to post
 ```yaml
 [Service]
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
+ExecStartPre=/usr/bin/mkdir -p /var/log/containers
 
 Environment=KUBELET_VERSION=${K8S_VER}
+Environment="RKT_OPTS=--volume var-log,kind=host,source=/var/log \
+  --mount volume=var-log,target=/var/log"
+
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=http://127.0.0.1:8080 \
   --network-plugin-dir=/etc/kubernetes/cni/net.d \
@@ -550,4 +553,3 @@ kube-proxy-$node
 [rdb]: kubelet-wrapper.md#allow-pods-to-use-rbd-volumes
 [iscsi]: kubelet-wrapper.md#allow-pods-to-use-iscsi-mounts
 [host-dns]: kubelet-wrapper.md#use-the-hosts-dns-configuration
-[cluster-logging]: kubelet-wrapper.md#use-the-cluster-logging-add-on

--- a/Documentation/deploy-workers.md
+++ b/Documentation/deploy-workers.md
@@ -87,7 +87,6 @@ Create `/etc/systemd/system/kubelet.service` and substitute the following variab
   - [allow pods to mount RDB][rdb] or [iSCSI volumes][iscsi]
   - [allowing access to insecure container registries][insecure-registry]
   - [use host DNS configuration instead of a public DNS server][host-dns]
-  - [enable the cluster logging add-on][cluster-logging]
   - [changing your CoreOS auto-update settings][update]
 
 **/etc/systemd/system/kubelet.service**
@@ -95,8 +94,12 @@ Create `/etc/systemd/system/kubelet.service` and substitute the following variab
 ```yaml
 [Service]
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
+ExecStartPre=/usr/bin/mkdir -p /var/log/containers
 
 Environment=KUBELET_VERSION=${K8S_VER}
+Environment="RKT_OPTS=--volume var-log,kind=host,source=/var/log \
+  --mount volume=var-log,target=/var/log"
+
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=https://${MASTER_HOST} \
   --network-plugin-dir=/etc/kubernetes/cni/net.d \
@@ -311,4 +314,3 @@ To check the health of the calico-node systemd unit that we created, run `system
 [rdb]: kubelet-wrapper.md#allow-pods-to-use-rbd-volumes
 [iscsi]: kubelet-wrapper.md#allow-pods-to-use-iscsi-mounts
 [host-dns]: kubelet-wrapper.md#use-the-hosts-dns-configuration
-[cluster-logging]: kubelet-wrapper.md#use-the-cluster-logging-add-on

--- a/Documentation/kubelet-wrapper.md
+++ b/Documentation/kubelet-wrapper.md
@@ -59,21 +59,6 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   ...other flags...
 ```
 
-### Use the cluster logging add-on
-
-Export the logs collected by the kubelet via a volume mount, so that [other logging applications][addon-logging] can consume it. In addition to setting `RKT_OPTS`, an `ExecStartPre` is included to create the log directory.
-
-```ini
-[Service]
-Environment="RKT_OPTS=--volume var-log,kind=host,source=/var/log --mount volume=var-log,target=/var/log"
-Environment=KUBELET_VERSION=v1.3.6_coreos.0
-ExecStartPre=/usr/bin/mkdir -p /var/log/containers
-ExecStart=/usr/lib/coreos/kubelet-wrapper \
-  --api-servers=http://127.0.0.1:8080 \
-  --config=/etc/kubernetes/manifests
-  ...other flags...
-```
-
 ### Allow pods to use rbd volumes
 
 Pods using the [rbd volume plugin][rbd-example] to consume data from ceph must ensure that the kubelet has access to modprobe. Add the following options to the `RKT_OPTS` env before launching the kubelet via kubelet-wrapper:
@@ -111,5 +96,4 @@ ExecStart=/opt/bin/kubelet-wrapper \
 
 [#2141]: https://github.com/coreos/rkt/issues/2141
 [kubelet-wrapper]: https://github.com/coreos/coreos-overlay/blob/master/app-admin/kubelet-wrapper/files/kubelet-wrapper
-[addon-logging]: https://github.com/kubernetes/kubernetes/tree/release-1.3/cluster/addons/fluentd-elasticsearch
 [rbd-example]: https://github.com/kubernetes/kubernetes/tree/master/examples/volumes/rbd

--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -43,12 +43,15 @@ coreos:
         Environment=KUBELET_ACI={{.HyperkubeImageRepo}}
         Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
         --mount volume=dns,target=/etc/resolv.conf \
-        --volume=rkt,kind=host,source=/opt/bin/host-rkt \
+        --volume rkt,kind=host,source=/opt/bin/host-rkt \
         --mount volume=rkt,target=/usr/bin/rkt \
         --volume var-lib-rkt,kind=host,source=/var/lib/rkt \
         --mount volume=var-lib-rkt,target=/var/lib/rkt \
-        --volume=stage,kind=host,source=/tmp \
-        --mount volume=stage,target=/tmp"
+        --volume stage,kind=host,source=/tmp \
+        --mount volume=stage,target=/tmp \
+        --volume var-log,kind=host,source=/var/log \
+        --mount volume=var-log,target=/var/log"
+        ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
         --api-servers=http://localhost:8080 \
         --network-plugin-dir=/etc/kubernetes/cni/net.d \

--- a/multi-node/aws/pkg/config/templates/cloud-config-worker
+++ b/multi-node/aws/pkg/config/templates/cloud-config-worker
@@ -25,12 +25,15 @@ coreos:
         Environment=KUBELET_ACI={{.HyperkubeImageRepo}}
         Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
         --mount volume=dns,target=/etc/resolv.conf \
-        --volume=rkt,kind=host,source=/opt/bin/host-rkt \
+        --volume rkt,kind=host,source=/opt/bin/host-rkt \
         --mount volume=rkt,target=/usr/bin/rkt \
         --volume var-lib-rkt,kind=host,source=/var/lib/rkt \
         --mount volume=var-lib-rkt,target=/var/lib/rkt \
-        --volume=stage,kind=host,source=/tmp \
-        --mount volume=stage,target=/tmp"
+        --volume stage,kind=host,source=/tmp \
+        --mount volume=stage,target=/tmp \
+        --volume var-log,kind=host,source=/var/log \
+        --mount volume=var-log,target=/var/log"
+        ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
         --api-servers={{.SecureAPIServers}} \
         --network-plugin-dir=/etc/kubernetes/cni/net.d \

--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -94,13 +94,16 @@ Environment=KUBELET_VERSION=${K8S_VER}
 Environment=KUBELET_ACI=${HYPERKUBE_IMAGE_REPO}
 Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
   --mount volume=dns,target=/etc/resolv.conf \
-  --volume=rkt,kind=host,source=/opt/bin/host-rkt \
+  --volume rkt,kind=host,source=/opt/bin/host-rkt \
   --mount volume=rkt,target=/usr/bin/rkt \
   --volume var-lib-rkt,kind=host,source=/var/lib/rkt \
   --mount volume=var-lib-rkt,target=/var/lib/rkt \
-  --volume=stage,kind=host,source=/tmp \
-  --mount volume=stage,target=/tmp"
+  --volume stage,kind=host,source=/tmp \
+  --mount volume=stage,target=/tmp \
+  --volume var-log,kind=host,source=/var/log \
+  --mount volume=var-log,target=/var/log"
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
+ExecStartPre=/usr/bin/mkdir -p /var/log/containers
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=http://127.0.0.1:8080 \
   --register-schedulable=false \

--- a/multi-node/generic/worker-install.sh
+++ b/multi-node/generic/worker-install.sh
@@ -60,13 +60,16 @@ Environment=KUBELET_VERSION=${K8S_VER}
 Environment=KUBELET_ACI=${HYPERKUBE_IMAGE_REPO}
 Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
   --mount volume=dns,target=/etc/resolv.conf \
-  --volume=rkt,kind=host,source=/opt/bin/host-rkt \
+  --volume rkt,kind=host,source=/opt/bin/host-rkt \
   --mount volume=rkt,target=/usr/bin/rkt \
   --volume var-lib-rkt,kind=host,source=/var/lib/rkt \
   --mount volume=var-lib-rkt,target=/var/lib/rkt \
-  --volume=stage,kind=host,source=/tmp \
-  --mount volume=stage,target=/tmp"
+  --volume stage,kind=host,source=/tmp \
+  --mount volume=stage,target=/tmp \
+  --volume var-log,kind=host,source=/var/log \
+  --mount volume=var-log,target=/var/log"
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
+ExecStartPre=/usr/bin/mkdir -p /var/log/containers
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=${CONTROLLER_ENDPOINT} \
   --network-plugin-dir=/etc/kubernetes/cni/net.d \

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -88,13 +88,16 @@ Environment=KUBELET_VERSION=${K8S_VER}
 Environment=KUBELET_ACI=${HYPERKUBE_IMAGE_REPO}
 Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
   --mount volume=dns,target=/etc/resolv.conf \
-  --volume=rkt,kind=host,source=/opt/bin/host-rkt \
+  --volume rkt,kind=host,source=/opt/bin/host-rkt \
   --mount volume=rkt,target=/usr/bin/rkt \
   --volume var-lib-rkt,kind=host,source=/var/lib/rkt \
   --mount volume=var-lib-rkt,target=/var/lib/rkt \
-  --volume=stage,kind=host,source=/tmp \
-  --mount volume=stage,target=/tmp"
+  --volume stage,kind=host,source=/tmp \
+  --mount volume=stage,target=/tmp \
+  --volume var-log,kind=host,source=/var/log \
+  --mount volume=var-log,target=/var/log"
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
+ExecStartPre=/usr/bin/mkdir -p /var/log/containers
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=http://127.0.0.1:8080 \
   --network-plugin-dir=/etc/kubernetes/cni/net.d \


### PR DESCRIPTION
The kubelet creates symlinks that capture the pod name, namespace, container name & Docker container ID to the Docker logs for pods in the `/var/log/containers` directory on the host.

By mapping the volume for this directory to the kubelet container by default, it becomes easier to use cluster level logging in Kubernetes, i.e., [fluentd-elasticsearch](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/fluentd-elasticsearch), if the user choose to (see my comment in #320).

This PR updates both single-node and multi-node configurations.

(I should probably update some documentation as well, but first I want to know how you guys feel about this.)