### PR TITLE
Docs: bump kubernetes version to 1.6.1 from 1.5.4

### DIFF
--- a/Documentation/configure-kubectl.md
+++ b/Documentation/configure-kubectl.md
@@ -15,13 +15,13 @@ Download `kubectl` from the Kubernetes release artifact site with the `curl` too
 The linux `kubectl` binary can be fetched with a command like:
 
 ```sh
-$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.5.4/bin/linux/amd64/kubectl
+$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.6.1/bin/linux/amd64/kubectl
 ```
 
 On an OS X workstation, replace `linux` in the URL above with `darwin`:
 
 ```sh
-$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.5.4/bin/darwin/amd64/kubectl
+$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.6.1/bin/darwin/amd64/kubectl
 ```
 
 After downloading the binary, ensure it is executable and move it into your `PATH`:

--- a/Documentation/deploy-addons.md
+++ b/Documentation/deploy-addons.md
@@ -173,11 +173,11 @@ Create `kube-dashboard-rc.yaml` and `kube-dashboard-svc.yaml` on your local mach
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: kubernetes-dashboard-v1.4.1
+  name: kubernetes-dashboard-v1.6.0
   namespace: kube-system
   labels:
     k8s-app: kubernetes-dashboard
-    version: v1.4.1
+    version: v1.6.0
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
@@ -187,7 +187,7 @@ spec:
     metadata:
       labels:
         k8s-app: kubernetes-dashboard
-        version: v1.4.1
+        version: v1.6.0
         kubernetes.io/cluster-service: "true"
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -195,7 +195,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.4.1
+        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.6.0
         resources:
           limits:
             cpu: 100m
