### PR TITLE
Correct some docs variables

### DIFF
--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -126,7 +126,7 @@ Note that the kubelet running on a master node may log repeated attempts to post
 * Replace `${K8S_VER}` This will map to: `quay.io/coreos/hyperkube:${K8S_VER}` release, e.g. `v1.5.3_coreos.0`.
 * If using Calico for network policy
   - Replace `${NETWORK_PLUGIN}` with `cni`
-  - Add the following to `RKT_OPS=`
+  - Add the following to `RKT_RUN_ARGS=`
     ```
     --volume cni-bin,kind=host,source=/opt/cni/bin \
     --mount volume=cni-bin,target=/opt/cni/bin
@@ -144,8 +144,8 @@ Note that the kubelet running on a master node may log repeated attempts to post
 
 ```yaml
 [Service]
-Environment=KUBELET_VERSION=${K8S_VER}
-Environment="RKT_OPTS=--uuid-file-save=/var/run/kubelet-pod.uuid \
+Environment=KUBELET_IMAGE_TAG=${K8S_VER}
+Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid \
   --volume var-log,kind=host,source=/var/log \
   --mount volume=var-log,target=/var/log \
   --volume dns,kind=host,source=/etc/resolv.conf \

--- a/Documentation/deploy-workers.md
+++ b/Documentation/deploy-workers.md
@@ -108,7 +108,7 @@ Create `/etc/systemd/system/kubelet.service` and substitute the following variab
 * Replace `${K8S_VER}` This will map to: `quay.io/coreos/hyperkube:${K8S_VER}` release, e.g. `v1.5.3_coreos.0`.
 * If using Calico for network policy
   - Replace `${NETWORK_PLUGIN}` with `cni`
-  - Add the following to `RKT_OPS=`
+  - Add the following to `RKT_RUN_ARGS=`
     ```
     --volume cni-bin,kind=host,source=/opt/cni/bin \
     --mount volume=cni-bin,target=/opt/cni/bin
@@ -126,8 +126,8 @@ Create `/etc/systemd/system/kubelet.service` and substitute the following variab
 
 ```yaml
 [Service]
-Environment=KUBELET_VERSION=${K8S_VER}
-Environment="RKT_OPTS=--uuid-file-save=/var/run/kubelet-pod.uuid \
+Environment=KUBELET_IMAGE_TAG=${K8S_VER}
+Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid \
   --volume dns,kind=host,source=/etc/resolv.conf \
   --mount volume=dns,target=/etc/resolv.conf \
   --volume var-log,kind=host,source=/var/log \

--- a/Documentation/kubelet-wrapper.md
+++ b/Documentation/kubelet-wrapper.md
@@ -19,8 +19,8 @@ An example systemd kubelet.service file which takes advantage of the kubelet-wra
 
 ```ini
 [Service]
-Environment=KUBELET_VERSION=v1.5.3_coreos.0
-Environment="RKT_OPTS=--uuid-file-save=/var/run/kubelet-pod.uuid"
+Environment=KUBELET_IMAGE_TAG=v1.5.3_coreos.0
+Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid"
 ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=http://127.0.0.1:8080 \
@@ -28,11 +28,11 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
 ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
 ```
 
-In the example above we set the `KUBELET_VERSION` and the kubelet-wrapper script takes care of running the correct container image with our desired API server address and manifest location.
+In the example above we set the `KUBELET_IMAGE_TAG` and the kubelet-wrapper script takes care of running the correct container image with our desired API server address and manifest location.
 
 ## Customizing rkt Options
 
-Passing customized options or flags to rkt can be accomplished with the RKT_OPTS environment variable. Referencing it in a unit file is straightforward.
+Passing customized options or flags to rkt can be accomplished with the RKT_RUN_ARGS environment variable. Referencing it in a unit file is straightforward.
 
 ### Use the host's DNS configuration
 
@@ -40,8 +40,8 @@ Mount the host's `/etc/resolv.conf` file directly into the container in order to
 
 ```ini
 [Service]
-Environment=KUBELET_VERSION=v1.5.3_coreos.0
-Environment="RKT_OPTS=--volume=resolv,kind=host,source=/etc/resolv.conf \
+Environment=KUBELET_IMAGE_TAG=v1.5.3_coreos.0
+Environment="RKT_RUN_ARGS=--volume=resolv,kind=host,source=/etc/resolv.conf \
   --mount volume=resolv,target=/etc/resolv.conf \
   --uuid-file-save=/var/run/kubelet-pod.uuid"
 ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
@@ -58,8 +58,8 @@ Pods running in your cluster can reference remote storage volumes located on an 
 
 ```ini
 [Service]
-Environment=KUBELET_VERSION=v1.5.3_coreos.0
-Environment="RKT_OPTS=--volume iscsiadm,kind=host,source=/usr/sbin/iscsiadm \
+Environment=KUBELET_IMAGE_TAG=v1.5.3_coreos.0
+Environment="RKT_RUN_ARGS=--volume iscsiadm,kind=host,source=/usr/sbin/iscsiadm \
   --mount volume=iscsiadm,target=/usr/sbin/iscsiadm \
   --uuid-file-save=/var/run/kubelet-pod.uuid"
 ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
