### PR TITLE
docs: mount resolv.conf from host

### DIFF
--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -103,7 +103,6 @@ Note that the kubelet running on a master node may log repeated attempts to post
   - [mounting ephemeral disks][mount-disks]
   - [allow pods to mount RDB][rdb] or [iSCSI volumes][iscsi]
   - [allowing access to insecure container registries][insecure-registry]
-  - [use host DNS configuration instead of a public DNS server][host-dns]
   - [changing your CoreOS auto-update settings][update]
 
 **/etc/systemd/system/kubelet.service**
@@ -115,7 +114,9 @@ ExecStartPre=/usr/bin/mkdir -p /var/log/containers
 
 Environment=KUBELET_VERSION=${K8S_VER}
 Environment="RKT_OPTS=--volume var-log,kind=host,source=/var/log \
-  --mount volume=var-log,target=/var/log"
+  --mount volume=var-log,target=/var/log \
+  --volume dns,kind=host,source=/etc/resolv.conf \
+  --mount volume=dns,target=/etc/resolv.conf"
 
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=http://127.0.0.1:8080 \

--- a/Documentation/deploy-workers.md
+++ b/Documentation/deploy-workers.md
@@ -86,7 +86,6 @@ Create `/etc/systemd/system/kubelet.service` and substitute the following variab
   - [mounting ephemeral disks][mount-disks]
   - [allow pods to mount RDB][rdb] or [iSCSI volumes][iscsi]
   - [allowing access to insecure container registries][insecure-registry]
-  - [use host DNS configuration instead of a public DNS server][host-dns]
   - [changing your CoreOS auto-update settings][update]
 
 **/etc/systemd/system/kubelet.service**
@@ -98,7 +97,9 @@ ExecStartPre=/usr/bin/mkdir -p /var/log/containers
 
 Environment=KUBELET_VERSION=${K8S_VER}
 Environment="RKT_OPTS=--volume var-log,kind=host,source=/var/log \
-  --mount volume=var-log,target=/var/log"
+  --mount volume=var-log,target=/var/log \
+  --volume dns,kind=host,source=/etc/resolv.conf \
+  --mount volume=dns,target=/etc/resolv.conf"
 
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=https://${MASTER_HOST} \


### PR DESCRIPTION
I discovered that the Vagrant boxes have already been mounting resolv.conf into the kubelet-wrapper:

https://github.com/coreos/coreos-kubernetes/blob/master/multi-node/generic/controller-install.sh#L95-L96

This PR brings the rest of the guides to parity.

fixes https://github.com/coreos/bugs/issues/1228 and https://github.com/coreos/coreos-kubernetes/issues/506