### PR TITLE
flannel-wrapper does not support RKT_OPTS

### DIFF
--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -143,7 +143,7 @@ Note that the kubelet running on a master node may log repeated attempts to post
 ```yaml
 [Service]
 Environment=KUBELET_VERSION=${K8S_VER}
-Environment="RKT_OPTS=--uuid-file-save=/var/run/kubelet-pod.uuid \
+Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid \
   --volume var-log,kind=host,source=/var/log \
   --mount volume=var-log,target=/var/log \
   --volume dns,kind=host,source=/etc/resolv.conf \


### PR DESCRIPTION
`RKT_OPTS` was deprecated in favour of `RKT_RUN_ARGS` in CoreOS CL 1214.0.0 for `kubelet-wrapper` and never existed for flannel-wrapper. Unlike the other wrapper scripts (`etcd-wrapper` and `kubelet-wrapper`), `flannel-wrapper` does not support a fallback from `RKT_OPTS` to `RKT_RUN_ARGS`. The summary of the commit is thus slightly wrong.