### PR TITLE
change calico.yaml path from /etc to /srv

### DIFF
--- a/single-node/user-data
+++ b/single-node/user-data
@@ -808,7 +808,7 @@ EOF
 }
 EOF
     fi
-    local TEMPLATE=/etc/kubernetes/manifests/calico.yaml
+    local TEMPLATE=/srv/kubernetes/manifests/calico.yaml
     if [ "${USE_CALICO}" = "true" ]; then
     echo "TEMPLATE: $TEMPLATE"
     mkdir -p $(dirname $TEMPLATE)


### PR DESCRIPTION
single-node/user-data: The calico.yaml needs to be created at /srv/kubernetes/manifests/calico.yaml instead of /etc/kubernetes/manifests/calico.yaml.

This is needed for the command `docker run --rm --net=host -v /srv/kubernetes/manifests:/host/manifests $HYPERKUBE_IMAGE_REPO:$K8S_VER /hyperkube kubectl apply -f /host/manifests/calico.yaml` to work. Without this change the above command fails and calico is not setup properly, and networking doesn't work at all.

