### PR TITLE
missing ports for master

### DIFF
--- a/Documentation/kubernetes-networking.md
+++ b/Documentation/kubernetes-networking.md
@@ -26,6 +26,8 @@ Master Node Inbound
 | Protocol | Port Range | Source                                    | Purpose                |
 -----------|------------|-------------------------------------------|------------------------|
 | TCP      | 443        | Worker Nodes, API Requests, and End-Users | Kubernetes API server. |
+| UDP      | 8285       | Master & Worker Nodes                   | flannel overlay network - *udp backend*. This is the default network configuration (only required if using flannel) |
+| UDP      | 8472       | Master & Worker Nodes                   | flannel overlay network - *vxlan backend* (only required if using flannel) |
 
 Worker Node Inbound
 
@@ -34,8 +36,8 @@ Worker Node Inbound
 | TCP      | 10250       | Master Nodes                   | Worker node Kubelet healthcheck port.                                  |
 | TCP      | 30000-32767 | External Application Consumers | Default port range for [external service][external-service] ports. Typically, these ports would need to be exposed to external load-balancers, or other external consumers of the application itself. |
 | TCP      | ALL         | Master & Worker Nodes          | Intra-cluster communication (unnecessary if `vxlan` is used for networking)           |
-| UDP      | 8285        | Worker Nodes                   | flannel overlay network - *udp backend*. This is the default network configuration (only required if using flannel) |
-| UDP      | 8472        | Worker Nodes                   | flannel overlay network - *vxlan backend* (only required if using flannel) |
+| UDP      | 8285        | Master & Worker Nodes                   | flannel overlay network - *udp backend*. This is the default network configuration (only required if using flannel) |
+| UDP      | 8472        | Master & Worker Nodes                   | flannel overlay network - *vxlan backend* (only required if using flannel) |
 | TCP      | 179         | Worker Nodes                   | Calico BGP network (only required if the BGP backend is used) |
 
 etcd Node Inbound


### PR DESCRIPTION
those ports have to be open on the master as well. otherwise things like kube-proxy+dashboard wont work.