### PR TITLE
Update config.rb.sample

### DIFF
--- a/multi-node/vagrant/config.rb.sample
+++ b/multi-node/vagrant/config.rb.sample
@@ -1,7 +1,7 @@
 #$update_channel="alpha"
 
 #$controller_count=1
-#$controller_vm_memory=512
+#$controller_vm_memory=1024
 
 #$worker_count=1
 #$worker_vm_memory=1024


### PR DESCRIPTION
if controller_vm_memory is less than 1024M, Vagrantfile will refuse according to Vagrantfile:24. so it is a good to keep the sample with valid values.