### PR TITLE
Delete all pods from the node before instance reboot, shutdown or terminate

### DIFF
--- a/multi-node/aws/pkg/config/templates/cloud-config-worker
+++ b/multi-node/aws/pkg/config/templates/cloud-config-worker
@@ -55,6 +55,23 @@ coreos:
         [Install]
         WantedBy=multi-user.target
 
+    - name: clean-reboot.service
+      command: start
+      runtime: true
+      content: |
+        [Unit]
+        Description=Delete all pods from the node before instance reboot, shutdown or terminate
+        Requires=decrypt-tls-assets.service
+        After=multi-user.target
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        ExecStart=/bin/sh -c "/opt/bin/node-status-change"
+        ExecStop=/bin/sh -c "/opt/bin/delete-pods-before-reboot"
+
+        [Install]
+        WantedBy=worker-reboot.target
+
 {{ if eq .ContainerRuntime "rkt" }}
     - name: rkt-api.service
       enable: true
@@ -192,6 +209,38 @@ write_files:
         base64 --decode < $encKey.b64 > ${encKey%.enc}
         sudo rkt rm --uuid-file=/var/run/coreos/decrypt-tls-assets.uuid
       done
+  - path: /opt/bin/delete-pods-before-reboot
+    owner: root:root
+    permissions: 0700
+    content: |
+      #!/bin/bash -e
+
+      curl \
+      -X "PATCH" "{{.SecureAPIServers}}/api/v1/nodes/`hostname`" \
+      -H "Content-Type: application/strategic-merge-patch+json; charset=utf-8" \
+      -d "{\"spec\":{\"unschedulable\":true}}" \
+      -k --cacert /etc/kubernetes/ssl/ca.pem \
+      --cert /etc/kubernetes/ssl/worker.pem \
+      --key /etc/kubernetes/ssl/worker-key.pem
+
+      for each in $(curl -XGET {{.SecureAPIServers}}/api/v1/namespaces -k --cacert /etc/kubernetes/ssl/ca.pem --cert /etc/kubernetes/ssl/worker.pem --key /etc/kubernetes/ssl/worker-key.pem | jq -r '.items[].metadata.name');
+      do
+      curl -XDELETE {{.SecureAPIServers}}/api/v1/namespaces/$each/pods -k --cacert /etc/kubernetes/ssl/ca.pem --cert /etc/kubernetes/ssl/worker.pem --key /etc/kubernetes/ssl/worker-key.pem
+      done
+
+  - path: /opt/bin/node-status-change
+    owner: root:root
+    permissions: 0700
+    content: |
+      #!/bin/bash -e
+
+      curl \
+      -X "PATCH" "{{.SecureAPIServers}}/api/v1/nodes/`hostname`" \
+      -H "Content-Type: application/strategic-merge-patch+json; charset=utf-8" \
+      -d "{\"spec\":{\"unschedulable\":false}}" \
+      -k --cacert /etc/kubernetes/ssl/ca.pem \
+      --cert /etc/kubernetes/ssl/worker.pem \
+      --key /etc/kubernetes/ssl/worker-key.pem
 
   - path: /etc/kubernetes/manifests/kube-proxy.yaml
     content: |

--- a/multi-node/aws/pkg/config/templates/cloud-config-worker
+++ b/multi-node/aws/pkg/config/templates/cloud-config-worker
@@ -223,9 +223,11 @@ write_files:
       --cert /etc/kubernetes/ssl/worker.pem \
       --key /etc/kubernetes/ssl/worker-key.pem
 
-      for each in $(curl -XGET {{.SecureAPIServers}}/api/v1/namespaces -k --cacert /etc/kubernetes/ssl/ca.pem --cert /etc/kubernetes/ssl/worker.pem --key /etc/kubernetes/ssl/worker-key.pem | jq -r '.items[].metadata.name');
-      do
-      curl -XDELETE {{.SecureAPIServers}}/api/v1/namespaces/$each/pods -k --cacert /etc/kubernetes/ssl/ca.pem --cert /etc/kubernetes/ssl/worker.pem --key /etc/kubernetes/ssl/worker-key.pem
+      for each in $(curl -XGET {{.SecureAPIServers}}/api/v1/namespaces -k --cacert /etc/kubernetes/ssl/ca.pem --cert /etc/kubernetes/ssl/worker.pem --key /etc/kubernetes/ssl/worker-key.pem | jq -r '.items[].metadata.name'); 
+            do arr=($(curl -XGET {{.SecureAPIServers}}/api/v1/namespaces/$each/pods -k --cacert /etc/kubernetes/ssl/ca.pem --cert /etc/kubernetes/ssl/worker.pem --key /etc/kubernetes/ssl/worker-key.pem | jq --arg node `hostname` -r '.items[] | select(.spec.nodeName == $node) | .metadata.name')); 
+        for i in  ${arr[@]};
+            do curl -XDELETE {{.SecureAPIServers}}/api/v1/namespaces/$each/pods/$i -k --cacert /etc/kubernetes/ssl/ca.pem --cert /etc/kubernetes/ssl/worker.pem --key /etc/kubernetes/ssl/worker-key.pem;
+        done
       done
 
   - path: /opt/bin/node-status-change

