### PR TITLE
Allow setting K8s Version as env

### DIFF
--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -5,7 +5,7 @@ set -e
 export ETCD_ENDPOINTS=
 
 # Specify the version (vX.Y.Z) of Kubernetes assets to deploy
-export K8S_VER=v1.3.6_coreos.0
+export K8S_VER=${K8S_VER:=v1.3.6_coreos.0}
 
 # Hyperkube image repository to use.
 export HYPERKUBE_IMAGE_REPO=quay.io/coreos/hyperkube

--- a/multi-node/generic/worker-install.sh
+++ b/multi-node/generic/worker-install.sh
@@ -10,7 +10,7 @@ export ETCD_ENDPOINTS=
 export CONTROLLER_ENDPOINT=
 
 # Specify the version (vX.Y.Z) of Kubernetes assets to deploy
-export K8S_VER=v1.3.6_coreos.0
+export K8S_VER=${K8S_VER:=v1.3.6_coreos.0}
 
 # Hyperkube image repository to use.
 export HYPERKUBE_IMAGE_REPO=quay.io/coreos/hyperkube

--- a/multi-node/vagrant/Vagrantfile
+++ b/multi-node/vagrant/Vagrantfile
@@ -130,12 +130,12 @@ Vagrant.configure("2") do |config|
     end
   end
 
-
   (1..$controller_count).each do |i|
     config.vm.define vm_name = "c%d" % i do |controller|
 
       env_file = Tempfile.new('env_file', :binmode => true)
       env_file.write("ETCD_ENDPOINTS=#{etcd_endpoints}\n")
+      env_file.write("K8S_VER=" + ENV['K8S_VER'].to_s + "\n")
       env_file.close
 
       controller.vm.hostname = vm_name
@@ -170,6 +170,7 @@ Vagrant.configure("2") do |config|
 
       env_file = Tempfile.new('env_file', :binmode => true)
       env_file.write("ETCD_ENDPOINTS=#{etcd_endpoints}\n")
+      env_file.write("K8S_VER=" + ENV['K8S_VER'].to_s + "\n")
       env_file.write("CONTROLLER_ENDPOINT=https://#{controllerIPs[0]}\n") #TODO(aaron): LB or DNS across control nodes
       env_file.close
 

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -5,7 +5,7 @@ set -e
 export ETCD_ENDPOINTS="http://127.0.0.1:2379"
 
 # Specify the version (vX.Y.Z) of Kubernetes assets to deploy
-export K8S_VER=v1.3.6_coreos.0
+export K8S_VER=${K8S_VER:=v1.3.6_coreos.0}
 
 # Hyperkube image repository to use.
 export HYPERKUBE_IMAGE_REPO=quay.io/coreos/hyperkube


### PR DESCRIPTION
This PR allows users to specify their K8s version without modifing the scripts they just have to set the env variable like `export K8S_VER=v1.3.7_coreos.0` and the scripts will take this version. This allows users to use older/newer versions of K8s without any modification of the scripts. 

All possible K8s versions can be found in https://quay.io/repository/coreos/hyperkube?tag=latest&tab=tags (even if some of these versions are not tested?) 

As an alternativ we could use the [`config.rb`](https://github.com/johscheuer/coreos-kubernetes/blob/master/Documentation/kubernetes-on-vagrant.md#start-the-machines) and add here a field `K8S_VER`.

If you like to add this feature I would add some docs for the [Vagrant setup](https://github.com/johscheuer/coreos-kubernetes/blob/master/Documentation/kubernetes-on-vagrant.md)
