### PR TITLE
"hostNetwork: true mentioned twice"

### DIFF
--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -325,7 +325,6 @@ spec:
     - mountPath: /etc/ssl/certs
       name: ssl-certs-host
       readOnly: true
-  hostNetwork: true
   volumes:
   - hostPath:
       path: /etc/kubernetes/ssl


### PR DESCRIPTION
 "hostNetwork: true" mentioned twice in Kube controller manager static pod manifest. (duplicate key)