### PR TITLE
Use var instead of predefined value.

### DIFF
--- a/Documentation/deploy-workers.md
+++ b/Documentation/deploy-workers.md
@@ -136,7 +136,7 @@ ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=${MASTER_HOST} \
   --cni-conf-dir=/etc/kubernetes/cni/net.d \
-  --network-plugin=cni \
+  --network-plugin=${NETWORK_PLUGIN} \
   --container-runtime=docker \
   --register-node=true \
   --allow-privileged=true \


### PR DESCRIPTION
In the docs are specified to use the var ${NETWORK_PLUGIN} if you use calico. I guess that if you use flanneld you must leave that field blank instead of use the default value "cni".

"* If using Calico for network policy
  - Replace `${NETWORK_PLUGIN}` with `cni`"