@@ -245,7 +245,7 @@ Access the dashboard by port forwarding with `kubectl`.
 
 ```sh
 $ kubectl get pods --namespace=kube-system
-$ kubectl port-forward kubernetes-dashboard-v1.4.1-SOME-ID 9090 --namespace=kube-system
+$ kubectl port-forward kubernetes-dashboard-v1.6.0-SOME-ID 9090 --namespace=kube-system
 ```
 
 Then visit [http://127.0.0.1:9090](http://127.0.0.1:9090/) in your browser.

--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -123,7 +123,7 @@ Note that the kubelet running on a master node may log repeated attempts to post
 
 * Replace `${ADVERTISE_IP}` with this node's publicly routable IP.
 * Replace `${DNS_SERVICE_IP}`
-* Replace `${K8S_VER}` This will map to: `quay.io/coreos/hyperkube:${K8S_VER}` release, e.g. `v1.5.4_coreos.0`.
+* Replace `${K8S_VER}` This will map to: `quay.io/coreos/hyperkube:${K8S_VER}` release, e.g. `v1.6.1_coreos.0`.
 * If using Calico for network policy
   - Replace `${NETWORK_PLUGIN}` with `cni`
   - Add the following to `RKT_RUN_ARGS=`
@@ -196,7 +196,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-apiserver
-    image: quay.io/coreos/hyperkube:v1.5.4_coreos.0
+    image: quay.io/coreos/hyperkube:v1.6.1_coreos.0
     command:
     - /hyperkube
     - apiserver
@@ -263,7 +263,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-proxy
-    image: quay.io/coreos/hyperkube:v1.5.4_coreos.0
+    image: quay.io/coreos/hyperkube:v1.6.1_coreos.0
     command:
     - /hyperkube
     - proxy
@@ -302,7 +302,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-controller-manager
-    image: quay.io/coreos/hyperkube:v1.5.4_coreos.0
+    image: quay.io/coreos/hyperkube:v1.6.1_coreos.0
     command:
     - /hyperkube
     - controller-manager
@@ -354,7 +354,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-scheduler
-    image: quay.io/coreos/hyperkube:v1.5.4_coreos.0
+    image: quay.io/coreos/hyperkube:v1.6.1_coreos.0
     command:
     - /hyperkube
     - scheduler

--- a/Documentation/deploy-workers.md
+++ b/Documentation/deploy-workers.md
@@ -105,7 +105,7 @@ Create `/etc/systemd/system/kubelet.service` and substitute the following variab
 * Replace `${MASTER_HOST}` 
 * Replace `${ADVERTISE_IP}` with this node's publicly routable IP.
 * Replace `${DNS_SERVICE_IP}`
-* Replace `${K8S_VER}` This will map to: `quay.io/coreos/hyperkube:${K8S_VER}` release, e.g. `v1.5.4_coreos.0`.
+* Replace `${K8S_VER}` This will map to: `quay.io/coreos/hyperkube:${K8S_VER}` release, e.g. `v1.6.1_coreos.0`.
 * If using Calico for network policy
   - Replace `${NETWORK_PLUGIN}` with `cni`
   - Add the following to `RKT_RUN_ARGS=`
@@ -175,7 +175,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-proxy
-    image: quay.io/coreos/hyperkube:v1.5.4_coreos.0
+    image: quay.io/coreos/hyperkube:v1.6.1_coreos.0
     command:
     - /hyperkube
     - proxy

--- a/Documentation/kubelet-wrapper.md
+++ b/Documentation/kubelet-wrapper.md
@@ -19,7 +19,7 @@ An example systemd kubelet.service file which takes advantage of the kubelet-wra
 
 ```ini
 [Service]
-Environment=KUBELET_IMAGE_TAG=v1.5.4_coreos.0
+Environment=KUBELET_IMAGE_TAG=v1.6.1_coreos.0
 Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid"
 ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
@@ -40,7 +40,7 @@ Mount the host's `/etc/resolv.conf` file directly into the container in order to
 
 ```ini
 [Service]
-Environment=KUBELET_IMAGE_TAG=v1.5.4_coreos.0
+Environment=KUBELET_IMAGE_TAG=v1.6.1_coreos.0
 Environment="RKT_RUN_ARGS=--volume=resolv,kind=host,source=/etc/resolv.conf \
   --mount volume=resolv,target=/etc/resolv.conf \
   --uuid-file-save=/var/run/kubelet-pod.uuid"
@@ -58,7 +58,7 @@ Pods running in your cluster can reference remote storage volumes located on an 
 
 ```ini
 [Service]
-Environment=KUBELET_IMAGE_TAG=v1.5.4_coreos.0
+Environment=KUBELET_IMAGE_TAG=v1.6.1_coreos.0
 Environment="RKT_RUN_ARGS=--volume iscsiadm,kind=host,source=/usr/sbin/iscsiadm \
   --mount volume=iscsiadm,target=/usr/sbin/iscsiadm \
   --uuid-file-save=/var/run/kubelet-pod.uuid"
@@ -76,7 +76,7 @@ Pods using the [rbd volume plugin][rbd-example] to consume data from ceph must e
 
 ```ini
 [Service]
-Environment=KUBELET_IMAGE_TAG=v1.5.4_coreos.0
+Environment=KUBELET_IMAGE_TAG=v1.6.1_coreos.0
 Environment="RKT_RUN_ARGS=--volume modprobe,kind=host,source=/usr/sbin/modprobe \
   --mount volume=modprobe,target=/usr/sbin/modprobe \
   --volume lib-modules,kind=host,source=/lib/modules \
@@ -111,7 +111,7 @@ For example:
 
 ```ini
 [Service]
-Environment=KUBELET_IMAGE_TAG=v1.5.4_coreos.0
+Environment=KUBELET_IMAGE_TAG=v1.6.1_coreos.0
 ...
 ExecStart=/opt/bin/kubelet-wrapper \
   --api-servers=http://127.0.0.1:8080 \

--- a/Documentation/kubernetes-on-vagrant-single.md
+++ b/Documentation/kubernetes-on-vagrant-single.md
@@ -19,13 +19,13 @@ Navigate to the [Vagrant downloads page][vagrant-downloads] and grab the appropr
 The linux `kubectl` binary can be fetched with a command like:
 
 ```sh
-$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.5.4/bin/linux/amd64/kubectl
+$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.6.1/bin/linux/amd64/kubectl
 ```
 
 On an OS X workstation, replace `linux` in the URL above with `darwin`:
 
 ```sh
-$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.5.4/bin/darwin/amd64/kubectl
+$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.6.1/bin/darwin/amd64/kubectl
 ```
 
 After downloading the binary, ensure it is executable and move it into your PATH:

--- a/Documentation/kubernetes-on-vagrant.md
+++ b/Documentation/kubernetes-on-vagrant.md
@@ -18,13 +18,13 @@ Navigate to the [Vagrant downloads page][vagrant-downloads] and grab the appropr
 The linux `kubectl` binary can be fetched with a command like:
 
 ```sh
-$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.5.4/bin/linux/amd64/kubectl
+$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.6.1/bin/linux/amd64/kubectl
 ```
 
 On an OS X workstation, replace `linux` in the URL above with `darwin`:
 
 ```sh
-$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.5.4/bin/darwin/amd64/kubectl
+$ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.6.1/bin/darwin/amd64/kubectl
 ```
 
 After downloading the binary, ensure it is executable and move it into your PATH:

--- a/Documentation/kubernetes-upgrade.md
+++ b/Documentation/kubernetes-upgrade.md
@@ -15,7 +15,7 @@ For example, modifying the `KUBELET_IMAGE_TAG` environment variable in the follo
 **/etc/systemd/system/kubelet.service**
 
 ```
-Environment=KUBELET_IMAGE_TAG=v1.5.4_coreos.0
+Environment=KUBELET_IMAGE_TAG=v1.6.1_coreos.0
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=https://master [...]
 ```


### PR DESCRIPTION
This relates to a downstream documentation sync.

We don't want to look like we're behind the times, right?

cc: @joshix @robszumski 