### PR TITLE
Update deploy-workers.md

### DIFF
--- a/Documentation/deploy-workers.md
+++ b/Documentation/deploy-workers.md
@@ -134,7 +134,7 @@ ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
 ExecStartPre=/usr/bin/mkdir -p /var/log/containers
 ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
-  --api-servers=${MASTER_HOST} \
+  --api-servers=https://${MASTER_HOST} \
   --cni-conf-dir=/etc/kubernetes/cni/net.d \
   --network-plugin=cni \
   --container-runtime=docker \


### PR DESCRIPTION
The worker nodes cannot communicate with the api server over port 80. The '--api-servers=' parameter must be prefixed with 'https://'.