### PR TITLE
docs: Remove extra instance deployment

### DIFF
--- a/Documentation/kubernetes-on-aws-launch.md
+++ b/Documentation/kubernetes-on-aws-launch.md
@@ -42,7 +42,6 @@ Once the API server is running, you should see:
 $ kubectl --kubeconfig=kubeconfig get nodes
 NAME                                       STATUS                     AGE
 ip-10-0-0-xxx.us-west-1.compute.internal   Ready                      5m
-ip-10-0-0-xxx.us-west-1.compute.internal   Ready                      5m
 ip-10-0-0-xx.us-west-1.compute.internal    Ready,SchedulingDisabled   5m
 ```
 


### PR DESCRIPTION
If you follow this guide, it will only provision a worker node and
controller node. In order to deploy 2 workers, you'd need to modify
workerCount in the cluster.yaml file before rendering the
CloudFormation template.

This commit corrects the output to what the user sees. Another question
is whether this guide should have users increase that value so their
sample deployment features > 1 worker.