### PR TITLE
aws: top-level services are runtime: true

### DIFF
--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -15,6 +15,7 @@ coreos:
   units:
     - name: etcd2.service
       command: start
+      runtime: true
 
     - name: docker.service
       drop-ins:
@@ -36,7 +37,7 @@ coreos:
             http://localhost:2379/v2/keys/coreos.com/network/config?prevExist=false
     - name: kubelet.service
       command: start
-      enable: true
+      runtime: true
       content: |
         [Service]
         Environment=KUBELET_VERSION={{.K8sVer}}
@@ -104,6 +105,7 @@ coreos:
 {{ if .UseCalico }}
     - name: calico-node.service
       command: start
+      runtime: true
       content: |
         [Unit]
         Description=Calico per-host agent
@@ -148,6 +150,7 @@ coreos:
 
     - name: install-kube-system.service
       command: start
+      runtime: true
       content: |
         [Unit]
         Requires=kubelet.service docker.service
@@ -163,6 +166,7 @@ coreos:
 {{ if .UseCalico }}
     - name: install-calico-system.service
       command: start
+      runtime: true
       content: |
         [Unit]
         Requires=kubelet.service docker.service

--- a/multi-node/aws/pkg/config/templates/cloud-config-worker
+++ b/multi-node/aws/pkg/config/templates/cloud-config-worker
@@ -17,8 +17,8 @@ coreos:
             EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
 
     - name: kubelet.service
-      enable: true
       command: start
+      runtime: true
       content: |
         [Service]
         Environment=KUBELET_VERSION={{.K8sVer}}
@@ -88,6 +88,7 @@ coreos:
 {{ if .UseCalico }}
     - name: calico-node.service
       command: start
+      runtime: true
       content: |
         [Unit]
         Description=Calico per-host agent


### PR DESCRIPTION
Fixes #676 

This passes conformance tests: https://jenkins.coreos.systems/view/Kubernetes/job/kubernetes-conformance-aws/131/consoleFull

\cc @crawford @pbx0 

`command: start` and `runtime: true` for all top-level services. 

The only things that are enabled are brought up as dependencies by systemd on behalf of other units (and have no command associated with them).