### PR TITLE
docs: add missing word in external dns copy

### DIFF
--- a/Documentation/kubernetes-on-aws-render.md
+++ b/Documentation/kubernetes-on-aws-render.md
@@ -36,7 +36,7 @@ You will use the KeyMetadata.Arn string to identify your KMS key in the init ste
 
 ### External DNS name
 
-Select a DNS hostname where the cluster API will be accessible. Typically this hostname is available over the internet ("external"), so end users can connect from different networks. This hostname be used to provision the TLS certificate for the API server, which encrypts traffic between your users and the API. Optionally, you can provide the certificates yourself, which is recommended for production clusters.
+Select a DNS hostname where the cluster API will be accessible. Typically this hostname is available over the internet ("external"), so end users can connect from different networks. This hostname will be used to provision the TLS certificate for the API server, which encrypts traffic between your users and the API. Optionally, you can provide the certificates yourself, which is recommended for production clusters.
 
 When the cluster is created, the controller will expose the TLS-secured API on a public IP address. You will need to create an A record for the external DNS hostname you want to point to this IP address. You can find the API external IP address after the cluster is created by invoking `kube-aws status`.
 


### PR DESCRIPTION
"This hostname be used to provision" to "This hostname *will* be used to provision"