### PR TITLE
deploy-master.md: Fixed kube-apiserver yaml schema

### DIFF
--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -202,6 +202,7 @@ spec:
     - apiserver
     - --bind-address=0.0.0.0
     - --etcd-servers=${ETCD_ENDPOINTS}
+    - --storage-backend=etcd2
     - --allow-privileged=true
     - --service-cluster-ip-range=${SERVICE_IP_RANGE}
     - --secure-port=443


### PR DESCRIPTION
CoreOS seems to be defaulting to etcd2, however k8s to etcd3.

This fixes error that occurs after following official guides,
since it now will crash and restart forever without being able
to connect to the etcd node/cluster.

Fixes #871

Tested on:
CoreOS stable (1353.8.0)
With kubernetes image/tag quay.io/coreos/hyperkube:v1.6.4_coreos.0