### PR TITLE
Docs: update Calico versions and add calico-policy-controller to api output

### DIFF
--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -62,7 +62,7 @@ Next create a [systemd drop-in][dropins], which is a method for appending or ove
 ExecStartPre=/usr/bin/ln -sf /etc/flannel/options.env /run/flannel/options.env
 ```
 
-[calico-docs]: https://github.com/projectcalico/calico-containers/tree/v0.19.0/docs/cni/kubernetes
+[calico-docs]: https://github.com/projectcalico/calico-containers/tree/v0.22.0/docs/cni/kubernetes
 [flannel-docs]: https://coreos.com/flannel/docs/latest/
 [pod-overview]: https://coreos.com/kubernetes/docs/latest/pods.html
 [service-overview]: https://coreos.com/kubernetes/docs/latest/services.html

--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -356,7 +356,7 @@ ExecStart=/usr/bin/rkt run --inherit-env --stage1-from-dir=stage1-fly.aci \
 --mount=volume=modules,target=/lib/modules \
 --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true \
 --mount=volume=dns,target=/etc/resolv.conf \
---trust-keys-from-https quay.io/calico/node:v0.19.0
+--trust-keys-from-https quay.io/calico/node:v0.22.0
 
 KillMode=mixed
 Restart=always
@@ -389,7 +389,7 @@ spec:
   containers:
     # The Calico policy controller.
     - name: k8s-policy-controller
-      image: calico/kube-policy-controller:v0.2.0
+      image: calico/kube-policy-controller:v0.3.0
       env:
         - name: ETCD_ENDPOINTS
           value: "${ETCD_ENDPOINTS}"

--- a/Documentation/deploy-workers.md
+++ b/Documentation/deploy-workers.md
@@ -263,7 +263,7 @@ ExecStart=/usr/bin/rkt run --inherit-env --stage1-from-dir=stage1-fly.aci \
 --mount=volume=modules,target=/lib/modules \
 --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true \
 --mount=volume=dns,target=/etc/resolv.conf \
---trust-keys-from-https quay.io/calico/node:v0.19.0
+--trust-keys-from-https quay.io/calico/node:v0.22.0
 KillMode=mixed
 Restart=always
 TimeoutStartSec=0

--- a/Documentation/kubernetes-networking.md
+++ b/Documentation/kubernetes-networking.md
@@ -95,6 +95,6 @@ IP addresses assigned on the pod network are typically not routable outside of t
 
 In a manually configured network, it may be necessary to open a range of ports to outside clients (default 30000-32767) for use with "external services". See the [Kubernetes Service][kube-service] documentation for more information on external services.
 
-[calico-external]: https://github.com/projectcalico/calico-containers/blob/v0.19.0/docs/ExternalConnectivity.md
+[calico-external]: https://github.com/projectcalico/calico-containers/blob/v0.22.0/docs/ExternalConnectivity.md
 [kube-service]: http://kubernetes.io/docs/user-guide/services/#publishing-services---service-types
 

--- a/Documentation/kubernetes-networking.md
+++ b/Documentation/kubernetes-networking.md
@@ -80,7 +80,7 @@ The actual allocation of Pod IPs on the host can be achieved by configuring Dock
 To achieve this network model, there are various methods that can be used. See the [Kubernetes Networking][how-to-achieve] documentation for more detail.
 
 [how-to-achieve]: http://kubernetes.io/docs/admin/networking.html#how-to-achieve-this
-[calico-bgp]: https://github.com/projectcalico/calico-containers/blob/v0.19.0/docs/bgp.md
+[calico-bgp]: https://github.com/projectcalico/calico-containers/blob/v0.22.0/docs/bgp.md
 [calico-l2]: http://docs.projectcalico.org/en/latest/l2-interconnectFabric.html
 
 ### Pod-to-Service Communication

--- a/Documentation/kubernetes-upgrade.md
+++ b/Documentation/kubernetes-upgrade.md
@@ -35,7 +35,7 @@ ExecStart=/usr/bin/rkt run --inherit-env --stage1-from-dir=stage1-fly.aci \
 --mount=volume=modules,target=/lib/modules \
 --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true \
 --mount=volume=dns,target=/etc/resolv.conf \
---trust-keys-from-https quay.io/calico/node:v0.19.0
+--trust-keys-from-https quay.io/calico/node:v0.22.0
 ```
 
 ## Upgrading Master Nodes

