### PR TITLE
allow creating devices to be mounted by pods

### DIFF
--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,0 +1,1 @@
+.virtualbox/

--- a/lib/volume.rb
+++ b/lib/volume.rb
@@ -1,0 +1,88 @@
+def get_provider
+  provider_index = ARGV.index('--provider')
+  if (provider_index && ARGV[provider_index + 1])
+     return ARGV[provider_index + 1]
+  elsif ARGV.index('--provider=lxc')
+     return "lxc"
+  end
+  return ENV['VAGRANT_DEFAULT_PROVIDER'] || 'virtualbox'
+end
+
+$provider = get_provider().to_sym
+
+class VagrantPlugins::ProviderVirtualBox::Action::SetName
+  alias_method :original_call, :call
+  def call(env)
+    machine = env[:machine]
+    driver = machine.provider.driver
+    uuid = driver.instance_eval { @uuid }
+    ui = env[:ui]
+
+    controller_name="SATA Controller"
+
+    vm_info = driver.execute("showvminfo", uuid)
+    controller_already_exists = vm_info.match("Storage Controller Name.*#{controller_name}")
+
+    if controller_already_exists
+      ui.info "already has the #{controller_name} hdd controller, skipping creation/add"
+    else
+      ui.info "creating #{controller_name} hdd controller"
+      driver.execute(
+        'storagectl',
+        uuid,
+        '--name', "#{controller_name}",
+        '--add', 'sata',
+        '--controller', 'IntelAHCI')
+    end
+
+    original_call(env)
+  end
+end
+
+# Add persistent storage volumes
+def attach_volumes(node, num_volumes, volume_size)
+  if $provider == :virtualbox
+    node.vm.provider :virtualbox do |v, override|
+      (1..num_volumes).each do |disk|
+        diskname = File.join(File.dirname(File.expand_path(__FILE__)), ".virtualbox", "#{node.vm.hostname}-#{disk}.vdi")
+        unless File.exist?(diskname)
+          v.customize ['createhd', '--filename', diskname, '--size', volume_size * 1024]
+        end
+        v.customize ['storageattach', :id, '--storagectl', 'SATA Controller', '--port', disk, '--device', 0, '--type', 'hdd', '--medium', diskname]
+      end
+    end
+  end
+
+  if $provider == :vmware_fusion
+    node.vm.provider :vmware_fusion do |v, override|
+      vdiskmanager = '/Applications/VMware\ Fusion.app/Contents/Library/vmware-vdiskmanager'
+      unless File.exist?(vdiskmanager)
+        dir = File.join(File.dirname(File.expand_path(__FILE__)), ".vmware")
+        unless File.directory?( dir )
+          Dir.mkdir dir
+        end
+
+        (1..num_volumes).each do |disk|
+          diskname = File.join(dir, "#{node.vm.hostname}-#{disk}.vmdk")
+          unless File.exist?(diskname)
+            `#{vdiskmanager} -c -s #{volume_size}GB -a lsilogic -t 1 #{diskname}`
+          end
+
+          v.vmx["scsi0:#{disk}.filename"] = diskname
+          v.vmx["scsi0:#{disk}.present"] = 'TRUE'
+          v.vmx["scsi0:#{disk}.redo"] = ''
+        end
+      end
+    end
+  end
+
+  if $provider == :parallels
+    node.vm.provider :parallels do |v, override|
+      (1..num_volumes).each do |disk|
+        v.customize ['set', :id, '--device-add', 'hdd', '--size', volume_size * 1024]
+      end
+    end
+  end
+
+end
+

--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -112,6 +112,10 @@ Environment="RKT_OPTS=--uuid-file-save=${uuid_file} \
   --mount volume=stage,target=/tmp \
   --volume var-log,kind=host,source=/var/log \
   --mount volume=var-log,target=/var/log \
+  --volume modprobe,kind=host,source=/usr/sbin/modprobe \
+  --mount volume=modprobe,target=/usr/sbin/modprobe \
+  --volume lib-modules,kind=host,source=/lib/modules \
+  --mount volume=lib-modules,target=/lib/modules \
   ${CALICO_OPTS}"
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
 ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin

