### PR TITLE
Fix: Pods' IP is now in POD_NETWORK range

### DIFF
--- a/Documentation/deploy-workers.md
+++ b/Documentation/deploy-workers.md
@@ -72,7 +72,7 @@ Create `/etc/systemd/system/docker.service.d/40-flannel.conf`
 Requires=flanneld.service
 After=flanneld.service
 [Service]
-EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
+EnvironmentFile=/run/flannel/flannel_docker_opts.env
 ```
 
 Create the Docker CNI Options file:


### PR DESCRIPTION
Change the drop-in 40-flannel.conf. Pods are now in range of the env var POD_NETWORK.

Fix #872 
Fix #884