### PR TITLE
Kubeconfig

### DIFF
--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -152,7 +152,8 @@ ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
 ExecStartPre=/usr/bin/mkdir -p /var/log/containers
 ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
-  --api-servers=http://127.0.0.1:8080 \
+  --kubeconfig=/etc/kubernetes/master-kubeconfig.yaml \
+  --require-kubeconfig \
   --register-schedulable=false \
   --cni-conf-dir=/etc/kubernetes/cni/net.d \
   --network-plugin=cni \
@@ -168,6 +169,25 @@ RestartSec=10
 
 [Install]
 WantedBy=multi-user.target
+```
+
+**/etc/kubernetes/master-kubeconfig.yaml**
+
+```yaml
+apiVersion: v1
+kind: Config
+clusters:
+- name: local
+  cluster:
+    server: http://127.0.0.1:8080
+users:
+- name: kubelet
+contexts:
+- context:
+    cluster: local
+    user: kubelet
+  name: kubelet-context
+current-context: kubelet-context
 ```
 
 ### Set Up the kube-apiserver Pod

--- a/Documentation/deploy-workers.md
+++ b/Documentation/deploy-workers.md
@@ -134,7 +134,8 @@ ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
 ExecStartPre=/usr/bin/mkdir -p /var/log/containers
 ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
-  --api-servers=${MASTER_HOST} \
+  --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
+  --require-kubeconfig \
   --cni-conf-dir=/etc/kubernetes/cni/net.d \
   --network-plugin=cni \
   --container-runtime=docker \
@@ -144,7 +145,6 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --hostname-override=${ADVERTISE_IP} \
   --cluster_dns=${DNS_SERVICE_IP} \
   --cluster_domain=cluster.local \
-  --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
   --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
   --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem
 ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
@@ -216,6 +216,7 @@ kind: Config
 clusters:
 - name: local
   cluster:
+    server: ${MASTER_HOST}
     certificate-authority: /etc/kubernetes/ssl/ca.pem
 users:
 - name: kubelet

--- a/Documentation/kubelet-wrapper.md
+++ b/Documentation/kubelet-wrapper.md
@@ -23,10 +23,12 @@ Environment=KUBELET_VERSION=v1.5.1_coreos.0
 Environment="RKT_OPTS=--uuid-file-save=/var/run/kubelet-pod.uuid"
 ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
-  --api-servers=http://127.0.0.1:8080 \
+  --kubeconfig=/etc/kubernetes/kubeconfig.yaml \
   --pod-manifest-path=/etc/kubernetes/manifests
 ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
 ```
+
+<!-- TODO we should definitely provide a minimal kubeconfig here -->
 
 In the example above we set the `KUBELET_VERSION` and the kubelet-wrapper script takes care of running the correct container image with our desired API server address and manifest location.
 
@@ -46,7 +48,7 @@ Environment="RKT_OPTS=--volume=resolv,kind=host,source=/etc/resolv.conf \
   --uuid-file-save=/var/run/kubelet-pod.uuid"
 ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
-  --api-servers=http://127.0.0.1:8080 \
+  --kubeconfig=/etc/kubernetes/kubeconfig.yaml \
   --pod-manifest-path=/etc/kubernetes/manifests
   ...other flags...
 ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
@@ -64,7 +66,7 @@ Environment="RKT_OPTS=--volume iscsiadm,kind=host,source=/usr/sbin/iscsiadm \
   --uuid-file-save=/var/run/kubelet-pod.uuid"
 ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
-  --api-servers=http://127.0.0.1:8080 \
+  --kubeconfig=/etc/kubernetes/kubeconfig.yaml \
   --pod-manifest-path=/etc/kubernetes/manifests
   ...other flags...
 ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
@@ -103,7 +105,7 @@ For example:
 Environment=KUBELET_VERSION=v1.5.1_coreos.0
 ...
 ExecStart=/opt/bin/kubelet-wrapper \
