### PR TITLE
Fixing for Windows environment. Bash shell env is different. 

### DIFF
--- a/lib/init-ssl
+++ b/lib/init-ssl
@@ -66,7 +66,7 @@ CONTENTS="${CAFILE} ${KEYFILE} ${PEMFILE}"
 echo "$CNF_TEMPLATE$(echo $SANS | tr ',' '\n')" > "$CONFIGFILE"
 
 $OPENSSL genrsa -out "$KEYFILE" 2048
-$OPENSSL req -new -key "$KEYFILE" -out "$CSRFILE" -subj "/CN=$CN" -config "$CONFIGFILE"
+$OPENSSL req -new -key "$KEYFILE" -out "$CSRFILE" -subj "//CN=$CN" -config "$CONFIGFILE"
 $OPENSSL x509 -req -in "$CSRFILE" -CA "$CAFILE" -CAkey "$CAKEYFILE" -CAcreateserial -out "$PEMFILE" -days 365 -extensions v3_req -extfile "$CONFIGFILE"
 
 tar -cf $OUTFILE -C $OUTDIR $(for  f in $CONTENTS;do printf "$(basename $f) ";done)

--- a/lib/init-ssl-ca
+++ b/lib/init-ssl-ca
@@ -30,6 +30,6 @@ fi
 
 # establish cluster CA and self-sign a cert
 openssl genrsa -out "$OUTDIR/ca-key.pem" 2048
-openssl req -x509 -new -nodes -key "$OUTDIR/ca-key.pem" -days 10000 -out "$OUTFILE" -subj "/CN=kube-ca"
+openssl req -x509 -new -nodes -key "$OUTDIR/ca-key.pem" -days 10000 -out "$OUTFILE" -subj "//CN=kube-ca"
 
 

--- a/multi-node/vagrant/Vagrantfile
+++ b/multi-node/vagrant/Vagrantfile
@@ -49,16 +49,26 @@ etcdIPs = [*1..$etcd_count].map{ |i| etcdIP(i) }
 initial_etcd_cluster = etcdIPs.map.with_index{ |ip, i| "e#{i+1}=http://#{ip}:2380" }.join(",")
 etcd_endpoints = etcdIPs.map.with_index{ |ip, i| "http://#{ip}:2379" }.join(",")
 
+def exec(s)
+  tmpFile = "bashScript"
+  File.open(tmpFile, 'w') { |file|
+    file.write(s)
+  }
+  p s
+  return `bash #{tmpFile} 2>&1`
+end
+
 # Generate root CA
-system("mkdir -p ssl && ./../../lib/init-ssl-ca ssl") or abort ("failed generating SSL artifacts")
+p exec "mkdir -p ssl 2>&1"
+(p exec "#{File.expand_path("../../lib/init-ssl-ca")} ssl") or abort ("failed generating SSL artifacts")
 
 # Generate admin key/cert
-system("./../../lib/init-ssl ssl admin kube-admin") or abort("failed generating admin SSL artifacts")
+(p exec "#{File.expand_path("../../lib/init-ssl")} ssl admin kube-admin") or abort("failed generating admin SSL artifacts")
 
 def provisionMachineSSL(machine,certBaseName,cn,ipAddrs)
   tarFile = "ssl/#{cn}.tar"
   ipString = ipAddrs.map.with_index { |ip, i| "IP.#{i+1}=#{ip}"}.join(",")
-  system("./../../lib/init-ssl ssl #{certBaseName} #{cn} #{ipString}") or abort("failed generating #{cn} SSL artifacts")
+  (p exec "#{File.expand_path("../../lib/init-ssl")} ssl #{certBaseName} #{cn} #{ipString}") or abort("failed generating #{cn} SSL artifacts")
   machine.vm.provision :file, :source => tarFile, :destination => "/tmp/ssl.tar"
   machine.vm.provision :shell, :inline => "mkdir -p /etc/kubernetes/ssl && tar -C /etc/kubernetes/ssl -xf /tmp/ssl.tar", :privileged => true
 end


### PR DESCRIPTION
The commands need tweaking and escaping.

Eventually got it working for myself.

I also added some stuff to generate a self-signed CA and issuer that gets added to `/etc/ssl/certs` for use by HTTPS services like the Docker Registry container which is one of the first ones I wanted to run, and which I wanted the kubelet workers etc to use to download images from. That part isn't included in this PR but probably should be a feature, if others agree.
