### PR TITLE
Update Calico to v2.4.1

### DIFF
--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -62,7 +62,7 @@ Next create a [systemd drop-in][dropins], which is a method for appending or ove
 ExecStartPre=/usr/bin/ln -sf /etc/flannel/options.env /run/flannel/options.env
 ```
 
-[calico-docs]: http://docs.projectcalico.org/v2.0/getting-started/kubernetes/
+[calico-docs]: http://docs.projectcalico.org/latest/getting-started/kubernetes/
 [flannel-docs]: https://coreos.com/flannel/docs/latest/
 [pod-overview]: https://coreos.com/kubernetes/docs/latest/pods.html
 [service-overview]: https://coreos.com/kubernetes/docs/latest/services.html
@@ -94,7 +94,7 @@ DOCKER_OPT_BIP=""
 DOCKER_OPT_IPMASQ=""
 ```
 
-If using Flannel for networking, setup the Flannel CNI configuration with below. If you intend to use Calico for networking, follow the guide to [Set Up Calico For Network Policy](#set-up-calico-for-network-policy-optional) instead.
+If using Flannel for networking, setup the Flannel CNI configuration with below. If you intend to use Calico for network policy, follow the guide to [Set Up Calico For Network Policy](#set-up-calico-for-network-policy-optional) instead.
 
 **/etc/kubernetes/cni/net.d/10-flannel.conf**
 
@@ -455,7 +455,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v0.23.0
+          image: quay.io/calico/node:v2.4.1
           env:
             # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS
@@ -466,6 +466,9 @@ spec:
             # Choose the backend to use. 
             - name: CALICO_NETWORKING_BACKEND
               value: "none"
+            # Cluster type to identify the deployment type
+            - name: CLUSTER_TYPE
+              value: "k8s,canal"
             # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
@@ -486,7 +489,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: quay.io/calico/cni:v1.5.2
+          image: quay.io/calico/cni:v1.10.0
           imagePullPolicy: Always
           command: ["/install-cni.sh"]
           env:
@@ -560,7 +563,7 @@ spec:
       hostNetwork: true
       containers:
         - name: calico-policy-controller
-          image: calico/kube-policy-controller:v0.4.0
+          image: calico/kube-policy-controller:v0.7.0
           env:
             # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS

--- a/Documentation/deploy-workers.md
+++ b/Documentation/deploy-workers.md
@@ -84,7 +84,7 @@ DOCKER_OPT_BIP=""
 DOCKER_OPT_IPMASQ=""
 ```
 
-If using Flannel for networking, setup the Flannel CNI configuration with below. If you intend to use Calico for networking, setup using [Set Up the CNI config (optional)](#set-up-the-cni-config-optional) instead.
+If using Flannel for networking, setup the Flannel CNI configuration with below. If you intend to use Calico for network policy, setup using [Set Up Calico for Network Policy (optional)](deploy-master.md#set-up-calico-for-network-policy-optional) instead.
 
 **/etc/kubernetes/cni/net.d/10-flannel.conf**
 

--- a/Documentation/kubernetes-networking.md
+++ b/Documentation/kubernetes-networking.md
@@ -57,7 +57,7 @@ The CoreOS Kubernetes documentation describes a software-defined overlay network
 The following requirements must be met by your existing infrastructure to use Tectonic with a self-managed network.
 
 [coreos-flannel]: https://coreos.com/flannel/docs/latest/flannel-config.html
-[calico]: http://docs.projectcalico.org/v2.0/getting-started/kubernetes/
+[calico]: http://docs.projectcalico.org/latest/getting-started/kubernetes/
 
 ### Pod-to-Pod Communication
 
@@ -83,8 +83,8 @@ The actual allocation of Pod IPs on the host can be achieved by configuring Dock
 To achieve this network model, there are various methods that can be used. See the [Kubernetes Networking][how-to-achieve] documentation for more detail.
 
 [how-to-achieve]: https://kubernetes.io/docs/admin/networking/#how-to-achieve-this
-[calico-bgp]: https://github.com/projectcalico/calico-containers/blob/v0.19.0/docs/bgp.md
-[calico-l2]: http://docs.projectcalico.org/v2.0/reference/private-cloud/l2-interconnect-fabric
+[calico-bgp]: https://docs.projectcalico.org/latest/usage/configuration/bgp
+[calico-l2]: http://docs.projectcalico.org/latest/reference/private-cloud/l2-interconnect-fabric
 
 ### Pod-to-Service Communication
 
@@ -98,6 +98,6 @@ IP addresses assigned on the pod network are typically not routable outside of t
 
 In a manually configured network, it may be necessary to open a range of ports to outside clients (default 30000-32767) for use with "external services". See the [Kubernetes Service][kube-service] documentation for more information on external services.
 
-[calico-external]: https://github.com/projectcalico/calico-containers/blob/v0.19.0/docs/ExternalConnectivity.md
+[calico-external]: https://docs.projectcalico.org/latest/usage/external-connectivity
 [kube-service]: http://kubernetes.io/docs/user-guide/services/#publishing-services---service-types
 

--- a/Documentation/kubernetes-upgrade.md
+++ b/Documentation/kubernetes-upgrade.md
@@ -24,7 +24,7 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
 
 The Calico agent runs on both master and worker nodes, and is distributed as a container image. It runs self hosted under Kubernetes.
 
-To upgrade Calico, follow the documentation [here](http://docs.projectcalico.org/v2.0/getting-started/kubernetes/upgrade)
+To upgrade Calico, follow the documentation [here](http://docs.projectcalico.org/latest/getting-started/kubernetes/upgrade)
 
 **Note:** If you are running Calico as a systemd service, you will first need to change to a self-hosted install by following [this guide](https://coreos.com/kubernetes/docs/latest/deploy-master.html)
 


### PR DESCRIPTION
Docs: Update Calico version and links

This PR updates the Calico version used to the latest and updates the links to the Calico docs to the latest also.