### PR TITLE
Change kubelet download url according to k8s faq

### DIFF
--- a/Documentation/configure-kubectl.md
+++ b/Documentation/configure-kubectl.md
@@ -10,18 +10,18 @@ To quickly launch a cluster, follow these guides for [AWS][kube-aws], [Vagrant][
 
 ## Download the kubectl Executable
 
-Download `kubectl` from the Kubernetes release artifact site with the `curl` tool.
+Download `kubectl` from the Kubernetes github release site with the `curl` tool.
 
 The linux `kubectl` binary can be fetched with a command like:
 
 ```sh
-$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.4.5/bin/linux/amd64/kubectl
+$  curl -L  https://github.com/kubernetes/kubernetes/releases/download/v1.4.5/kubernetes.tar.gz | tar xzf - kubernetes/platforms/linux/amd64/kubectl
 ```
 
 On an OS X workstation, replace `linux` in the URL above with `darwin`:
 
 ```sh
-$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.4.5/bin/darwin/amd64/kubectl
+$  curl -L  https://github.com/kubernetes/kubernetes/releases/download/v1.4.5/kubernetes.tar.gz | tar xzf - kubernetes/platforms/darwin/amd64/kubectl
 ```
 
 After downloading the binary, ensure it is executable and move it into your `PATH`:

--- a/Documentation/kubernetes-on-vagrant-single.md
+++ b/Documentation/kubernetes-on-vagrant-single.md
@@ -19,13 +19,13 @@ Navigate to the [Vagrant downloads page][vagrant-downloads] and grab the appropr
 The linux `kubectl` binary can be fetched with a command like:
 
 ```sh
-$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.4.5/bin/linux/amd64/kubectl
+$  curl -L  https://github.com/kubernetes/kubernetes/releases/download/v1.4.5/kubernetes.tar.gz | tar xzf - kubernetes/platforms/linux/amd64/kubectl
 ```
 
 On an OS X workstation, replace `linux` in the URL above with `darwin`:
 
 ```sh
-$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.4.5/bin/darwin/amd64/kubectl
+$  curl -L  https://github.com/kubernetes/kubernetes/releases/download/v1.4.5/kubernetes.tar.gz | tar xzf - kubernetes/platforms/darwin/amd64/kubectl
 ```
 
 After downloading the binary, ensure it is executable and move it into your PATH:

--- a/Documentation/kubernetes-on-vagrant.md
+++ b/Documentation/kubernetes-on-vagrant.md
@@ -18,13 +18,13 @@ Navigate to the [Vagrant downloads page][vagrant-downloads] and grab the appropr
 The linux `kubectl` binary can be fetched with a command like:
 
 ```sh
-$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.4.5/bin/linux/amd64/kubectl
+$  curl -L  https://github.com/kubernetes/kubernetes/releases/download/v1.4.5/kubernetes.tar.gz | tar xzf - kubernetes/platforms/linux/amd64/kubectl
 ```
 
 On an OS X workstation, replace `linux` in the URL above with `darwin`:
 
 ```sh
-$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.4.5/bin/darwin/amd64/kubectl
+$  curl -L  https://github.com/kubernetes/kubernetes/releases/download/v1.4.5/kubernetes.tar.gz | tar xzf - kubernetes/platforms/darwin/amd64/kubectl
 ```
 
 After downloading the binary, ensure it is executable and move it into your PATH:


### PR DESCRIPTION
According to https://github.com/kubernetes/kubernetes/wiki/User-FAQ#where-should-i-get-kubernetes we should use the github release page to get our binaries instead of storage.googleapis.com/kubernetes.

This will increase the download size, because we will get the whole k8s release but `We recommend you do not use binaries from http://storage.googleapis.com/kubernetes, as these are neither official releases nor maintained.`