### PR TITLE
aws: workaround for systemd #1312

### DIFF
--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -22,10 +22,10 @@ coreos:
         - name: 40-flannel.conf
           content: |
             [Unit]
-            Requires=flanneld.service
-            After=flanneld.service
+            Wants=flanneld.service
             [Service]
             EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
+            ExecStartPre=systemctl is-active flanneld.service
 
     - name: flanneld.service
       drop-ins:
@@ -39,6 +39,8 @@ coreos:
       command: start
       runtime: true
       content: |
+        [Unit]
+        Wants=docker.service
         [Service]
         Environment=KUBELET_VERSION={{.K8sVer}}
         Environment=KUBELET_ACI={{.HyperkubeImageRepo}}
@@ -52,6 +54,8 @@ coreos:
         --mount volume=stage,target=/tmp \
         --volume var-log,kind=host,source=/var/log \
         --mount volume=var-log,target=/var/log"
+        ExecStartPre=systemctl is-active docker.service
+        ExecStartPre=/opt/bin/decrypt-tls-assets
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
         --api-servers=http://localhost:8080 \
@@ -91,12 +95,12 @@ coreos:
         [Unit]
         Description=Load rkt stage1 images
         Documentation=http://github.com/coreos/rkt
-        Requires=network-online.target
-        After=network-online.target
+        Wants=network-online.target
         Before=rkt-api.service
         [Service]
         Type=oneshot
         RemainAfterExit=yes
+        ExecStartPre=systemctl is-active network-online.target
         ExecStart=/usr/bin/rkt fetch /usr/lib/rkt/stage1-images/stage1-coreos.aci /usr/lib/rkt/stage1-images/stage1-fly.aci  --insecure-options=image
         [Install]
         RequiredBy=rkt-api.service
@@ -109,8 +113,7 @@ coreos:
       content: |
         [Unit]
         Description=Calico per-host agent
-        Requires=network-online.target
-        After=network-online.target
+        Wants=network-online.target
 
         [Service]
         Slice=machine.slice
@@ -121,6 +124,7 @@ coreos:
         Environment=CALICO_NETWORKING=false
         Environment=NO_DEFAULT_POOLS=true
         Environment=ETCD_ENDPOINTS={{ .ETCDEndpoints }}
+        ExecStartPre=systemctl is-active network-online.target
         ExecStart=/usr/bin/rkt run --inherit-env --stage1-from-dir=stage1-fly.aci \
         --volume=modules,kind=host,source=/lib/modules,readOnly=false \
         --mount=volume=modules,target=/lib/modules \
@@ -135,33 +139,18 @@ coreos:
         WantedBy=multi-user.target
 {{ end }}
 
-    - name: decrypt-tls-assets.service
-      enable: true
-      content: |
-        [Unit]
-        Description=decrypt kubelet tls assets using amazon kms
-        Before=kubelet.service
-
-        [Service]
-        Type=oneshot
-        RemainAfterExit=yes
-        ExecStart=/opt/bin/decrypt-tls-assets
-
-        [Install]
-        RequiredBy=kubelet.service
-
     - name: install-kube-system.service
       command: start
       runtime: true
       content: |
         [Unit]
-        Requires=kubelet.service docker.service
-        After=kubelet.service docker.service
+        Wants=kubelet.service docker.service
 
         [Service]
         Type=simple
         StartLimitInterval=0
         Restart=on-failure
+        ExecStartPre=systemctl is-active kubelet.service docker.service
         ExecStartPre=/usr/bin/curl http://127.0.0.1:8080/version
         ExecStart=/opt/bin/install-kube-system
 
@@ -171,13 +160,13 @@ coreos:
       runtime: true
       content: |
         [Unit]
-        Requires=kubelet.service docker.service
-        After=kubelet.service docker.service
+        Wants=kubelet.service docker.service
 
         [Service]
         Type=simple
         StartLimitInterval=0
         Restart=on-failure
+        ExecStartPre=systemctl is-active kubelet.service docker.service
         ExecStartPre=/usr/bin/curl http://127.0.0.1:8080/version
         ExecStart=/opt/bin/install-calico-system
 {{ end }}