--- a/multi-node/generic/worker-install.sh
+++ b/multi-node/generic/worker-install.sh
@@ -83,6 +83,10 @@ Environment="RKT_OPTS=--uuid-file-save=${uuid_file} \
   --mount volume=stage,target=/tmp \
   --volume var-log,kind=host,source=/var/log \
   --mount volume=var-log,target=/var/log \
+  --volume modprobe,kind=host,source=/usr/sbin/modprobe \
+  --mount volume=modprobe,target=/usr/sbin/modprobe \
+  --volume lib-modules,kind=host,source=/lib/modules \
+  --mount volume=lib-modules,target=/lib/modules \
   ${CALICO_OPTS}"
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
 ExecStartPre=/usr/bin/mkdir -p /var/log/containers

--- a/multi-node/vagrant/Vagrantfile
+++ b/multi-node/vagrant/Vagrantfile
@@ -5,6 +5,7 @@ require 'fileutils'
 require 'open-uri'
 require 'tempfile'
 require 'yaml'
+require_relative '../../lib/volume.rb'
 
 Vagrant.require_version ">= 1.6.0"
 
@@ -15,6 +16,8 @@ $worker_count = 1
 $worker_vm_memory = 1024
 $etcd_count = 1
 $etcd_vm_memory = 512
+$disks_per_node = 0
+$disk_size = 5
 
 CONFIG = File.expand_path("config.rb")
 if File.exist?(CONFIG)
@@ -153,6 +156,8 @@ Vagrant.configure("2") do |config|
       controllerIP = controllerIP(i)
       controller.vm.network :private_network, ip: controllerIP
 
+      attach_volumes(controller, $disks_per_node, $disk_size)
+
       # Each controller gets the same cert
       provisionMachineSSL(controller,"apiserver","kube-apiserver-#{controllerIP}",controllerIPs)
 
@@ -185,6 +190,8 @@ Vagrant.configure("2") do |config|
 
       workerIP = workerIP(i)
       worker.vm.network :private_network, ip: workerIP
+
+      attach_volumes(worker, $disks_per_node, $disk_size)
 
       provisionMachineSSL(worker,"worker","kube-worker-#{workerIP}",[workerIP])
 

--- a/single-node/Vagrantfile
+++ b/single-node/Vagrantfile
@@ -5,6 +5,7 @@ require 'fileutils'
 require 'open-uri'
 require 'tempfile'
 require 'yaml'
+require_relative '../lib/volume.rb'
 
 Vagrant.require_version ">= 1.6.0"
 
@@ -16,6 +17,8 @@ NODE_VCPUS = 1
 NODE_MEMORY_SIZE = 2048
 USER_DATA_PATH = File.expand_path("user-data")
 SSL_TARBALL_PATH = File.expand_path("ssl/controller.tar")
+$disks_per_node = 0
+$disk_size = 5
 
 system("mkdir -p ssl && ./../lib/init-ssl-ca ssl") or abort ("failed generating SSL CA artifacts")
 system("./../lib/init-ssl ssl apiserver controller IP.1=#{NODE_IP},IP.2=#{CLUSTER_IP}") or abort ("failed generating SSL certificate artifacts")
@@ -56,6 +59,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.network :private_network, ip: NODE_IP
+  attach_volumes(config, $disks_per_node, $disk_size)
 
   config.vm.provision :file, :source => SSL_TARBALL_PATH, :destination => "/tmp/ssl.tar"
   config.vm.provision :shell, :inline => "mkdir -p /etc/kubernetes/ssl && tar -C /etc/kubernetes/ssl -xf /tmp/ssl.tar", :privileged => true

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -107,6 +107,10 @@ Environment="RKT_OPTS=--uuid-file-save=${uuid_file} \
   --mount volume=stage,target=/tmp \
   --volume var-log,kind=host,source=/var/log \
   --mount volume=var-log,target=/var/log \
+  --volume modprobe,kind=host,source=/usr/sbin/modprobe \
+  --mount volume=modprobe,target=/usr/sbin/modprobe \
+  --volume lib-modules,kind=host,source=/lib/modules \
+  --mount volume=lib-modules,target=/lib/modules \
   ${CALICO_OPTS}"
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
 ExecStartPre=/usr/bin/mkdir -p /var/log/containers


### PR DESCRIPTION
Enable creation of storage devices in the vagrant environment so storage can be mounted by pods running in the cluster. By default no storage devices will be created. To create devices, the value of disks_per_node must be set to non-zero. For example, this will create two per node. By default the size of each is 5GB.
$disks_per_node=2
$disk_size = 5