### PR TITLE
fix cn bug when generating tls assets using OpenSSL

### DIFF
--- a/Documentation/openssl.md
+++ b/Documentation/openssl.md
@@ -34,7 +34,7 @@ First, we need to create a new certificate authority which will be used to sign 
 
 ```sh
 $ openssl genrsa -out ca-key.pem 2048
-$ openssl req -x509 -new -nodes -key ca-key.pem -days 10000 -out ca.pem -subj "/CN=kube-ca"
+$ openssl req -x509 -new -nodes -key ca-key.pem -days 10000 -out ca.pem -subj "/CN={MASTER_HOST}"
 ```
 
 **You need to store the CA keypair in a secure location for future use.**
@@ -84,7 +84,7 @@ Using the above `openssl.cnf`, create the api-server keypair:
 
 ```sh
 $ openssl genrsa -out apiserver-key.pem 2048
-$ openssl req -new -key apiserver-key.pem -out apiserver.csr -subj "/CN=kube-apiserver" -config openssl.cnf
+$ openssl req -new -key apiserver-key.pem -out apiserver.csr -subj "/CN=${MASTER_HOST}" -config openssl.cnf
 $ openssl x509 -req -in apiserver.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out apiserver.pem -days 365 -extensions v3_req -extfile openssl.cnf
 ```
 
@@ -125,7 +125,7 @@ $ WORKER_IP=${WORKER_IP} openssl x509 -req -in ${WORKER_FQDN}-worker.csr -CA ca.
 
 ```sh
 $ openssl genrsa -out admin-key.pem 2048
-$ openssl req -new -key admin-key.pem -out admin.csr -subj "/CN=kube-admin"
+$ openssl req -new -key admin-key.pem -out admin.csr -subj "/CN=${KUBE_ADMIN}"
 $ openssl x509 -req -in admin.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out admin.pem -days 365
 ```
 


### PR DESCRIPTION
These hostnames should be explicitly shown to avoid potential misunderstandings.