### PR TITLE
Add name tags where applicable

### DIFF
--- a/multi-node/aws/pkg/config/templates/stack-template.json
+++ b/multi-node/aws/pkg/config/templates/stack-template.json
@@ -379,6 +379,10 @@
         ],
         "Tags": [
           {
+            "Key": "Name",
+            "Value": "{{.ClusterName}}-sg-controller"
+          },
+          {
             "Key": "KubernetesCluster",
             "Value": "{{.ClusterName}}"
           }
@@ -441,6 +445,10 @@
           }
         ],
         "Tags": [
+          {
+            "Key": "Name",
+            "Value": "{{.ClusterName}}-sg-worker"
+          },
           {
             "Key": "KubernetesCluster",
             "Value": "{{.ClusterName}}"
@@ -558,6 +566,10 @@
         "MapPublicIpOnLaunch": true,
         "Tags": [
           {
+            "Key": "Name",
+            "Value": "{{.ClusterName}}-{{$subnetLogicalName}}"
+          },
+          {
             "Key": "KubernetesCluster",
             "Value": "{{$.ClusterName}}"
           }
@@ -583,7 +595,7 @@
           },
           {
             "Key": "Name",
-            "Value": "kubernetes-{{.ClusterName}}-vpc"
+            "Value": "{{.ClusterName}}-vpc"
           }
         ]
       },
@@ -592,6 +604,10 @@
     "RouteTable": {
       "Properties": {
         "Tags": [
+          {
+            "Key": "Name",
+            "Value": "{{.ClusterName}}-route-table"
+          },
           {
             "Key": "KubernetesCluster",
             "Value": "{{.ClusterName}}"
@@ -614,6 +630,10 @@
     "InternetGateway": {
       "Properties": {
         "Tags": [
+          {
+            "Key": "Name",
+            "Value": "{{.ClusterName}}-igw"
+          },
           {
             "Key": "KubernetesCluster",
             "Value": "{{.ClusterName}}"

--- a/multi-node/aws/pkg/config/templates/stack-template.json
+++ b/multi-node/aws/pkg/config/templates/stack-template.json
@@ -571,7 +571,7 @@
           },
           {
             "Key": "KubernetesCluster",
-            "Value": "{{$.ClusterName}}"
+            "Value": "{{.ClusterName}}"
           }
         ],
         "VpcId": {{$.VPCRef}}

--- a/multi-node/aws/pkg/config/templates/stack-template.json
+++ b/multi-node/aws/pkg/config/templates/stack-template.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "kube-aws Kubernetes cluster {{.ClusterName}}",
+  "Description": "kube-aws Kubernetes cluster {{$.ClusterName}}",
   "Resources": {
     "AlarmControllerRecover": {
       "Properties": {
@@ -57,12 +57,12 @@
           {
             "Key": "KubernetesCluster",
             "PropagateAtLaunch": "true",
-            "Value": "{{.ClusterName}}"
+            "Value": "{{$.ClusterName}}"
           },
           {
             "Key": "Name",
             "PropagateAtLaunch": "true",
-            "Value": "{{.ClusterName}}-kube-aws-worker"
+            "Value": "{{$.ClusterName}}-kube-aws-worker"
           }
         ],
         "VPCZoneIdentifier": [
@@ -289,11 +289,11 @@
         "Tags": [
           {
             "Key": "KubernetesCluster",
-            "Value": "{{.ClusterName}}"
+            "Value": "{{$.ClusterName}}"
           },
           {
             "Key": "Name",
-            "Value": "{{.ClusterName}}-kube-aws-controller"
+            "Value": "{{$.ClusterName}}-kube-aws-controller"
           }
         ],
         "UserData": "{{ .UserDataController }}"
@@ -380,11 +380,11 @@
         "Tags": [
           {
             "Key": "Name",
-            "Value": "{{.ClusterName}}-sg-controller"
+            "Value": "{{$.ClusterName}}-sg-controller"
           },
           {
             "Key": "KubernetesCluster",
-            "Value": "{{.ClusterName}}"
+            "Value": "{{$.ClusterName}}"
           }
         ],
         "VpcId": {{.VPCRef}}
@@ -447,11 +447,11 @@
         "Tags": [
           {
             "Key": "Name",
-            "Value": "{{.ClusterName}}-sg-worker"
+            "Value": "{{$.ClusterName}}-sg-worker"
           },
           {
             "Key": "KubernetesCluster",
-            "Value": "{{.ClusterName}}"
+            "Value": "{{$.ClusterName}}"
           }
         ],
         "VpcId": {{.VPCRef}}
@@ -567,11 +567,11 @@
         "Tags": [
           {
             "Key": "Name",
-            "Value": "{{.ClusterName}}-{{$subnetLogicalName}}"
+            "Value": "{{$.ClusterName}}-{{$subnetLogicalName}}"
           },
           {
             "Key": "KubernetesCluster",
-            "Value": "{{.ClusterName}}"
+            "Value": "{{$.ClusterName}}"
           }
         ],
         "VpcId": {{$.VPCRef}}
@@ -591,11 +591,11 @@
         "Tags": [
           {
             "Key": "KubernetesCluster",
-            "Value": "{{.ClusterName}}"
+            "Value": "{{$.ClusterName}}"
           },
           {
             "Key": "Name",
-            "Value": "{{.ClusterName}}-vpc"
+            "Value": "{{$.ClusterName}}-vpc"
           }
         ]
       },
@@ -606,11 +606,11 @@
         "Tags": [
           {
             "Key": "Name",
-            "Value": "{{.ClusterName}}-route-table"
+            "Value": "{{$.ClusterName}}-route-table"
           },
           {
             "Key": "KubernetesCluster",
-            "Value": "{{.ClusterName}}"
+            "Value": "{{$.ClusterName}}"
           }
         ],
         "VpcId": {{.VPCRef}}
@@ -632,11 +632,11 @@
         "Tags": [
           {
             "Key": "Name",
-            "Value": "{{.ClusterName}}-igw"
+            "Value": "{{$.ClusterName}}-igw"
           },
           {
             "Key": "KubernetesCluster",
-            "Value": "{{.ClusterName}}"
+            "Value": "{{$.ClusterName}}"
           }
         ]
       },


### PR DESCRIPTION
Not everything is tagged with a name which means the AWS console gets filled with empty named resources, this helps fix it up.