--- a/multi-node/aws/pkg/config/templates/cloud-config-worker
+++ b/multi-node/aws/pkg/config/templates/cloud-config-worker
@@ -55,7 +55,7 @@ coreos:
         [Install]
         WantedBy=multi-user.target
 
-    - name: clean-reboot.service
+    - name: drain-node.service
       command: start
       runtime: true
       content: |
@@ -66,8 +66,8 @@ coreos:
         [Service]
         Type=oneshot
         RemainAfterExit=true
-        ExecStart=/bin/sh -c "/opt/bin/node-status-change"
-        ExecStop=/bin/sh -c "/opt/bin/delete-pods-before-reboot"
+        ExecStart=/bin/sh -c "/opt/bin/uncordon-node"
+        ExecStop=/bin/sh -c "/opt/bin/drain-node"
 
         [Install]
         WantedBy=worker-reboot.target
@@ -209,7 +209,7 @@ write_files:
         base64 --decode < $encKey.b64 > ${encKey%.enc}
         sudo rkt rm --uuid-file=/var/run/coreos/decrypt-tls-assets.uuid
       done
-  - path: /opt/bin/delete-pods-before-reboot
+  - path: /opt/bin/drain-node
     owner: root:root
     permissions: 0700
     content: |
@@ -223,14 +223,14 @@ write_files:
       --cert /etc/kubernetes/ssl/worker.pem \
       --key /etc/kubernetes/ssl/worker-key.pem
 
-      for each in $(curl -XGET {{.SecureAPIServers}}/api/v1/namespaces -k --cacert /etc/kubernetes/ssl/ca.pem --cert /etc/kubernetes/ssl/worker.pem --key /etc/kubernetes/ssl/worker-key.pem | jq -r '.items[].metadata.name'); 
-            do arr=($(curl -XGET {{.SecureAPIServers}}/api/v1/namespaces/$each/pods -k --cacert /etc/kubernetes/ssl/ca.pem --cert /etc/kubernetes/ssl/worker.pem --key /etc/kubernetes/ssl/worker-key.pem | jq --arg node `hostname` -r '.items[] | select(.spec.nodeName == $node) | .metadata.name')); 
+      for each in $(curl -XGET {{.SecureAPIServers}}/api/v1/namespaces -k --cacert /etc/kubernetes/ssl/ca.pem --cert /etc/kubernetes/ssl/worker.pem --key /etc/kubernetes/ssl/worker-key.pem | jq -r '.items[].metadata.name');
+            do arr=($(curl -XGET {{.SecureAPIServers}}/api/v1/namespaces/$each/pods -k --cacert /etc/kubernetes/ssl/ca.pem --cert /etc/kubernetes/ssl/worker.pem --key /etc/kubernetes/ssl/worker-key.pem | jq --arg node `hostname` -r '.items[] | select(.spec.nodeName == $node) | .metadata.name'));
         for i in  ${arr[@]};
             do curl -XDELETE {{.SecureAPIServers}}/api/v1/namespaces/$each/pods/$i -k --cacert /etc/kubernetes/ssl/ca.pem --cert /etc/kubernetes/ssl/worker.pem --key /etc/kubernetes/ssl/worker-key.pem;
         done
       done
 
-  - path: /opt/bin/node-status-change
+  - path: /opt/bin/uncordon-node
     owner: root:root
     permissions: 0700
     content: |


### PR DESCRIPTION
Maybe someone  find this useful. For me it works well with auto-scaling but also allow pods to be rescheduled faster on other nodes before reboots.

Behaviour 
On Stop: first set node "unschedulable=true", then delete all the pods from all namespaces
OnStart: set node "unschedulable=false"