### PR TITLE
Updating Calico to hosted install

### DIFF
--- a/Documentation/deploy-workers.md
+++ b/Documentation/deploy-workers.md
@@ -106,7 +106,14 @@ Create `/etc/systemd/system/kubelet.service` and substitute the following variab
 * Replace `${ADVERTISE_IP}` with this node's publicly routable IP.
 * Replace `${DNS_SERVICE_IP}`
 * Replace `${K8S_VER}` This will map to: `quay.io/coreos/hyperkube:${K8S_VER}` release, e.g. `v1.4.6_coreos.0`.
-* Replace `${NETWORK_PLUGIN}` with `cni` if using Calico. Otherwise just leave it blank.
+* If using Calico for network policy
+  - Replace `${NETWORK_PLUGIN}` with `cni`
+  - Add the following to `RKT_OPS=`
+    ```
+    --volume cni-bin,kind=host,source=/opt/cni/bin \
+    --mount volume=cni-bin,target=/opt/cni/bin
+    ```
+  - Add `ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin`
 * Decide if you will use [additional features][rkt-opts-examples] such as:
   - [mounting ephemeral disks][mount-disks]
   - [allow pods to mount RDB][rdb] or [iSCSI volumes][iscsi]
@@ -146,38 +153,6 @@ RestartSec=10
 
 [Install]
 WantedBy=multi-user.target
-```
-
-### Set Up the CNI config (optional)
-
-The kubelet reads the CNI configuration on startup and uses that to determine which CNI plugin to call. Create the following file which tells the kubelet to call the flannel plugin but to then delegate control to the Calico plugin. Using the flannel plugin ensures that the Calico plugin is called with the IP range for the node that was selected by flannel.
-
-Note that this configuration is different to the one on the master nodes. It includes additional Kubernetes authentication information since the API server isn't available on localhost.
-
-* Replace `${ADVERTISE_IP}` with this node's publicly routable IP.
-* Replace `${ETCD_ENDPOINTS}`
-* Replace `${MASTER_HOST}`
-
-**/etc/kubernetes/cni/net.d/10-calico.conf**
-
-```json
-{
-    "name": "calico",
-    "type": "flannel",
-    "delegate": {
-        "type": "calico",
-        "etcd_endpoints": "${ETCD_ENDPOINTS}",
-        "log_level": "none",
-        "log_level_stderr": "info",
-        "hostname": "${ADVERTISE_IP}",
-        "policy": {
-            "type": "k8s",
-            "k8s_api_root": "https://${MASTER_HOST}:443/api/v1/",
-            "k8s_client_key": "/etc/kubernetes/ssl/worker-key.pem",
-            "k8s_client_certificate": "/etc/kubernetes/ssl/worker.pem"
-        }
-    }
-}
 ```
 
 ### Set Up the kube-proxy Pod
@@ -255,50 +230,6 @@ contexts:
 current-context: kubelet-context
 ```
 
-### Set Up Calico Node Container (optional)
-
-The Calico node container runs on all hosts, including the master node. It performs two functions:
-* Connects containers to the flannel overlay network, which enables the "one IP per pod" concept.
-* Enforces network policy created through the Kubernetes policy API, ensuring pods talk to authorized resources only.
-
-This step can be skipped if not using Calico.
-
-Create `/etc/systemd/system/calico-node.service` and substitute the following variables:
-
-* Replace `${ADVERTISE_IP}` with this node's publicly routable IP.
-* Replace `${ETCD_ENDPOINTS}`
-
-**/etc/systemd/system/calico-node.service**
-
-```yaml
-[Unit]
-Description=Calico node for network policy
-Requires=network-online.target
-After=network-online.target
-
-[Service]
-Slice=machine.slice
-Environment=CALICO_DISABLE_FILE_LOGGING=true
-Environment=HOSTNAME=${ADVERTISE_IP}
-Environment=IP=${ADVERTISE_IP}
-Environment=FELIX_FELIXHOSTNAME=${ADVERTISE_IP}
-Environment=CALICO_NETWORKING=false
-Environment=NO_DEFAULT_POOLS=true
-Environment=ETCD_ENDPOINTS=${ETCD_ENDPOINTS}
-ExecStart=/usr/bin/rkt run --inherit-env --stage1-from-dir=stage1-fly.aci \
---volume=modules,kind=host,source=/lib/modules,readOnly=false \
---mount=volume=modules,target=/lib/modules \
---volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true \
---mount=volume=dns,target=/etc/resolv.conf \
---trust-keys-from-https quay.io/calico/node:v0.19.0
-KillMode=mixed
-Restart=always
-TimeoutStartSec=0
-
-[Install]
-WantedBy=multi-user.target
-```
-
 ## Start Services
 
 Now we can start the Worker services.