--- a/multi-node/aws/pkg/config/templates/cloud-config-worker
+++ b/multi-node/aws/pkg/config/templates/cloud-config-worker
@@ -11,15 +11,17 @@ coreos:
         - name: 40-flannel.conf
           content: |
             [Unit]
-            Requires=flanneld.service
-            After=flanneld.service
+            Wants=flanneld.service
             [Service]
             EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
+            ExecStartPre=systemctl is-active flanneld.service
 
     - name: kubelet.service
       command: start
       runtime: true
       content: |
+        [Unit]
+        Wants=docker.service
         [Service]
         Environment=KUBELET_VERSION={{.K8sVer}}
         Environment=KUBELET_ACI={{.HyperkubeImageRepo}}
@@ -33,6 +35,8 @@ coreos:
         --mount volume=stage,target=/tmp \
         --volume var-log,kind=host,source=/var/log \
         --mount volume=var-log,target=/var/log"
+        ExecStartPre=systemctl is-active docker.service
+        ExecStartPre=/opt/bin/decrypt-tls-assets
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
         --api-servers={{.SecureAPIServers}} \
@@ -74,12 +78,12 @@ coreos:
         [Unit]
         Description=Load rkt stage1 images
         Documentation=http://github.com/coreos/rkt
-        Requires=network-online.target
-        After=network-online.target
+        Wants=network-online.target
         Before=rkt-api.service
         [Service]
         Type=oneshot
         RemainAfterExit=yes
+        ExecStartPre=systemctl is-active network-online.target
         ExecStart=/usr/bin/rkt fetch /usr/lib/rkt/stage1-images/stage1-coreos.aci /usr/lib/rkt/stage1-images/stage1-fly.aci  --insecure-options=image
         [Install]
         RequiredBy=rkt-api.service
@@ -92,8 +96,7 @@ coreos:
       content: |
         [Unit]
         Description=Calico per-host agent
-        Requires=network-online.target
-        After=network-online.target
+        Wants=network-online.target
 
         [Service]
         Slice=machine.slice
@@ -104,6 +107,7 @@ coreos:
         Environment=CALICO_NETWORKING=false
         Environment=NO_DEFAULT_POOLS=true
         Environment=ETCD_ENDPOINTS={{ .ETCDEndpoints }}
+        ExecStartPre=systemctl is-active network-online.target
         ExecStart=/usr/bin/rkt run --inherit-env --stage1-from-dir=stage1-fly.aci \
         --volume=modules,kind=host,source=/lib/modules,readOnly=false \
         --mount=volume=modules,target=/lib/modules \
@@ -117,21 +121,6 @@ coreos:
         [Install]
         WantedBy=multi-user.target
 {{ end }}
-
-    - name: decrypt-tls-assets.service
-      enable: true
-      content: |
-        [Unit]
-        Description=decrypt kubelet tls assets using amazon kms
-        Before=kubelet.service
-
-        [Service]
-        Type=oneshot
-        RemainAfterExit=yes
-        ExecStart=/opt/bin/decrypt-tls-assets
-
-        [Install]
-        RequiredBy=kubelet.service
 
 write_files:
   - path: /etc/kubernetes/cni/docker_opts_cni.env


### PR DESCRIPTION
On top of https://github.com/coreos/coreos-kubernetes/issues/682#issuecomment-248692751, replaces a dependency from kubelet to the oneshot service `decrypt-tls-assets` with an ExecStartPre in the kubelet service because systemd doesn't seem to restart failed `decrypt-tls-assets` services that way.

Also, I've changed where to add `ExecStartPre`, instead of `[Unit]` sections as done in https://gist.github.com/spacepluk/a14f10cfed3756c0f1f079e73cdc6c9a#gistcomment-1885799, to `[Service]` sections as done in this PR.

Mainly purposed to fix #675 which I've encountered earlier, but would fix #682 too.

Although my cluster brought up via kube-aws with this change is working without any problem,
I have not yet a chance to reproduce #682 to test this.
Is anyone aware of a handy way to reproduce it?

cc @cgag @spacepluk 
