### PR TITLE
Retain IP addresses of pods on node reboot or kubelet restart

### DIFF
--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -128,6 +128,8 @@ Note that the kubelet running on a master node may log repeated attempts to post
   - Replace `${NETWORK_PLUGIN}` with `cni`
   - Add the following to `RKT_OPS=`
     ```
+    --volume cni-lib,kind=host,source=/var/lib/cni \
+    --mount volume=cni-lib,target=/var/lib/cni \
     --volume cni-bin,kind=host,source=/opt/cni/bin \
     --mount volume=cni-bin,target=/opt/cni/bin
     ```

--- a/Documentation/deploy-workers.md
+++ b/Documentation/deploy-workers.md
@@ -110,6 +110,8 @@ Create `/etc/systemd/system/kubelet.service` and substitute the following variab
   - Replace `${NETWORK_PLUGIN}` with `cni`
   - Add the following to `RKT_OPS=`
     ```
+    --volume cni-lib,kind=host,source=/var/lib/cni \
+    --mount volume=cni-lib,target=/var/lib/cni \
     --volume cni-bin,kind=host,source=/opt/cni/bin \
     --mount volume=cni-bin,target=/opt/cni/bin
     ```


### PR DESCRIPTION
This will prevent from assigning the same IP addresses to new pods after node reboot or kubelet restart.

See https://github.com/coreos/kube-aws/pull/64/files and https://github.com/coreos/kube-aws/issues/60 for more details.