@@ -311,14 +242,13 @@ Tell systemd to rescan the units on disk:
 $ sudo systemctl daemon-reload
 ```
 
-### Start kubelet, flannel and Calico Node
+### Start kubelet, and flannel
 
-Start the kubelet, which will start the proxy as well as the Calico node (if required).
+Start the kubelet, which will start the proxy.
 
 ```sh
 $ sudo systemctl start flanneld
 $ sudo systemctl start kubelet
-$ sudo systemctl start calico-node
 ```
 
 Ensure that the services start on each boot:
@@ -328,12 +258,9 @@ $ sudo systemctl enable flanneld
 Created symlink from /etc/systemd/system/multi-user.target.wants/flanneld.service to /etc/systemd/system/flanneld.service.
 $ sudo systemctl enable kubelet
 Created symlink from /etc/systemd/system/multi-user.target.wants/kubelet.service to /etc/systemd/system/kubelet.service.
-$ sudo systemctl enable calico-node
-Created symlink from /etc/systemd/system/multi-user.target.wants/calico-node.service to /etc/systemd/system/calico-node.service.
 ```
 
 To check the health of the kubelet systemd unit that we created, run `systemctl status kubelet.service`.
-To check the health of the calico-node systemd unit that we created, run `systemctl status calico-node.service`.
 
 <div class="co-m-docs-next-step">
   <p><strong>Is the kubelet running?</strong></p>

--- a/Documentation/kubernetes-on-vagrant-single.md
+++ b/Documentation/kubernetes-on-vagrant-single.md
@@ -50,6 +50,10 @@ The runtime defaults to docker. If you wish to use rkt simply edit the user-data
 
 `export CONTAINER_RUNTIME=rkt`
 
+## Enable Network Policy (Optional)
+
+To enable network policy edit the user-data file and set `USE_CALICO=true`.
+
 ## Start the Machine
 
 Ensure the latest CoreOS vagrant image will be used by running `vagrant box update`.

--- a/Documentation/kubernetes-on-vagrant.md
+++ b/Documentation/kubernetes-on-vagrant.md
@@ -43,6 +43,30 @@ $ git clone https://github.com/coreos/coreos-kubernetes.git
 $ cd coreos-kubernetes/multi-node/vagrant
 ```
 
+## Choose Container Runtime (Optional)
+
+The runtime defaults to docker. To change to use rkt edit the following files:
+
+```
+../generic/controller-install.sh
+../generic/worker-install.sh
+```
+
+ And change the line beginning with `export CONTAINER_RUNTIME` to:
+
+`export CONTAINER_RUNTIME=rkt`
+
+## Enable Network Policy (Optional)
+
+To enable network policy edit the following files:
+
+```
+../generic/controller-install.sh
+../generic/worker-install.sh
+```
+
+And set `USE_CALICO=true`.
+
 ## Start the Machines
 
 The default cluster configuration is to start a virtual machine for each role &mdash; master node, worker node, and etcd server. However, you can modify the default cluster settings by copying `config.rb.sample` to `config.rb` and modifying configuration values.
@@ -51,18 +75,14 @@ The default cluster configuration is to start a virtual machine for each role &m
 #$update_channel="alpha"
 
 #$controller_count=1
-#$controller_vm_memory=512
+#$controller_vm_memory=1024
 
 #$worker_count=1
-#$worker_vm_memory=512
+#$worker_vm_memory=1024
 
 #$etcd_count=1
 #$etcd_vm_memory=512
 ```
-
-By default, Calico network policy is disabled. To enable it, change the line `export USE_CALICO=false` to `export USE_CALICO=true` in both the `../generic/controller-install.sh` and the `../generic/worker-install.sh` scripts.
-
-Also by default, the container runtime used is docker. To use rkt as the container runtime, change the line `export CONTAINER_RUNTIME=docker` to `export CONTAINER_RUNTIME=rkt` in both the `../generic/controller-install.sh` and the `../generic/worker-install.sh` scripts.
 
 Ensure the latest CoreOS vagrant image will be used by running `vagrant box update`.
 

--- a/Documentation/kubernetes-upgrade.md
+++ b/Documentation/kubernetes-upgrade.md
@@ -22,21 +22,11 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
 
 ## Upgrading Calico
 
-The Calico agent runs on both master and worker nodes, and is is distributed as a container image. It runs under rkt using systemd.
+The Calico agent runs on both master and worker nodes, and is distributed as a container image. It runs self hosted under Kubernetes.
 
