### PR TITLE
docs: link to shell scripts on GH

### DIFF
--- a/Documentation/kubernetes-on-generic-platforms.md
+++ b/Documentation/kubernetes-on-generic-platforms.md
@@ -104,5 +104,5 @@ $ journalctl -u kubelet -f
 [mount-disks]: https://coreos.com/os/docs/latest/mounting-storage.html
 [insecure-registry]: https://coreos.com/os/docs/latest/registry-authentication.html#using-a-registry-without-ssl-configured
 [update]: https://coreos.com/os/docs/latest/switching-channels.html
-[controller-script]: ../multi-node/generic/controller-install.sh
-[worker-script]: ../multi-node/generic/worker-install.sh
+[controller-script]: https://github.com/coreos/coreos-kubernetes/blob/master/multi-node/generic/controller-install.sh
+[worker-script]: https://github.com/coreos/coreos-kubernetes/blob/master/multi-node/generic/worker-install.sh


### PR DESCRIPTION
> Hi guys. Broken link on https://coreos.com/kubernetes/docs/latest/kubernetes-on-generic-platforms.html to download worker-install.sh (https://coreos.com/kubernetes/docs/multi-node/generic/worker-install.sh)

This PR will reference these scripts on Github to 1) fix these links and 2) its probably better than serving shell scripts off of our domain.