### PR TITLE
Docs: Sync Kubernetes step-by-step with generic scripts

### DIFF
--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -94,9 +94,7 @@ DOCKER_OPT_BIP=""
 DOCKER_OPT_IPMASQ=""
 ```
 
-If using Flannel for networking. 
-
-*Note:* Do not use below if you intend to use Callico for networking
+If using Flannel for networking, setup the Flannel CNI configuration with below. If you intend to use Calico for networking, setup using [Set Up the CNI config (optional)](#set-up-the-cni-config-optional) instead.
 
 **/etc/kubernetes/cni/net.d/10-flannel.conf**
 

--- a/Documentation/deploy-workers.md
+++ b/Documentation/deploy-workers.md
@@ -84,9 +84,7 @@ DOCKER_OPT_BIP=""
 DOCKER_OPT_IPMASQ=""
 ```
 
-If using Flannel for networking. 
-
-*Note:* Do not use below if you intend to use Callico for networking
+If using Flannel for networking, setup the Flannel CNI configuration with below. If you intend to use Calico for networking, setup using [Set Up the CNI config (optional)](#set-up-the-cni-config-optional) instead.
 
 **/etc/kubernetes/cni/net.d/10-flannel.conf**
 
@@ -268,7 +266,6 @@ spec:
       path: /var/run/dbus
     name: dbus
 ```
-
 
 ### Set Up kubeconfig
 

--- a/Documentation/deploy-workers.md
+++ b/Documentation/deploy-workers.md
@@ -98,7 +98,7 @@ If using Flannel for networking.
         "isDefaultGateway": true
     }
 }
-
+```
 
 ### Create the kubelet Unit
 


### PR DESCRIPTION
There seem to be some updates to the scripts that are not covered in the Kubernetes Step by Step documentation. Updates documentation to add the changes that are applied in generic scripts folder.

Namely:
- flannel drop-in uses environment file /etc/kubernetes/cni/docker_opts_cni.env
- changes to the kubelet.service , which also require /opt/bin/host-rkt creation and /etc/kubernetes/cni folder artifacts
- kube-proxy annotation and dbus mount
- api-server livenessprobe
