### PR TITLE
Fixed a bug of apiserver's service account key file.

### DIFF
--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -267,7 +267,7 @@ spec:
     - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
     - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
     - --client-ca-file=/etc/kubernetes/ssl/ca.pem
-    - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
+    - --service-account-key-file=/etc/kubernetes/ssl/apiserver.pem
     - --runtime-config=extensions/v1beta1/networkpolicies=true
     - --anonymous-auth=false
     livenessProbe:


### PR DESCRIPTION
According to https://kubernetes.io/docs/admin/service-accounts-admin/, the apiserver accepts `service-account-key-file` with public key, not private key file.