@@ -72,12 +72,12 @@ ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
 
 ### Allow pods to use rbd volumes
 
-Pods using the [rbd volume plugin][rbd-example] to consume data from ceph must ensure that the kubelet has access to modprobe. Add the following options to the `RKT_OPTS` env before launching the kubelet via kubelet-wrapper:
+Pods using the [rbd volume plugin][rbd-example] to consume data from ceph must ensure that the kubelet has access to modprobe. Add the following options to the `RKT_RUN_ARGS` env before launching the kubelet via kubelet-wrapper:
 
 ```ini
 [Service]
-Environment=KUBELET_VERSION=v1.5.3_coreos.0
-Environment="RKT_OPTS=--volume modprobe,kind=host,source=/usr/sbin/modprobe \
+Environment=KUBELET_IMAGE_TAG=v1.5.3_coreos.0
+Environment="RKT_RUN_ARGS=--volume modprobe,kind=host,source=/usr/sbin/modprobe \
   --mount volume=modprobe,target=/usr/sbin/modprobe \
   --volume lib-modules,kind=host,source=/lib/modules \
   --mount volume=lib-modules,target=/lib/modules \
@@ -111,7 +111,7 @@ For example:
 
 ```ini
 [Service]
-Environment=KUBELET_VERSION=v1.5.3_coreos.0
+Environment=KUBELET_IMAGE_TAG=v1.5.3_coreos.0
 ...
 ExecStart=/opt/bin/kubelet-wrapper \
   --api-servers=http://127.0.0.1:8080 \

--- a/Documentation/kubernetes-upgrade.md
+++ b/Documentation/kubernetes-upgrade.md
@@ -10,12 +10,12 @@ The Kubelet runs on both master and worker nodes, and is distributed as a hyperk
 
 To update the image version, modify the kubelet service file on each node (`/etc/systemd/system/kubelet.service`) to reference the new hyperkube image.
 
-For example, modifying the `KUBELET_VERSION` environment variable in the following service file would change the container image version used when launching the kubelet via the [kubelet-wrapper](kubelet-wrapper.md) script.
+For example, modifying the `KUBELET_IMAGE_TAG` environment variable in the following service file would change the container image version used when launching the kubelet via the [kubelet-wrapper](kubelet-wrapper.md) script.
 
 **/etc/systemd/system/kubelet.service**
 
 ```
-Environment=KUBELET_VERSION=v1.5.3_coreos.0
+Environment=KUBELET_IMAGE_TAG=v1.5.3_coreos.0
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=https://master [...]
 ```

--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -99,9 +99,9 @@ function init_templates {
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
 [Service]
-Environment=KUBELET_VERSION=${K8S_VER}
-Environment=KUBELET_ACI=${HYPERKUBE_IMAGE_REPO}
-Environment="RKT_OPTS=--uuid-file-save=${uuid_file} \
+Environment=KUBELET_IMAGE_TAG=${K8S_VER}
+Environment=KUBELET_IMAGE_URL=${HYPERKUBE_IMAGE_REPO}
+Environment="RKT_RUN_ARGS=--uuid-file-save=${uuid_file} \
   --volume dns,kind=host,source=/etc/resolv.conf \
   --mount volume=dns,target=/etc/resolv.conf \
   --volume rkt,kind=host,source=/opt/bin/host-rkt \

--- a/multi-node/generic/worker-install.sh
+++ b/multi-node/generic/worker-install.sh
@@ -70,9 +70,9 @@ function init_templates {
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
 [Service]
-Environment=KUBELET_VERSION=${K8S_VER}
-Environment=KUBELET_ACI=${HYPERKUBE_IMAGE_REPO}
-Environment="RKT_OPTS=--uuid-file-save=${uuid_file} \
+Environment=KUBELET_IMAGE_TAG=${K8S_VER}
+Environment=KUBELET_IMAGE_URL=${HYPERKUBE_IMAGE_REPO}
+Environment="RKT_RUN_ARGS=--uuid-file-save=${uuid_file} \
   --volume dns,kind=host,source=/etc/resolv.conf \
   --mount volume=dns,target=/etc/resolv.conf \
   --volume rkt,kind=host,source=/opt/bin/host-rkt \

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -94,9 +94,9 @@ function init_templates {
 [Service]
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
 ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
-Environment=KUBELET_VERSION=${K8S_VER}
-Environment=KUBELET_ACI=${HYPERKUBE_IMAGE_REPO}
-Environment="RKT_OPTS=--uuid-file-save=${uuid_file} \
+Environment=KUBELET_IMAGE_TAG=${K8S_VER}
+Environment=KUBELET_IMAGE_URL=${HYPERKUBE_IMAGE_REPO}
+Environment="RKT_RUN_ARGS=--uuid-file-save=${uuid_file} \
   --volume dns,kind=host,source=/etc/resolv.conf \
   --mount volume=dns,target=/etc/resolv.conf \
   --volume rkt,kind=host,source=/opt/bin/host-rkt \


### PR DESCRIPTION
This PR substitutes old deprecated variables used in kubelet-wrapper (RKT_OPTS, KUBELET_VERSION and KUBELET_ACI) to the new one.

