### PR TITLE
Retain IP address assignments on reboot or kubelet restarts

### DIFF
--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -128,10 +128,13 @@ Note that the kubelet running on a master node may log repeated attempts to post
   - Replace `${NETWORK_PLUGIN}` with `cni`
   - Add the following to `RKT_OPS=`
     ```
+    --volume cni-lib,kind=host,source=/var/lib/cni \
+    --mount volume=cni-lib,target=/var/lib/cni \
     --volume cni-bin,kind=host,source=/opt/cni/bin \
     --mount volume=cni-bin,target=/opt/cni/bin
     ```
   - Add `ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin`
+  - Add `ExecStartPre=/usr/bin/mkdir -p /var/lib/cni`
 * Decide if you will use [additional features][rkt-opts-examples] such as:
   - [mounting ephemeral disks][mount-disks]
   - [allow pods to mount RDB][rdb] or [iSCSI volumes][iscsi]

--- a/Documentation/deploy-workers.md
+++ b/Documentation/deploy-workers.md
@@ -110,10 +110,13 @@ Create `/etc/systemd/system/kubelet.service` and substitute the following variab
   - Replace `${NETWORK_PLUGIN}` with `cni`
   - Add the following to `RKT_OPS=`
     ```
+    --volume cni-lib,kind=host,source=/var/lib/cni \
+    --mount volume=cni-lib,target=/var/lib/cni \
     --volume cni-bin,kind=host,source=/opt/cni/bin \
     --mount volume=cni-bin,target=/opt/cni/bin
     ```
   - Add `ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin`
+  - Add `ExecStartPre=/usr/bin/mkdir -p /var/lib/cni`
 * Decide if you will use [additional features][rkt-opts-examples] such as:
   - [mounting ephemeral disks][mount-disks]
   - [allow pods to mount RDB][rdb] or [iSCSI volumes][iscsi]


### PR DESCRIPTION
This will prevent from assigning the same IP addresses to new pods after node reboot or kubelet restart.

See https://github.com/coreos/kube-aws/pull/64/files and https://github.com/coreos/kube-aws/issues/60 for more details.