### PR TITLE
Add a 20 minute timeout for flanneld, so that it doesn't fail on slow connections.

### DIFF
--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -778,6 +778,7 @@ EOF
         cat << EOF > $TEMPLATE
 [Service]
 ExecStartPre=/usr/bin/ln -sf /etc/flannel/options.env /run/flannel/options.env
+TimeoutSec=20m
 EOF
     fi
 

--- a/multi-node/generic/worker-install.sh
+++ b/multi-node/generic/worker-install.sh
@@ -280,6 +280,7 @@ EOF
         cat << EOF > $TEMPLATE
 [Service]
 ExecStartPre=/usr/bin/ln -sf /etc/flannel/options.env /run/flannel/options.env
+TimeoutSec=20m
 EOF
     fi
 


### PR DESCRIPTION
While troubleshooting #749, I noticed that flanneld fails to start because it didn't finish downloading the flannel image before the timeout. Because flanneld fails, the VM wasn't provisioned.

After adding a longer timeout, the VM provisions correctly.