--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -126,7 +126,7 @@ coreos:
         --mount=volume=modules,target=/lib/modules \
         --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true \
         --mount=volume=dns,target=/etc/resolv.conf \
-        --trust-keys-from-https quay.io/calico/node:v0.19.0
+        --trust-keys-from-https quay.io/calico/node:v0.22.0
         KillMode=mixed
         Restart=always
         TimeoutStartSec=0

--- a/multi-node/aws/pkg/config/templates/cloud-config-controller
+++ b/multi-node/aws/pkg/config/templates/cloud-config-controller
@@ -442,7 +442,7 @@ write_files:
         containers:
           # The Calico policy controller.
           - name: kube-policy-controller
-            image: calico/kube-policy-controller:v0.2.0
+            image: calico/kube-policy-controller:v0.3.0
             env:
               - name: ETCD_ENDPOINTS
                 value: "{{ .ETCDEndpoints }}"

--- a/multi-node/aws/pkg/config/templates/cloud-config-worker
+++ b/multi-node/aws/pkg/config/templates/cloud-config-worker
@@ -109,7 +109,7 @@ coreos:
         --mount=volume=modules,target=/lib/modules \
         --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true \
         --mount=volume=dns,target=/etc/resolv.conf \
-        --trust-keys-from-https quay.io/calico/node:v0.19.0
+        --trust-keys-from-https quay.io/calico/node:v0.22.0
         KillMode=mixed
         Restart=always
         TimeoutStartSec=0

--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -208,7 +208,7 @@ ExecStart=/usr/bin/rkt run --inherit-env --stage1-from-dir=stage1-fly.aci \
 --mount=volume=modules,target=/lib/modules \
 --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true \
 --mount=volume=dns,target=/etc/resolv.conf \
---trust-keys-from-https quay.io/calico/node:v0.19.0
+--trust-keys-from-https quay.io/calico/node:v0.22.0
 KillMode=mixed
 Restart=always
 TimeoutStartSec=0
@@ -416,7 +416,7 @@ spec:
   containers:
     # The Calico policy controller.
     - name: kube-policy-controller
-      image: calico/kube-policy-controller:v0.2.0
+      image: calico/kube-policy-controller:v0.3.0
       env:
         - name: ETCD_ENDPOINTS
           value: "${ETCD_ENDPOINTS}"

--- a/multi-node/generic/worker-install.sh
+++ b/multi-node/generic/worker-install.sh
@@ -176,7 +176,7 @@ ExecStart=/usr/bin/rkt run --inherit-env --stage1-from-dir=stage1-fly.aci \
 --mount=volume=modules,target=/lib/modules \
 --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true \
 --mount=volume=dns,target=/etc/resolv.conf \
---trust-keys-from-https quay.io/calico/node:v0.19.0
+--trust-keys-from-https quay.io/calico/node:v0.22.0
 KillMode=mixed
 Restart=always
 TimeoutStartSec=0

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -200,7 +200,7 @@ ExecStart=/usr/bin/rkt run --inherit-env --stage1-from-dir=stage1-fly.aci \
 --mount=volume=modules,target=/lib/modules \
 --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true \
 --mount=volume=dns,target=/etc/resolv.conf \
---trust-keys-from-https quay.io/calico/node:v0.19.0
+--trust-keys-from-https quay.io/calico/node:v0.22.0
 KillMode=mixed
 Restart=always
 TimeoutStartSec=0

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -406,7 +406,7 @@ spec:
   containers:
     # The Calico policy controller.
     - name: kube-policy-controller
-      image: calico/kube-policy-controller:v0.2.0
+      image: calico/kube-policy-controller:v0.3.0
       env:
         - name: ETCD_ENDPOINTS
           value: "${ETCD_ENDPOINTS}"


### PR DESCRIPTION
Update Calico containers from:
`quay.io/calico/node:v0.19.0`-> `quay.io/calico/node:v0.22.0`
and
`calico/kube-policy-controller:v0.2.0` -> `calico/kube-policy-controller:v0.3.0`

also added the `calico-policy-controller-$node` to the api output
