### PR TITLE
kubelet: document that 10250 shouldn't be exposed

### DIFF
--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -138,6 +138,8 @@ Note that the kubelet running on a master node may log repeated attempts to post
   - [allowing access to insecure container registries][insecure-registry]
   - [changing your CoreOS auto-update settings][update]
 
+**Note**: Anyone with access to port 10250 on a node can execute arbitrary code in a pod on the node. Information, including logs and metadata, is also disclosed on port 10255. See [securing the Kubelet API][securing-kubelet-api] for more information.
+
 **/etc/systemd/system/kubelet.service**
 
 ```yaml
@@ -671,3 +673,4 @@ kube-proxy-$node
 [mount-disks]: https://coreos.com/os/docs/latest/mounting-storage.html
 [insecure-registry]: https://coreos.com/os/docs/latest/registry-authentication.html#using-a-registry-without-ssl-configured
 [update]: https://coreos.com/os/docs/latest/switching-channels.html
+[securing-kubelet-api]: kubelet-wrapper.md#Securing-the-Kubelet-API

--- a/Documentation/deploy-workers.md
+++ b/Documentation/deploy-workers.md
@@ -120,6 +120,8 @@ Create `/etc/systemd/system/kubelet.service` and substitute the following variab
   - [allowing access to insecure container registries][insecure-registry]
   - [changing your CoreOS auto-update settings][update]
 
+**Note**: Anyone with access to port 10250 on a node can execute arbitrary code in a pod on the node. Information, including logs and metadata, is also disclosed on port 10255. See [securing the Kubelet API][securing-kubelet-api] for more information.
+
 **/etc/systemd/system/kubelet.service**
 
 ```yaml
@@ -274,3 +276,4 @@ To check the health of the kubelet systemd unit that we created, run `systemctl 
 [mount-disks]: https://coreos.com/os/docs/latest/mounting-storage.html
 [insecure-registry]: https://coreos.com/os/docs/latest/registry-authentication.html#using-a-registry-without-ssl-configured
 [update]: https://coreos.com/os/docs/latest/switching-channels.html
+[securing-kubelet-api]: kubelet-wrapper.md#Securing-the-Kubelet-API

--- a/Documentation/kubelet-wrapper.md
+++ b/Documentation/kubelet-wrapper.md
@@ -87,6 +87,17 @@ Environment="RKT_OPTS=--volume modprobe,kind=host,source=/usr/sbin/modprobe \
 
 Note that the kubelet also requires access to the userspace `rbd` tool that is included only in hyperkube images tagged `v1.3.6_coreos.0` or later.
 
+### Securing the Kubelet API
+
+By default, the Kubelet allows unauthenticated access to its [API ports][kubernetes-ports].
+
+In order to secure your Kubernetes cluster, you **must** either:
+
+1. Avoid exposing the Kubelet API to the internet, and trust all software with access to it (including every pod run on your cluster), or
+2. Turn on [Kubelet authentication][kubelet-authn-authz].
+
+The Kubernetes documentation on [Master -> Cluster communication][master-cluster-communication] provides more information and details solutions.
+
 ## Manual deployment
 
 If you wish to use the kubelet-wrapper on a CoreOS version prior to 962.0.0, you can manually place the script on the host. Please note that this requires rkt version 0.15.0+.
@@ -111,3 +122,6 @@ ExecStart=/opt/bin/kubelet-wrapper \
 [#2141]: https://github.com/coreos/rkt/issues/2141
 [kubelet-wrapper]: https://github.com/coreos/coreos-overlay/blob/master/app-admin/kubelet-wrapper/files/kubelet-wrapper
 [rbd-example]: https://github.com/kubernetes/kubernetes/tree/master/examples/volumes/rbd
+[kubernetes-ports]: https://github.com/kubernetes/kubernetes/tree/master/examples/volumes/rbd
+[kubelet-authn-authz]: https://kubernetes.io/docs/admin/kubelet-authentication-authorization/ 
+[master-cluster-communication]: https://kubernetes.io/docs/admin/master-node-communication/#master---cluster

--- a/Documentation/kubernetes-networking.md
+++ b/Documentation/kubernetes-networking.md
@@ -31,7 +31,8 @@ Worker Node Inbound
 
 | Protocol | Port Range  | Source                         | Purpose                                                                |
 -----------|-------------|--------------------------------|------------------------------------------------------------------------|
-| TCP      | 10250       | Master Nodes                   | Worker node Kubelet healthcheck port.                                  |
+| TCP      | 10250       | Master Nodes                   | Worker node Kubelet API for exec and logs.                                  |
+| TCP      | 10255       | Heapster                       | Worker node read-only Kubelet API.                                  |
 | TCP      | 30000-32767 | External Application Consumers | Default port range for [external service][external-service] ports. Typically, these ports would need to be exposed to external load-balancers, or other external consumers of the application itself. |
 | TCP      | ALL         | Master & Worker Nodes          | Intra-cluster communication (unnecessary if `vxlan` is used for networking)           |
 | UDP      | 8285        | Worker Nodes                   | flannel overlay network - *udp backend*. This is the default network configuration (only required if using flannel) |


### PR DESCRIPTION
Fixes #656

I'll file a followup to document the details of actually enabling kubelet authn/authz... but knowing is half the battle so we should have the note there until we have better docs.