-To update the image version, change the image tag in the service file (`/etc/systemd/system/calico-node.service`) to reference the new calico-node image.
+To upgrade Calico, follow the documentation [here](http://docs.projectcalico.org/v2.0/getting-started/kubernetes/upgrade)
 
-
-**/etc/systemd/system/calico-node.service**
-
-```
-ExecStart=/usr/bin/rkt run --inherit-env --stage1-from-dir=stage1-fly.aci \
---volume=modules,kind=host,source=/lib/modules,readOnly=false \
---mount=volume=modules,target=/lib/modules \
---volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true \
---mount=volume=dns,target=/etc/resolv.conf \
---trust-keys-from-https quay.io/calico/node:v0.19.0
-```
+**Note:** If you are running Calico as a systemd service, you will first need to change to a self-hosted install by following [this guide](https://coreos.com/kubernetes/docs/latest/deploy-master.html)
 
 ## Upgrading Master Nodes
 

--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -39,6 +39,14 @@ export CONTAINER_RUNTIME=docker
 # The above settings can optionally be overridden using an environment file:
 ENV_FILE=/run/coreos-kubernetes/options.env
 
+# To run a self hosted Calico install it needs to be able to write to the CNI dir
+if [ "${USE_CALICO}" = "true" ]; then
+    export CALICO_OPTS="--volume cni-bin,kind=host,source=/opt/cni/bin \
+                        --mount volume=cni-bin,target=/opt/cni/bin"
+else
+    export CALICO_OPTS=""
+fi
+
 # -------------
 
 function init_config {
@@ -103,8 +111,10 @@ Environment="RKT_OPTS=--uuid-file-save=${uuid_file} \
   --volume stage,kind=host,source=/tmp \
   --mount volume=stage,target=/tmp \
   --volume var-log,kind=host,source=/var/log \
-  --mount volume=var-log,target=/var/log"
+  --mount volume=var-log,target=/var/log \
+  ${CALICO_OPTS}"
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
+ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
 ExecStartPre=/usr/bin/mkdir -p /var/log/containers
 ExecStartPre=-/usr/bin/rkt rm --uuid-file=${uuid_file}
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
@@ -188,40 +198,6 @@ RequiredBy=kubelet.service
 EOF
     fi
 
-    local TEMPLATE=/etc/systemd/system/calico-node.service
-    if [ "${USE_CALICO}" = "true" ] && [ ! -f "${TEMPLATE}" ]; then
-        echo "TEMPLATE: $TEMPLATE"
-        mkdir -p $(dirname $TEMPLATE)
-        cat << EOF > $TEMPLATE
-[Unit]
-Description=Calico per-host agent
-Requires=network-online.target
-After=network-online.target
-
-[Service]
-Slice=machine.slice
-Environment=CALICO_DISABLE_FILE_LOGGING=true
-Environment=HOSTNAME=${ADVERTISE_IP}
-Environment=IP=${ADVERTISE_IP}
-Environment=FELIX_FELIXHOSTNAME=${ADVERTISE_IP}
-Environment=CALICO_NETWORKING=false
-Environment=NO_DEFAULT_POOLS=true
-Environment=ETCD_ENDPOINTS=${ETCD_ENDPOINTS}
-ExecStart=/usr/bin/rkt run --inherit-env --stage1-from-dir=stage1-fly.aci \
---volume=modules,kind=host,source=/lib/modules,readOnly=false \
---mount=volume=modules,target=/lib/modules \
---volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true \
---mount=volume=dns,target=/etc/resolv.conf \
---trust-keys-from-https quay.io/calico/node:v0.19.0
-KillMode=mixed
-Restart=always
-TimeoutStartSec=0
-
-[Install]
-WantedBy=multi-user.target
-EOF
-    fi
-
     local TEMPLATE=/etc/kubernetes/manifests/kube-proxy.yaml
     if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
@@ -243,6 +219,7 @@ spec:
     - /hyperkube
     - proxy
     - --master=http://127.0.0.1:8080
+    - --cluster-cidr=${POD_NETWORK}
     securityContext:
       privileged: true
     volumeMounts:
@@ -402,55 +379,6 @@ spec:
         port: 10251
       initialDelaySeconds: 15
       timeoutSeconds: 15
-EOF
-    fi
-
-    local TEMPLATE=/etc/kubernetes/manifests/calico-policy-controller.yaml
-    if [ "${USE_CALICO}" = "true" ] && [ ! -f "${TEMPLATE}" ]; then
-        echo "TEMPLATE: $TEMPLATE"
-        mkdir -p $(dirname $TEMPLATE)
-        cat << EOF > $TEMPLATE
-apiVersion: v1
-kind: Pod
-metadata:
-  name: calico-policy-controller
-  namespace: calico-system
-spec:
-  hostNetwork: true
-  containers:
-    # The Calico policy controller.
-    - name: kube-policy-controller
-      image: calico/kube-policy-controller:v0.2.0
-      env:
-        - name: ETCD_ENDPOINTS
-          value: "${ETCD_ENDPOINTS}"
-        - name: K8S_API
-          value: "http://127.0.0.1:8080"
-        - name: LEADER_ELECTION
-          value: "true"
-    # Leader election container used by the policy controller.
-    - name: leader-elector
-      image: quay.io/calico/leader-elector:v0.1.0
-      imagePullPolicy: IfNotPresent
-      args:
-        - "--election=calico-policy-election"
-        - "--election-namespace=calico-system"
-        - "--http=127.0.0.1:4040"
-EOF
-    fi
-
-    local TEMPLATE=/srv/kubernetes/manifests/calico-system.json
-    if [ "${USE_CALICO}" = "true" ] && [ ! -f "${TEMPLATE}" ]; then
-        echo "TEMPLATE: $TEMPLATE"
-        mkdir -p $(dirname $TEMPLATE)
-        cat << EOF > $TEMPLATE
-{
-  "apiVersion": "v1",
-  "kind": "Namespace",
-  "metadata": {
-    "name": "calico-system"
-  }
-}
 EOF
     fi
 
@@ -679,17 +607,17 @@ EOF
         cat << EOF > $TEMPLATE
 kind: Service
 apiVersion: v1
-metadata: 
+metadata:
   name: heapster
   namespace: kube-system
-  labels: 
+  labels:
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "Heapster"
-spec: 
-  ports: 
+spec:
+  ports:
     - port: 80
       targetPort: 8082
-  selector: 
+  selector:
     k8s-app: heapster
 EOF
     fi
@@ -808,29 +736,6 @@ DOCKER_OPT_IPMASQ=""
 EOF
     fi
 
-    local TEMPLATE=/etc/kubernetes/cni/net.d/10-calico.conf
-    if [ "${USE_CALICO}" = "true" ] && [ ! -f "${TEMPLATE}" ]; then
-        echo "TEMPLATE: $TEMPLATE"
-        mkdir -p $(dirname $TEMPLATE)
-        cat << EOF > $TEMPLATE
-{
-    "name": "calico",
-    "type": "flannel",
-    "delegate": {
-        "type": "calico",
-        "etcd_endpoints": "$ETCD_ENDPOINTS",
-        "log_level": "none",
-        "log_level_stderr": "info",
-        "hostname": "${ADVERTISE_IP}",
-        "policy": {
-            "type": "k8s",
-            "k8s_api_root": "http://127.0.0.1:8080/api/v1/"
-        }
-    }
-}
-EOF
-    fi
-
     local TEMPLATE=/etc/kubernetes/cni/net.d/10-flannel.conf
     if [ "${USE_CALICO}" = "false" ] && [ ! -f "${TEMPLATE}" ]; then
         echo "TEMPLATE: $TEMPLATE"
@@ -845,6 +750,199 @@ EOF
 }
 EOF
     fi
+
+    local TEMPLATE=/srv/kubernetes/manifests/calico.yaml
+    if [ "${USE_CALICO}" = "true" ]; then
+    echo "TEMPLATE: $TEMPLATE"
+    mkdir -p $(dirname $TEMPLATE)
+    cat << EOF > $TEMPLATE
+# This ConfigMap is used to configure a self-hosted Calico installation.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-config 
+  namespace: kube-system
+data:
+  # Configure this with the location of your etcd cluster.
+  etcd_endpoints: "${ETCD_ENDPOINTS}"
+
+  # The CNI network configuration to install on each node.  The special
+  # values in this config will be automatically populated.
+  cni_network_config: |-
+    {
+        "name": "calico",
+        "type": "flannel",
+        "delegate": {
+          "type": "calico",
+          "etcd_endpoints": "__ETCD_ENDPOINTS__",
+          "log_level": "info",
+          "policy": {
+              "type": "k8s",
+              "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+              "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+          },
+          "kubernetes": {
+              "kubeconfig": "/etc/kubernetes/cni/net.d/__KUBECONFIG_FILENAME__"
+          }
+        }
+    }
+
+---
+
+# This manifest installs the calico/node container, as well
+# as the Calico CNI plugins and network config on 
+# each master and worker node in a Kubernetes cluster.
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: calico-node
+  namespace: kube-system
+  labels:
+    k8s-app: calico-node
+spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-node
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-node
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+    spec:
+      hostNetwork: true
+      containers:
+        # Runs calico/node container on each Kubernetes node.  This 
+        # container programs network policy and routes on each
+        # host.
+        - name: calico-node
+          image: quay.io/calico/node:v0.23.0
+          env:
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            # Choose the backend to use. 
+            - name: CALICO_NETWORKING_BACKEND
+              value: "none"
+            # Disable file logging so `kubectl logs` works.
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            - name: NO_DEFAULT_POOLS
+              value: "true"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: false
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+            - mountPath: /etc/resolv.conf
+              name: dns
+              readOnly: true
+        # This container installs the Calico CNI binaries
+        # and CNI network config file on each node.
+        - name: install-cni
+          image: quay.io/calico/cni:v1.5.2
+          imagePullPolicy: Always
+          command: ["/install-cni.sh"]
+          env:
+            # CNI configuration filename
+            - name: CNI_CONF_NAME
+              value: "10-calico.conf"
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            # The CNI network config to install on each node.
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: cni_network_config
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+      volumes:
+        # Used by calico/node.
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: var-run-calico
+          hostPath:
+            path: /var/run/calico
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/kubernetes/cni/net.d
+        - name: dns
+          hostPath:
+            path: /etc/resolv.conf
+
+---
+
+# This manifest deploys the Calico policy controller on Kubernetes.
+# See https://github.com/projectcalico/k8s-policy
+apiVersion: extensions/v1beta1
+kind: ReplicaSet 
+metadata:
+  name: calico-policy-controller
+  namespace: kube-system
+  labels:
+    k8s-app: calico-policy
+spec:
+  # The policy controller can only have a single active instance.
+  replicas: 1
+  template:
+    metadata:
+      name: calico-policy-controller
+      namespace: kube-system
+      labels:
+        k8s-app: calico-policy
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+    spec:
+      # The policy controller must run in the host network namespace so that
+      # it isn't governed by policy that would prevent it from working.
+      hostNetwork: true
+      containers:
+        - name: calico-policy-controller
+          image: calico/kube-policy-controller:v0.4.0
+          env:
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            # The location of the Kubernetes API.  Use the default Kubernetes
+            # service for API access.
+            - name: K8S_API
+              value: "https://kubernetes.default:443"
+            # Since we're running in the host namespace and might not have KubeDNS 
+            # access, configure the container's /etc/hosts to resolve
+            # kubernetes.default to the correct service clusterIP.
+            - name: CONFIGURE_ETC_HOSTS
+              value: "true"
+EOF
+    fi
 }
 
 function start_addons {
@@ -853,6 +951,7 @@ function start_addons {
     do
         sleep 5
     done
+
     echo
     echo "K8S: DNS addon"
     curl --silent -H "Content-Type: application/yaml" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-rc.yaml)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
@@ -865,15 +964,17 @@ function start_addons {
     curl --silent -H "Content-Type: application/yaml" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dashboard-svc.yaml)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
 }
 
-function enable_calico_policy {
+function start_calico {
     echo "Waiting for Kubernetes API..."
-    until curl --silent "http://127.0.0.1:8080/version"
+    # wait for the API
+    until curl --silent "http://127.0.0.1:8080/version/"
     do
         sleep 5
     done
-    echo
-    echo "K8S: Calico Policy"
-    curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/calico-system.json)" "http://127.0.0.1:8080/api/v1/namespaces/" > /dev/null
+    echo "Deploying Calico"
+    # Deploy Calico
+    #TODO: change to rkt once this is resolved (https://github.com/coreos/rkt/issues/3181)
+    docker run --rm --net=host -v /srv/kubernetes/manifests:/host/manifests $HYPERKUBE_IMAGE_REPO:$K8S_VER /hyperkube kubectl apply -f /host/manifests/calico.yaml
 }
 
 init_config
@@ -893,11 +994,11 @@ if [ $CONTAINER_RUNTIME = "rkt" ]; then
 fi
 
 systemctl enable flanneld; systemctl start flanneld
+
 systemctl enable kubelet; systemctl start kubelet
 
 if [ $USE_CALICO = "true" ]; then
-        systemctl enable calico-node; systemctl start calico-node
-        enable_calico_policy
+        start_calico
 fi
 
 start_addons

--- a/multi-node/vagrant/Vagrantfile
+++ b/multi-node/vagrant/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.require_version ">= 1.6.0"
 
 $update_channel = "alpha"
 $controller_count = 1
-$controller_vm_memory = 512
+$controller_vm_memory = 1024
 $worker_count = 1
 $worker_vm_memory = 1024
 $etcd_count = 1

--- a/single-node/Vagrantfile
+++ b/single-node/Vagrantfile
@@ -12,6 +12,7 @@ $update_channel = "alpha"
 
 CLUSTER_IP="10.3.0.1"
 NODE_IP = "172.17.4.99"
+NODE_VCPUS = 1
 NODE_MEMORY_SIZE = 2048
 USER_DATA_PATH = File.expand_path("user-data")
 SSL_TARBALL_PATH = File.expand_path("ssl/controller.tar")
@@ -30,7 +31,7 @@ Vagrant.configure("2") do |config|
 
   ["vmware_fusion", "vmware_workstation"].each do |vmware|
     config.vm.provider vmware do |v, override|
-      v.vmx['numvcpus'] = 1
+      v.vmx['numvcpus'] = NODE_VCPUS
       v.vmx['memsize'] = NODE_MEMORY_SIZE
       v.gui = false
 
@@ -39,7 +40,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.provider :virtualbox do |v|
-    v.cpus = 1
+    v.cpus = NODE_VCPUS
     v.gui = false
     v.memory = NODE_MEMORY_SIZE
 
@@ -61,5 +62,5 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision :file, :source => USER_DATA_PATH, :destination => "/tmp/vagrantfile-user-data"
   config.vm.provision :shell, :inline => "mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/", :privileged => true
-
+  
 end

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -36,6 +36,14 @@ export USE_CALICO=false
 # Determines the container runtime for kubernetes to use. Accepts 'docker' or 'rkt'.
 export CONTAINER_RUNTIME=docker
 
+# We need to overwrite this for a hosted Calico install
+if [ "${USE_CALICO}" = "true" ]; then
+    export CALICO_OPTS="--volume cni-bin,kind=host,source=/opt/cni/bin \
+                        --mount volume=cni-bin,target=/opt/cni/bin"
+else
+    export CALICO_OPTS=""
+fi
+
 # -------------
 
 function init_config {
@@ -85,6 +93,7 @@ function init_templates {
         cat << EOF > $TEMPLATE
 [Service]
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
+ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
 Environment=KUBELET_VERSION=${K8S_VER}
 Environment=KUBELET_ACI=${HYPERKUBE_IMAGE_REPO}
 Environment="RKT_OPTS=--uuid-file-save=${uuid_file} \
@@ -97,7 +106,8 @@ Environment="RKT_OPTS=--uuid-file-save=${uuid_file} \
   --volume stage,kind=host,source=/tmp \
   --mount volume=stage,target=/tmp \
   --volume var-log,kind=host,source=/var/log \
-  --mount volume=var-log,target=/var/log"
+  --mount volume=var-log,target=/var/log \
+  ${CALICO_OPTS}"
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
 ExecStartPre=/usr/bin/mkdir -p /var/log/containers
 ExecStartPre=-/usr/bin/rkt rm --uuid-file=${uuid_file}
@@ -177,40 +187,6 @@ RestartSec=10
 
 [Install]
 RequiredBy=kubelet.service
-EOF
-    fi
-
-    local TEMPLATE=/etc/systemd/system/calico-node.service
-    if [ "${USE_CALICO}" = "true" ] && [ ! -f "${TEMPLATE}" ]; then
-        echo "TEMPLATE: $TEMPLATE"
-        mkdir -p $(dirname $TEMPLATE)
-        cat << EOF > $TEMPLATE
-[Unit]
-Description=Calico per-host agent
-Requires=network-online.target
-After=network-online.target
-
-[Service]
-Slice=machine.slice
-Environment=CALICO_DISABLE_FILE_LOGGING=true
-Environment=HOSTNAME=${ADVERTISE_IP}
-Environment=IP=${ADVERTISE_IP}
-Environment=FELIX_FELIXHOSTNAME=${ADVERTISE_IP}
-Environment=CALICO_NETWORKING=false
-Environment=NO_DEFAULT_POOLS=true
-Environment=ETCD_ENDPOINTS=${ETCD_ENDPOINTS}
-ExecStart=/usr/bin/rkt run --inherit-env --stage1-from-dir=stage1-fly.aci \
---volume=modules,kind=host,source=/lib/modules,readOnly=false \
---mount=volume=modules,target=/lib/modules \
---volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true \
---mount=volume=dns,target=/etc/resolv.conf \
---trust-keys-from-https quay.io/calico/node:v0.19.0
-KillMode=mixed
-Restart=always
-TimeoutStartSec=0
-
-[Install]
-WantedBy=multi-user.target
 EOF
     fi
 
@@ -392,56 +368,6 @@ spec:
         port: 10251
       initialDelaySeconds: 15
       timeoutSeconds: 15
-EOF
-    fi
-
-    local TEMPLATE=/etc/kubernetes/manifests/calico-policy-controller.yaml
-    if [ "${USE_CALICO}" = "true" ] && [ ! -f "${TEMPLATE}" ]; then
-        echo "TEMPLATE: $TEMPLATE"
-        mkdir -p $(dirname $TEMPLATE)
-        cat << EOF > $TEMPLATE
-apiVersion: v1
-kind: Pod
-metadata:
-  name: calico-policy-controller
-  namespace: calico-system
-spec:
-  hostNetwork: true
-  containers:
-    # The Calico policy controller.
-    - name: kube-policy-controller
-      image: calico/kube-policy-controller:v0.2.0
-      env:
-        - name: ETCD_ENDPOINTS
-          value: "${ETCD_ENDPOINTS}"
-        - name: K8S_API
-          value: "http://127.0.0.1:8080"
-        - name: LEADER_ELECTION
-          value: "true"
-    # Leader election container used by the policy controller.
-    - name: leader-elector
-      image: quay.io/calico/leader-elector:v0.1.0
-      imagePullPolicy: IfNotPresent
-      args:
-        - "--election=calico-policy-election"
-        - "--election-namespace=calico-system"
-        - "--http=127.0.0.1:4040"
-
-EOF
-    fi
-
-    local TEMPLATE=/srv/kubernetes/manifests/calico-system.json
-    if [ ! -f $TEMPLATE ]; then
-        echo "TEMPLATE: $TEMPLATE"
-        mkdir -p $(dirname $TEMPLATE)
-        cat << EOF > $TEMPLATE
-{
-  "apiVersion": "v1",
-  "kind": "Namespace",
-  "metadata": {
-    "name": "calico-system"
-  }
-}
 EOF
     fi
 
@@ -799,29 +725,6 @@ DOCKER_OPT_IPMASQ=""
 EOF
     fi
 
-    local TEMPLATE=/etc/kubernetes/cni/net.d/10-calico.conf
-    if [ "${USE_CALICO}" = "true" ] && [ ! -f "${TEMPLATE}" ]; then
-        echo "TEMPLATE: $TEMPLATE"
-        mkdir -p $(dirname $TEMPLATE)
-        cat << EOF > $TEMPLATE
-{
-    "name": "calico",
-    "type": "flannel",
-    "delegate": {
-        "type": "calico",
-        "etcd_endpoints": "$ETCD_ENDPOINTS",
-        "log_level": "none",
-        "log_level_stderr": "info",
-        "hostname": "${ADVERTISE_IP}",
-        "policy": {
-            "type": "k8s",
-            "k8s_api_root": "http://127.0.0.1:8080/api/v1/"
-        }
-    }
-}
-EOF
-    fi
-
     local TEMPLATE=/etc/kubernetes/cni/net.d/10-flannel.conf
     if [ "${USE_CALICO}" = "false" ] && [ ! -f "${TEMPLATE}" ]; then
         echo "TEMPLATE: $TEMPLATE"
@@ -834,6 +737,198 @@ EOF
         "isDefaultGateway": true
     }
 }
+EOF
+    fi
+    local TEMPLATE=/etc/kubernetes/manifests/calico.yaml
+    if [ "${USE_CALICO}" = "true" ]; then
+    echo "TEMPLATE: $TEMPLATE"
+    mkdir -p $(dirname $TEMPLATE)
+    cat << EOF > $TEMPLATE
+# This ConfigMap is used to configure a self-hosted Calico installation.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-config 
+  namespace: kube-system
+data:
+  # Configure this with the location of your etcd cluster.
+  etcd_endpoints: "${ETCD_ENDPOINTS}"
+
+  # The CNI network configuration to install on each node.  The special
+  # values in this config will be automatically populated.
+  cni_network_config: |-
+    {
+        "name": "calico",
+        "type": "flannel",
+        "delegate": {
+          "type": "calico",
+          "etcd_endpoints": "__ETCD_ENDPOINTS__",
+          "log_level": "info",
+          "policy": {
+              "type": "k8s",
+              "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+              "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+          },
+          "kubernetes": {
+              "kubeconfig": "/etc/kubernetes/cni/net.d/__KUBECONFIG_FILENAME__"
+          }
+        }
+    }
+
+---
+
+# This manifest installs the calico/node container, as well
+# as the Calico CNI plugins and network config on 
+# each master and worker node in a Kubernetes cluster.
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: calico-node
+  namespace: kube-system
+  labels:
+    k8s-app: calico-node
+spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-node
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-node
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+    spec:
+      hostNetwork: true
+      containers:
+        # Runs calico/node container on each Kubernetes node.  This 
+        # container programs network policy and routes on each
+        # host.
+        - name: calico-node
+          image: quay.io/calico/node:v0.23.0
+          env:
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            # Choose the backend to use. 
+            - name: CALICO_NETWORKING_BACKEND
+              value: "none"
+            # Disable file logging so `kubectl logs` works.
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            - name: NO_DEFAULT_POOLS
+              value: "true"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: false
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+            - mountPath: /etc/resolv.conf
+              name: dns
+              readOnly: true
+        # This container installs the Calico CNI binaries
+        # and CNI network config file on each node.
+        - name: install-cni
+          image: quay.io/calico/cni:v1.5.2
+          imagePullPolicy: Always
+          command: ["/install-cni.sh"]
+          env:
+            # CNI configuration filename
+            - name: CNI_CONF_NAME
+              value: "10-calico.conf"
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            # The CNI network config to install on each node.
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: cni_network_config
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+      volumes:
+        # Used by calico/node.
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: var-run-calico
+          hostPath:
+            path: /var/run/calico
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/kubernetes/cni/net.d
+        - name: dns
+          hostPath:
+            path: /etc/resolv.conf
+
+---
+
+# This manifest deploys the Calico policy controller on Kubernetes.
+# See https://github.com/projectcalico/k8s-policy
+apiVersion: extensions/v1beta1
+kind: ReplicaSet 
+metadata:
+  name: calico-policy-controller
+  namespace: kube-system
+  labels:
+    k8s-app: calico-policy
+spec:
+  # The policy controller can only have a single active instance.
+  replicas: 1
+  template:
+    metadata:
+      name: calico-policy-controller
+      namespace: kube-system
+      labels:
+        k8s-app: calico-policy
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+    spec:
+      # The policy controller must run in the host network namespace so that
+      # it isn't governed by policy that would prevent it from working.
+      hostNetwork: true
+      containers:
+        - name: calico-policy-controller
+          image: calico/kube-policy-controller:v0.4.0
+          env:
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            # The location of the Kubernetes API.  Use the default Kubernetes
+            # service for API access.
+            - name: K8S_API
+              value: "https://kubernetes.default:443"
+            # Since we're running in the host namespace and might not have KubeDNS 
+            # access, configure the container's /etc/hosts to resolve
+            # kubernetes.default to the correct service clusterIP.
+            - name: CONFIGURE_ETC_HOSTS
+              value: "true"
 EOF
     fi
 }
