### PR TITLE
Update deploy-master.md

### DIFF
--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -1,6 +1,6 @@
 # Deploy Kubernetes Master Node(s)
 
-Boot a single CoreOS machine which will be used as the Kubernetes master node. You must use a CoreOS version 962.0.0+ for the `/usr/lib/coreos/kubelet-wrapper` script to be present in the image. See [kubelet-wrapper](kubelet-wrapper.md) for more information.
+Boot a single CoreOS machine which will be used as the Kubernetes master node. You must use a CoreOS version 962.0.0+ for the `/usr/lib/coreos/kubelet-wrapper` or `/usr/lib64/coreos/kubelet-wrapper` script to be present in the image. See [kubelet-wrapper](kubelet-wrapper.md) for more information.
 
 See the [CoreOS Documentation](https://coreos.com/os/docs/latest/) for guides on launching nodes on supported platforms.
 


### PR DESCRIPTION
I found that on Container Linux by CoreOS stable (1298.7.0) the kubelet-wrapper is actually in this location `/usr/lib64/coreos/kubelet-wrapper`