### PR TITLE
Add Parallels support to Vagrantfile

### DIFF
--- a/single-node/Vagrantfile
+++ b/single-node/Vagrantfile
@@ -39,6 +39,13 @@ Vagrant.configure("2") do |config|
     end
   end
 
+  config.vm.provider "parallels" do |prl, override|
+    prl.cpus = NODE_VCPUS
+    prl.memory = NODE_MEMORY_SIZE
+    override.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant_parallels.json" % $update_channel
+  end
+
+
   config.vm.provider :virtualbox do |v|
     v.cpus = NODE_VCPUS
     v.gui = false


### PR DESCRIPTION
Most of the main hypervisors where covered in the Vagrantfile except Parallels and there are Parallels images in https://alpha.release.core-os.net/amd64-usr/current/coreos_production_vagrant_parallels.json so why not enable them? 