@@ -856,15 +951,15 @@ function start_addons {
     curl --silent -H "Content-Type: application/yaml" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dashboard-svc.yaml)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
 }
 
-function enable_calico_policy {
+function enable_calico {
     echo "Waiting for Kubernetes API..."
     until curl --silent "http://127.0.0.1:8080/version"
     do
         sleep 5
     done
-    echo
-    echo "K8S: Calico Policy"
-    curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/calico-system.json)" "http://127.0.0.1:8080/api/v1/namespaces/" > /dev/null
+    echo "Deploying Calico"
+    #TODO: change to rkt once this is resolved (https://github.com/coreos/rkt/issues/3181)
+    docker run --rm --net=host -v /srv/kubernetes/manifests:/host/manifests $HYPERKUBE_IMAGE_REPO:$K8S_VER /hyperkube kubectl apply -f /host/manifests/calico.yaml
 }
 
 init_config
@@ -888,8 +983,7 @@ systemctl enable flanneld; systemctl start flanneld
 systemctl enable kubelet; systemctl start kubelet
 
 if [ $USE_CALICO = "true" ]; then
-        systemctl enable calico-node; systemctl start calico-node
-        enable_calico_policy
+        enable_calico
 fi
 
 start_addons


### PR DESCRIPTION
In order to get the hosted intall to work we had to make some changes to the deployment, the most disruptive being that we need to write to the hyperkubes `/opt/cni/bin` directory, so when Calico is enabled we mount that directory to the host.  Our calico/cni:v1.5.2 image deploys flannel, host-local, and loopback CNI binaries alongside the calico binaries.

Some other minor changes were:
- adding the pod-cidr to the proxy pods to get around some issues with Vagrant networking
- We use docker to run hyperkube with kubectl to deploy the calico.yaml manifest
- Removed all systemd Calico configuration
- Using one CNI conf for all nodes
- Vagrant files needed some touching as the VMs needed a bit more CPU/memory

We will want to update the remaining docs to use the same changes, but I wanted this reviewed before going through that process.