-  --api-servers=http://127.0.0.1:8080 \
+  --kubeconfig=/etc/kubernetes/kubeconfig.yaml \
   --pod-manifest-path=/etc/kubernetes/manifests
 ...
 ```

--- a/Documentation/kubernetes-upgrade.md
+++ b/Documentation/kubernetes-upgrade.md
@@ -17,7 +17,7 @@ For example, modifying the `KUBELET_VERSION` environment variable in the followi
 ```
 Environment=KUBELET_VERSION=v1.5.1_coreos.0
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
-  --api-servers=https://master [...]
+  [...]
 ```
 
 ## Upgrading Calico

--- a/multi-node/aws/pkg/config/templates/cloud-config-worker
+++ b/multi-node/aws/pkg/config/templates/cloud-config-worker
@@ -37,7 +37,8 @@ coreos:
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
-        --api-servers={{.SecureAPIServers}} \
+        --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
+        --require-kubeconfig \
         --cni-conf-dir=/etc/kubernetes/cni/net.d \
         --network-plugin={{.K8sNetworkPlugin}} \
         --container-runtime={{.ContainerRuntime}} \
@@ -49,7 +50,6 @@ coreos:
         --cluster_dns={{.DNSServiceIP}} \
         --cluster_domain=cluster.local \
         --cloud-provider=aws \
-        --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
         --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
         --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
@@ -250,6 +250,7 @@ write_files:
         clusters:
         - name: local
           cluster:
+            server: {{.SecureAPIServers}}
             certificate-authority: /etc/kubernetes/ssl/ca.pem
         users:
         - name: kubelet

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -85,6 +85,25 @@ function init_flannel {
 }
 
 function init_templates {
+    local TEMPLATE=/etc/kubernetes/master-kubeconfig.yaml
+    if [[ ! -f "${TEMPLATE}" ]]; then
+      cat > "${TEMPLATE}" <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+- name: kubernetes
+  cluster:
+    server: http://127.0.0.1:8080
+users:
+- name: kubelet
+context:
+- context:
+    cluster: kubernetes
+    user: kubelet
+  name: kubelet-context
+current-context: kubelet-context
+EOF
+    fi
     local TEMPLATE=/etc/systemd/system/kubelet.service
     local uuid_file="/var/run/kubelet-pod.uuid"
     if [ ! -f $TEMPLATE ]; then
@@ -112,7 +131,8 @@ ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
 ExecStartPre=/usr/bin/mkdir -p /var/log/containers
 ExecStartPre=-/usr/bin/rkt rm --uuid-file=${uuid_file}
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
-  --api-servers=http://127.0.0.1:8080 \
+  --kubeconfig=/etc/kubernetes/master-kubeconfig.yaml \
+  --require-kubeconfig \
   --cni-conf-dir=/etc/kubernetes/cni/net.d \
   --network-plugin=cni \
   --container-runtime=${CONTAINER_RUNTIME} \


### PR DESCRIPTION
Please include how multiple api servers are specified in the kubeconfig YAML structure. 

For example, the --api-servers flag accepted a list such as "hostname1:port1,hostname2:port2,..."

However, the YAML key "server" name implies a single server, and the examples below only show it's a dict key accepting a string:

clusters:
  - name: local
  cluster:
    server: http://127.0.0.1:8080


So would one have to duplicate the cluster itself?

clusters:
  - name: local1
  cluster:
    server: http://hostname1:8080
  - name: local2
  cluster:
    server: http://hostname2:8080
  - name: local3
  cluster:
    server: http://hostname3:8080


Or is a list allowed?

clusters:
  - name: local
  cluster:
    server: 
      - http://hostname1:8080
      - http://hostname2:8080
      - http://hostname3:8080


Or are the servers embedded in a comma-delimited string?

clusters:
  - name: local
  cluster:
    server: http://hostname1:8080,http://hostname2:8080,http://hostname3:8080

Thank you.